### PR TITLE
Feature/icat auth #129

### DIFF
--- a/cypress/integration/login.spec.ts
+++ b/cypress/integration/login.spec.ts
@@ -110,4 +110,49 @@ describe('Login', () => {
       window => expect(window.localStorage.getItem('scigateway:token')).be.null
     );
   });
+
+  describe('authenticator selector', () => {
+    beforeEach(() => {
+      cy.server();
+      cy.route('/settings.json', {
+        plugins: [],
+        'ui-strings': 'res/default.json',
+        'auth-provider': 'icat',
+        'help-tour-steps': [],
+      });
+      cy.route('/authenticators', [
+        {
+          mnemonic: 'user/pass',
+          keys: [{ name: 'username' }, { name: 'password' }],
+        },
+        {
+          mnemonic: 'anon',
+          keys: [],
+        },
+      ]);
+      cy.visit('/login');
+    });
+
+    it('should show a dropdown', () => {
+      cy.contains('Authenticator').should('be.visible');
+      cy.get('#select-mnemonic').click();
+      cy.contains('user/pass').should('be.visible');
+      cy.contains('anon').should('be.visible');
+    });
+
+    it('should be able to select user/pass from the dropdown', () => {
+      cy.get('#select-mnemonic').click();
+      cy.contains('user/pass').click();
+
+      cy.contains('Username*').should('be.visible');
+      cy.contains('Password*').should('be.visible');
+    });
+
+    it('should be able to select anon from the dropdown', () => {
+      cy.get('#select-mnemonic').click();
+      cy.contains('anon').click();
+
+      cy.contains('Sign In').should('not.be.disabled');
+    });
+  });
 });

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "@types/jsonwebtoken": "^8.3.2",
     "@types/node": "^12.6.8",
     "@types/react": "^16.8.23",
-    "@types/react-dom": "16.8.5",
+    "@types/react-dom": "^16.8.5",
     "@types/react-redux": "^7.1.1",
     "@types/react-redux-toastr": "^7.4.1",
     "@types/react-router": "^5.0.3",

--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "@types/single-spa-react": "^2.8.3",
     "@typescript-eslint/eslint-plugin": "^1.13.0",
     "@typescript-eslint/parser": "^1.13.0",
+    "axios-mock-adapter": "^1.17.0",
     "babel-eslint": "10.0.1",
     "babel-loader": "8.0.5",
     "body-parser": "^1.19.0",

--- a/src/authentication/icatAuthProvider.test.tsx
+++ b/src/authentication/icatAuthProvider.test.tsx
@@ -1,0 +1,122 @@
+import mockAxios from 'axios';
+import ICATAuthProvider from './icatAuthProvider';
+import ReactGA from 'react-ga';
+
+describe('ICAT auth provider', () => {
+  let icatAuthProvider: ICATAuthProvider;
+
+  beforeEach(() => {
+    jest.spyOn(window.localStorage.__proto__, 'getItem');
+    window.localStorage.__proto__.getItem = jest
+      .fn()
+      .mockImplementation(name =>
+        name === 'scigateway:token' ? 'token' : null
+      );
+    window.localStorage.__proto__.removeItem = jest.fn();
+    window.localStorage.__proto__.setItem = jest.fn();
+
+    icatAuthProvider = new ICATAuthProvider('mnemonic');
+    ReactGA.initialize('test id', { testMode: true, titleCase: false });
+  });
+
+  afterEach(() => {
+    ReactGA.testModeAPI.resetCalls();
+  });
+
+  it('should load the token when built', () => {
+    expect(localStorage.getItem).toBeCalledWith('scigateway:token');
+    expect(icatAuthProvider.isLoggedIn()).toBeTruthy();
+  });
+
+  it('should clear the token when logging out', () => {
+    icatAuthProvider.logOut();
+
+    expect(localStorage.removeItem).toBeCalledWith('scigateway:token');
+    expect(icatAuthProvider.isLoggedIn()).toBeFalsy();
+  });
+
+  it('should successfully log in if user is already logged in', () => {
+    return icatAuthProvider.logIn('user', 'password');
+  });
+
+  it('should call the api to authenticate', async () => {
+    (mockAxios.post as jest.Mock).mockImplementation(() =>
+      Promise.resolve({
+        data: 'token',
+      })
+    );
+
+    // ensure the token is null
+    icatAuthProvider.logOut();
+
+    await icatAuthProvider.logIn('user', 'password');
+
+    expect(mockAxios.post).toHaveBeenCalledWith('/login', {
+      mnemonic: 'mnemonic',
+      credentials: { username: 'user', password: 'password' },
+    });
+    expect(localStorage.setItem).toBeCalledWith('scigateway:token', 'token');
+
+    expect(icatAuthProvider.isLoggedIn()).toBeTruthy();
+
+    expect(ReactGA.testModeAPI.calls[1][0]).toEqual('send');
+    expect(ReactGA.testModeAPI.calls[1][1]).toEqual({
+      eventAction: 'Sucessfully logged in via JWT',
+      eventCategory: 'Login',
+      hitType: 'event',
+    });
+  });
+
+  it('should log the user out for an invalid login attempt', async () => {
+    (mockAxios.post as jest.Mock).mockImplementation(() =>
+      Promise.reject({
+        response: {
+          status: 401,
+        },
+      })
+    );
+
+    // ensure the token is null
+    icatAuthProvider.logOut();
+
+    await icatAuthProvider.logIn('user', 'invalid').catch(() => {});
+
+    expect(localStorage.removeItem).toBeCalledWith('scigateway:token');
+    expect(icatAuthProvider.isLoggedIn()).toBeFalsy();
+
+    expect(ReactGA.testModeAPI.calls[1][0]).toEqual('send');
+    expect(ReactGA.testModeAPI.calls[1][1]).toEqual({
+      eventAction: 'Failed to log in via JWT',
+      eventCategory: 'Login',
+      hitType: 'event',
+    });
+  });
+
+  it('should call api to verify token', async () => {
+    (mockAxios.post as jest.Mock).mockImplementation(() => Promise.resolve());
+
+    await icatAuthProvider.verifyLogIn();
+
+    expect(mockAxios.post).toBeCalledWith('/verify', {
+      token: 'token',
+    });
+  });
+
+  it('should log the user out if the token has expired', async () => {
+    (mockAxios.post as jest.Mock).mockImplementation(() =>
+      Promise.reject({
+        response: {
+          status: 401,
+        },
+      })
+    );
+
+    // ensure the token is null
+    icatAuthProvider.logOut();
+
+    await icatAuthProvider.verifyLogIn().catch(() => {});
+
+    expect(localStorage.removeItem).toBeCalledWith('scigateway:token');
+    expect(icatAuthProvider.isLoggedIn()).toBeFalsy();
+  });
+});

--- a/src/authentication/icatAuthProvider.tsx
+++ b/src/authentication/icatAuthProvider.tsx
@@ -1,30 +1,13 @@
 import Axios from 'axios';
 import BaseAuthProvider from './baseAuthProvider';
 import ReactGA from 'react-ga';
-import axios from 'axios';
-import { ICATAuthenticator } from '../state/state.types';
 
 export default class ICATAuthProvider extends BaseAuthProvider {
   public mnemonic: string;
 
   public constructor(mnemonic: string) {
     super();
-    this.mnemonic = mnemonic;
-  }
-
-  public fetchMnemonics(): Promise<ICATAuthenticator[]> {
-    return axios
-      .get('/authenticators')
-      .then(res => {
-        return res.data;
-      })
-      .catch(err => {
-        ReactGA.event({
-          category: 'Login',
-          action: 'Failed to fetch ICAT authenticator mnemonics',
-        });
-        return [];
-      });
+    this.mnemonic = mnemonic || '';
   }
 
   public logIn(username: string, password: string): Promise<void> {
@@ -57,7 +40,7 @@ export default class ICATAuthProvider extends BaseAuthProvider {
   }
 
   public verifyLogIn(): Promise<void> {
-    return Axios.post('/api/jwt/checkToken', {
+    return Axios.post('/verify', {
       token: this.token,
     })
       .then(() => {})

--- a/src/authentication/icatAuthProvider.tsx
+++ b/src/authentication/icatAuthProvider.tsx
@@ -1,0 +1,66 @@
+import Axios from 'axios';
+import BaseAuthProvider from './baseAuthProvider';
+import ReactGA from 'react-ga';
+import axios from 'axios';
+import { ICATAuthenticator } from '../state/state.types';
+
+export default class ICATAuthProvider extends BaseAuthProvider {
+  public mnemonic: string;
+
+  public constructor(mnemonic: string) {
+    super();
+    this.mnemonic = mnemonic;
+  }
+
+  public fetchMnemonics(): Promise<ICATAuthenticator[]> {
+    return axios
+      .get('/authenticators')
+      .then(res => {
+        return res.data;
+      })
+      .catch(err => {
+        ReactGA.event({
+          category: 'Login',
+          action: 'Failed to fetch ICAT authenticator mnemonics',
+        });
+        return [];
+      });
+  }
+
+  public logIn(username: string, password: string): Promise<void> {
+    if (this.isLoggedIn()) {
+      return Promise.resolve();
+    }
+
+    return Axios.post('/login', {
+      mnemonic: this.mnemonic,
+      credentials: {
+        username,
+        password,
+      },
+    })
+      .then(res => {
+        ReactGA.event({
+          category: 'Login',
+          action: 'Sucessfully logged in via JWT',
+        });
+        this.storeToken(res.data);
+        return;
+      })
+      .catch(err => {
+        ReactGA.event({
+          category: 'Login',
+          action: 'Failed to log in via JWT',
+        });
+        this.handleAuthError(err);
+      });
+  }
+
+  public verifyLogIn(): Promise<void> {
+    return Axios.post('/api/jwt/checkToken', {
+      token: this.token,
+    })
+      .then(() => {})
+      .catch(err => this.handleAuthError(err));
+  }
+}

--- a/src/authentication/testAuthProvider.tsx
+++ b/src/authentication/testAuthProvider.tsx
@@ -4,10 +4,12 @@ export default class TestAuthProvider implements AuthProvider {
   private token: string | null;
   public redirectUrl: string | null;
   public user = null;
+  public mnemonic: string;
 
   public constructor(token: string | null) {
     this.token = token;
     this.redirectUrl = null;
+    this.mnemonic = '';
   }
 
   public isLoggedIn(): boolean {

--- a/src/authentication/testAuthProvider.tsx
+++ b/src/authentication/testAuthProvider.tsx
@@ -4,12 +4,11 @@ export default class TestAuthProvider implements AuthProvider {
   private token: string | null;
   public redirectUrl: string | null;
   public user = null;
-  public mnemonic: string;
+  public mnemonic: string | undefined;
 
   public constructor(token: string | null) {
     this.token = token;
     this.redirectUrl = null;
-    this.mnemonic = '';
   }
 
   public isLoggedIn(): boolean {

--- a/src/loginPage/__snapshots__/loginPage.component.test.tsx.snap
+++ b/src/loginPage/__snapshots__/loginPage.component.test.tsx.snap
@@ -1,5 +1,86 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Login page component anonymous component renders correctly 1`] = `
+<div
+  className="root-1"
+  onKeyPress={[Function]}
+>
+  <WithStyles(Button)
+    color="primary"
+    onClick={[Function]}
+    variant="contained"
+  >
+    <WithStyles(Typography)
+      color="inherit"
+      noWrap={true}
+      style={
+        Object {
+          "marginTop": 3,
+        }
+      }
+    >
+      login-button
+    </WithStyles(Typography)>
+  </WithStyles(Button)>
+</div>
+`;
+
+exports[`Login page component anonymous component renders failedToLogin error correctly 1`] = `
+<div
+  className="root-1"
+  onKeyPress={[Function]}
+>
+  <WithStyles(Typography)>
+    login-error-msg
+  </WithStyles(Typography)>
+  <WithStyles(Button)
+    color="primary"
+    onClick={[Function]}
+    variant="contained"
+  >
+    <WithStyles(Typography)
+      color="inherit"
+      noWrap={true}
+      style={
+        Object {
+          "marginTop": 3,
+        }
+      }
+    >
+      login-button
+    </WithStyles(Typography)>
+  </WithStyles(Button)>
+</div>
+`;
+
+exports[`Login page component anonymous component renders signedOutDueToTokenInvalidation error correctly 1`] = `
+<div
+  className="root-1"
+  onKeyPress={[Function]}
+>
+  <WithStyles(Typography)>
+    token-invalid-msg
+  </WithStyles(Typography)>
+  <WithStyles(Button)
+    color="primary"
+    onClick={[Function]}
+    variant="contained"
+  >
+    <WithStyles(Typography)
+      color="inherit"
+      noWrap={true}
+      style={
+        Object {
+          "marginTop": 3,
+        }
+      }
+    >
+      login-button
+    </WithStyles(Typography)>
+  </WithStyles(Button)>
+</div>
+`;
+
 exports[`Login page component credential component renders correctly 1`] = `
 <div
   className="root-1"
@@ -45,6 +126,176 @@ exports[`Login page component credential component renders correctly 1`] = `
 </div>
 `;
 
+exports[`Login page component credential component renders failedToLogin error correctly 1`] = `
+<div
+  className="root-1"
+  onKeyPress={[Function]}
+>
+  <WithStyles(Typography)>
+    login-error-msg
+  </WithStyles(Typography)>
+  <TextField
+    disabled={false}
+    label="username-placeholder"
+    onChange={[Function]}
+    required={false}
+    select={false}
+    value=""
+    variant="standard"
+  />
+  <TextField
+    disabled={false}
+    label="password-placeholder"
+    onChange={[Function]}
+    required={false}
+    select={false}
+    type="password"
+    value=""
+    variant="standard"
+  />
+  <WithStyles(Button)
+    color="primary"
+    disabled={true}
+    onClick={[Function]}
+    variant="contained"
+  >
+    <WithStyles(Typography)
+      color="inherit"
+      noWrap={true}
+      style={
+        Object {
+          "marginTop": 3,
+        }
+      }
+    >
+      login-button
+    </WithStyles(Typography)>
+  </WithStyles(Button)>
+</div>
+`;
+
+exports[`Login page component credential component renders signedOutDueToTokenInvalidation error correctly 1`] = `
+<div
+  className="root-1"
+  onKeyPress={[Function]}
+>
+  <WithStyles(Typography)>
+    token-invalid-msg
+  </WithStyles(Typography)>
+  <TextField
+    disabled={false}
+    label="username-placeholder"
+    onChange={[Function]}
+    required={false}
+    select={false}
+    value=""
+    variant="standard"
+  />
+  <TextField
+    disabled={false}
+    label="password-placeholder"
+    onChange={[Function]}
+    required={false}
+    select={false}
+    type="password"
+    value=""
+    variant="standard"
+  />
+  <WithStyles(Button)
+    color="primary"
+    disabled={true}
+    onClick={[Function]}
+    variant="contained"
+  >
+    <WithStyles(Typography)
+      color="inherit"
+      noWrap={true}
+      style={
+        Object {
+          "marginTop": 3,
+        }
+      }
+    >
+      login-button
+    </WithStyles(Typography)>
+  </WithStyles(Button)>
+</div>
+`;
+
+exports[`Login page component login page renders anonymous login if mnemonic present + anon is selected 1`] = `
+<div
+  className="LoginPageComponent-root-1 root-1"
+>
+  <WithStyles(Paper)
+    className="LoginPageComponent-paper-3"
+  >
+    <WithStyles(Avatar)
+      className="LoginPageComponent-avatar-2"
+    >
+      <pure(LockOutlinedIcon) />
+    </WithStyles(Avatar)>
+    <WithStyles(Typography)
+      component="h1"
+      variant="h5"
+    >
+      title
+    </WithStyles(Typography)>
+    <AnonLoginScreen
+      auth={
+        Object {
+          "failedToLogin": false,
+          "loading": false,
+          "provider": TestAuthProvider {
+            "mnemonic": "anon",
+            "redirectUrl": null,
+            "token": null,
+            "user": null,
+          },
+          "signedOutDueToTokenInvalidation": false,
+        }
+      }
+      changeMnemonic={
+        [MockFunction] {
+          "calls": Array [
+            Array [
+              "anon",
+            ],
+          ],
+          "results": Array [
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+          ],
+        }
+      }
+      classes={
+        Object {
+          "avatar": "LoginPageComponent-avatar-2",
+          "button": "LoginPageComponent-button-6",
+          "formControl": "LoginPageComponent-formControl-5",
+          "info": "LoginPageComponent-info-8",
+          "paper": "LoginPageComponent-paper-3",
+          "root": "LoginPageComponent-root-1 root-1",
+          "spinner": "LoginPageComponent-spinner-9",
+          "textField": "LoginPageComponent-textField-4",
+          "warning": "LoginPageComponent-warning-7",
+        }
+      }
+      location={
+        Object {
+          "hash": "",
+          "pathname": "/",
+          "search": "",
+          "state": undefined,
+        }
+      }
+      verifyUsernameAndPassword={[Function]}
+    />
+  </WithStyles(Paper)>
+</div>
+`;
+
 exports[`Login page component login page renders credential component if no redirect url 1`] = `
 <div
   className="LoginPageComponent-root-1 root-1"
@@ -69,23 +320,26 @@ exports[`Login page component login page renders credential component if no redi
           "failedToLogin": false,
           "loading": false,
           "provider": TestAuthProvider {
+            "mnemonic": undefined,
             "redirectUrl": null,
             "token": null,
             "user": null,
           },
-          "signedOutDueToTokenExpiry": false,
+          "signedOutDueToTokenInvalidation": false,
         }
       }
+      changeMnemonic={[MockFunction]}
       classes={
         Object {
           "avatar": "LoginPageComponent-avatar-2",
-          "button": "LoginPageComponent-button-5",
-          "info": "LoginPageComponent-info-7",
+          "button": "LoginPageComponent-button-6",
+          "formControl": "LoginPageComponent-formControl-5",
+          "info": "LoginPageComponent-info-8",
           "paper": "LoginPageComponent-paper-3",
           "root": "LoginPageComponent-root-1 root-1",
-          "spinner": "LoginPageComponent-spinner-8",
+          "spinner": "LoginPageComponent-spinner-9",
           "textField": "LoginPageComponent-textField-4",
-          "warning": "LoginPageComponent-warning-6",
+          "warning": "LoginPageComponent-warning-7",
         }
       }
       location={
@@ -95,6 +349,159 @@ exports[`Login page component login page renders credential component if no redi
           "search": "",
           "state": undefined,
         }
+      }
+      verifyUsernameAndPassword={[Function]}
+    />
+  </WithStyles(Paper)>
+</div>
+`;
+
+exports[`Login page component login page renders credentials login if mnemonic present + user/pass is selected 1`] = `
+<div
+  className="LoginPageComponent-root-1 root-1"
+>
+  <WithStyles(Paper)
+    className="LoginPageComponent-paper-3"
+  >
+    <WithStyles(Avatar)
+      className="LoginPageComponent-avatar-2"
+    >
+      <pure(LockOutlinedIcon) />
+    </WithStyles(Avatar)>
+    <WithStyles(Typography)
+      component="h1"
+      variant="h5"
+    >
+      title
+    </WithStyles(Typography)>
+    <CredentialsLoginScreen
+      auth={
+        Object {
+          "failedToLogin": false,
+          "loading": false,
+          "provider": TestAuthProvider {
+            "mnemonic": "user/pass",
+            "redirectUrl": null,
+            "token": null,
+            "user": null,
+          },
+          "signedOutDueToTokenInvalidation": false,
+        }
+      }
+      changeMnemonic={
+        [MockFunction] {
+          "calls": Array [
+            Array [
+              "user/pass",
+            ],
+          ],
+          "results": Array [
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+          ],
+        }
+      }
+      classes={
+        Object {
+          "avatar": "LoginPageComponent-avatar-2",
+          "button": "LoginPageComponent-button-6",
+          "formControl": "LoginPageComponent-formControl-5",
+          "info": "LoginPageComponent-info-8",
+          "paper": "LoginPageComponent-paper-3",
+          "root": "LoginPageComponent-root-1 root-1",
+          "spinner": "LoginPageComponent-spinner-9",
+          "textField": "LoginPageComponent-textField-4",
+          "warning": "LoginPageComponent-warning-7",
+        }
+      }
+      location={
+        Object {
+          "hash": "",
+          "pathname": "/",
+          "search": "",
+          "state": undefined,
+        }
+      }
+      verifyUsernameAndPassword={[Function]}
+    />
+  </WithStyles(Paper)>
+</div>
+`;
+
+exports[`Login page component login page renders dropdown if mnemonic present + there are multiple mnemonics 1`] = `
+<div
+  className="LoginPageComponent-root-1 root-1"
+>
+  <WithStyles(Paper)
+    className="LoginPageComponent-paper-3"
+  >
+    <WithStyles(Avatar)
+      className="LoginPageComponent-avatar-2"
+    >
+      <pure(LockOutlinedIcon) />
+    </WithStyles(Avatar)>
+    <WithStyles(Typography)
+      component="h1"
+      variant="h5"
+    >
+      title
+    </WithStyles(Typography)>
+    <LoginSelector
+      auth={
+        Object {
+          "failedToLogin": false,
+          "loading": false,
+          "provider": TestAuthProvider {
+            "mnemonic": "",
+            "redirectUrl": null,
+            "token": null,
+            "user": null,
+          },
+          "signedOutDueToTokenInvalidation": false,
+        }
+      }
+      changeMnemonic={[MockFunction]}
+      classes={
+        Object {
+          "avatar": "LoginPageComponent-avatar-2",
+          "button": "LoginPageComponent-button-6",
+          "formControl": "LoginPageComponent-formControl-5",
+          "info": "LoginPageComponent-info-8",
+          "paper": "LoginPageComponent-paper-3",
+          "root": "LoginPageComponent-root-1 root-1",
+          "spinner": "LoginPageComponent-spinner-9",
+          "textField": "LoginPageComponent-textField-4",
+          "warning": "LoginPageComponent-warning-7",
+        }
+      }
+      location={
+        Object {
+          "hash": "",
+          "pathname": "/",
+          "search": "",
+          "state": undefined,
+        }
+      }
+      mnemonics={
+        Array [
+          Object {
+            "keys": Array [
+              Object {
+                "name": "username",
+              },
+              Object {
+                "name": "password",
+              },
+            ],
+            "mnemonic": "user/pass",
+          },
+          Object {
+            "keys": Array [],
+            "mnemonic": "anon",
+          },
+        ]
       }
       verifyUsernameAndPassword={[Function]}
     />
@@ -126,23 +533,26 @@ exports[`Login page component login page renders redirect component if redirect 
           "failedToLogin": false,
           "loading": false,
           "provider": TestAuthProvider {
+            "mnemonic": undefined,
             "redirectUrl": "test redirect",
             "token": null,
             "user": null,
           },
-          "signedOutDueToTokenExpiry": false,
+          "signedOutDueToTokenInvalidation": false,
         }
       }
+      changeMnemonic={[MockFunction]}
       classes={
         Object {
           "avatar": "LoginPageComponent-avatar-2",
-          "button": "LoginPageComponent-button-5",
-          "info": "LoginPageComponent-info-7",
+          "button": "LoginPageComponent-button-6",
+          "formControl": "LoginPageComponent-formControl-5",
+          "info": "LoginPageComponent-info-8",
           "paper": "LoginPageComponent-paper-3",
           "root": "LoginPageComponent-root-1 root-1",
-          "spinner": "LoginPageComponent-spinner-8",
+          "spinner": "LoginPageComponent-spinner-9",
           "textField": "LoginPageComponent-textField-4",
-          "warning": "LoginPageComponent-warning-6",
+          "warning": "LoginPageComponent-warning-7",
         }
       }
       location={
@@ -159,10 +569,101 @@ exports[`Login page component login page renders redirect component if redirect 
 </div>
 `;
 
+exports[`Login page component login page renders spinner if auth is loading 1`] = `
+<div
+  className="LoginPageComponent-root-1 root-1"
+>
+  <WithStyles(Paper)
+    className="LoginPageComponent-paper-3"
+  >
+    <WithStyles(Avatar)
+      className="LoginPageComponent-avatar-2"
+    >
+      <pure(LockOutlinedIcon) />
+    </WithStyles(Avatar)>
+    <WithStyles(Typography)
+      component="h1"
+      variant="h5"
+    >
+      title
+    </WithStyles(Typography)>
+    <CredentialsLoginScreen
+      auth={
+        Object {
+          "failedToLogin": false,
+          "loading": true,
+          "provider": TestAuthProvider {
+            "mnemonic": undefined,
+            "redirectUrl": null,
+            "token": null,
+            "user": null,
+          },
+          "signedOutDueToTokenInvalidation": false,
+        }
+      }
+      changeMnemonic={[MockFunction]}
+      classes={
+        Object {
+          "avatar": "LoginPageComponent-avatar-2",
+          "button": "LoginPageComponent-button-6",
+          "formControl": "LoginPageComponent-formControl-5",
+          "info": "LoginPageComponent-info-8",
+          "paper": "LoginPageComponent-paper-3",
+          "root": "LoginPageComponent-root-1 root-1",
+          "spinner": "LoginPageComponent-spinner-9",
+          "textField": "LoginPageComponent-textField-4",
+          "warning": "LoginPageComponent-warning-7",
+        }
+      }
+      location={
+        Object {
+          "hash": "",
+          "pathname": "/",
+          "search": "",
+          "state": undefined,
+        }
+      }
+      verifyUsernameAndPassword={[Function]}
+    />
+    <WithStyles(CircularProgress)
+      className="LoginPageComponent-spinner-9"
+    />
+  </WithStyles(Paper)>
+</div>
+`;
+
 exports[`Login page component redirect component renders correctly 1`] = `
 <div
   className="root-1"
 >
+  <WithStyles(Button)
+    color="primary"
+    disabled={false}
+    onClick={[Function]}
+    variant="contained"
+  >
+    <WithStyles(Typography)
+      color="inherit"
+      noWrap={true}
+      style={
+        Object {
+          "marginTop": 3,
+        }
+      }
+    >
+      Login with Github
+    </WithStyles(Typography)>
+  </WithStyles(Button)>
+</div>
+`;
+
+exports[`Login page component redirect component renders failedToLogin error correctly 1`] = `
+<div
+  className="root-1"
+>
+  <WithStyles(Typography)>
+    login-redirect-error-msg
+  </WithStyles(Typography)>
   <WithStyles(Button)
     color="primary"
     disabled={false}

--- a/src/loginPage/loginPage.component.tsx
+++ b/src/loginPage/loginPage.component.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { connect } from 'react-redux';
 import { AnyAction } from 'redux';
 import { ThunkDispatch } from 'redux-thunk';
@@ -282,21 +282,8 @@ const LoginPageComponent = (props: CombinedLoginProps): React.ReactElement => {
   const mnemonic = props.auth.provider.mnemonic;
   const [mnemonics, setMnemonics] = useState<ICATAuthenticator[]>([]);
 
-  useEffect(() => {
-    if (
-      props.auth.provider.redirectUrl &&
-      props.location.search &&
-      !props.auth.loading &&
-      !props.auth.failedToLogin
-    ) {
-      if (props.location.search) {
-        props.verifyUsernameAndPassword('', props.location.search);
-      }
-    }
-  });
-
   const changeMnemonic = props.changeMnemonic;
-  useEffect(() => {
+  React.useEffect(() => {
     if (typeof mnemonic !== 'undefined') {
       fetchMnemonics().then(mnemonics => {
         const nonAdminAuthenticators = mnemonics.filter(
@@ -308,6 +295,19 @@ const LoginPageComponent = (props: CombinedLoginProps): React.ReactElement => {
       });
     }
   }, [changeMnemonic, setMnemonics, mnemonic]);
+
+  React.useEffect(() => {
+    if (
+      props.auth.provider.redirectUrl &&
+      props.location.search &&
+      !props.auth.loading &&
+      !props.auth.failedToLogin
+    ) {
+      if (props.location.search) {
+        props.verifyUsernameAndPassword('', props.location.search);
+      }
+    }
+  });
 
   let LoginScreen: React.ReactElement | null = null;
 

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -9,3 +9,5 @@ function noOp() {}
 if (typeof window.URL.createObjectURL === 'undefined') {
   Object.defineProperty(window.URL, 'createObjectURL', { value: noOp });
 }
+
+export const flushPromises = () => new Promise(setImmediate);

--- a/src/state/reducers/scigateway.reducer.test.tsx
+++ b/src/state/reducers/scigateway.reducer.test.tsx
@@ -23,6 +23,7 @@ import { ScigatewayState } from '../state.types';
 import TestAuthProvider from '../../authentication/testAuthProvider';
 import JWTAuthProvider from '../../authentication/jwtAuthProvider';
 import GithubAuthProvider from '../../authentication/githubAuthProvider';
+import ICATAuthProvider from '../../authentication/icatAuthProvider';
 
 describe('scigateway reducer', () => {
   let state: ScigatewayState;
@@ -202,6 +203,18 @@ describe('scigateway reducer', () => {
 
     expect(updatedState.authorisation.provider).toBeInstanceOf(
       GithubAuthProvider
+    );
+
+    updatedState = ScigatewayReducer(state, loadAuthProvider('icat'));
+
+    expect(updatedState.authorisation.provider).toBeInstanceOf(
+      ICATAuthProvider
+    );
+
+    updatedState = ScigatewayReducer(state, loadAuthProvider('icat.anon'));
+
+    expect(updatedState.authorisation.provider).toBeInstanceOf(
+      ICATAuthProvider
     );
   });
 

--- a/src/state/reducers/scigateway.reducer.tsx
+++ b/src/state/reducers/scigateway.reducer.tsx
@@ -34,6 +34,7 @@ import JWTAuthProvider from '../../authentication/jwtAuthProvider';
 import LoadingAuthProvider from '../../authentication/loadingAuthProvider';
 import GithubAuthProvider from '../../authentication/githubAuthProvider';
 import { Step } from 'react-joyride';
+import ICATAuthProvider from '../../authentication/icatAuthProvider';
 
 export const authState: AuthState = {
   failedToLogin: false,
@@ -205,13 +206,17 @@ export function handleAuthProviderUpdate(
   payload: AuthProviderPayload
 ): ScigatewayState {
   let provider = state.authorisation.provider;
-  switch (payload.authProvider) {
+  switch (payload.authProvider.split('.')[0]) {
     case 'jwt':
       provider = new JWTAuthProvider();
       break;
 
     case 'github':
       provider = new GithubAuthProvider();
+      break;
+
+    case 'icat':
+      provider = new ICATAuthProvider(payload.authProvider.split('.')[1]);
       break;
 
     default:
@@ -252,7 +257,9 @@ export function handleConfigureAnalytics(
   };
 }
 
-export function handleInitialiseAnalytics(state: ScigatewayState): ScigatewayState {
+export function handleInitialiseAnalytics(
+  state: ScigatewayState
+): ScigatewayState {
   if (state.analytics) {
     return {
       ...state,

--- a/src/state/state.types.tsx
+++ b/src/state/state.types.tsx
@@ -50,6 +50,14 @@ export interface User {
   avatarUrl: string;
 }
 
+// eslint-disable-next-line @typescript-eslint/interface-name-prefix
+export interface ICATAuthenticator {
+  mnemonic: string;
+  keys: { name: string; hide?: boolean }[];
+  friendly?: string;
+  admin?: boolean;
+}
+
 export interface AuthProvider {
   isLoggedIn: () => boolean;
   logOut: () => void;
@@ -57,6 +65,7 @@ export interface AuthProvider {
   verifyLogIn: () => Promise<void>;
   redirectUrl: string | null;
   user: User | null;
+  mnemonic?: string;
 }
 
 export interface AuthState {

--- a/src/stories/loginPage.stories.tsx
+++ b/src/stories/loginPage.stories.tsx
@@ -51,6 +51,21 @@ const buildRedirectLoginPage = (
   return buildLoginPage(failedToLogin, loading, provider);
 };
 
+const buildAnonLoginPage = (
+  failedToLogin: boolean,
+  loading: boolean
+): React.ReactElement => {
+  const provider = new TestAuthProvider(null);
+  provider.mnemonic = 'anon';
+  mock.onGet('/authenticators').reply(200, [
+    {
+      mnemonic: 'anon',
+      keys: [],
+    },
+  ]);
+  return buildLoginPage(failedToLogin, loading, provider);
+};
+
 const buildICATLoginPage = (
   failedToLogin: boolean,
   loading: boolean,
@@ -106,7 +121,17 @@ storiesOf('LoginPage/redirect', module)
   .add('loading', () => buildRedirectLoginPage(false, true))
   .add('unsuccessful', () => buildRedirectLoginPage(true, false));
 
-storiesOf('LoginPage/ICAT', module)
+storiesOf('LoginPage/anonymous', module)
+  .addParameters({
+    info: {
+      text: 'This is the login page for the whole site.',
+    },
+  })
+  .add('default', () => buildAnonLoginPage(false, false))
+  .add('loading', () => buildAnonLoginPage(false, true))
+  .add('unsuccessful', () => buildAnonLoginPage(true, false));
+
+storiesOf('LoginPage/multiple', module)
   .addParameters({
     info: {
       text: 'This is the login page for the whole site.',
@@ -117,6 +142,4 @@ storiesOf('LoginPage/ICAT', module)
   .add('username/password selected', () =>
     buildICATLoginPage(false, false, 'user/pass')
   )
-  .add('anon selected', () => buildICATLoginPage(false, false, 'anon'))
-  .add('loading', () => buildICATLoginPage(false, true))
-  .add('unsuccessful', () => buildICATLoginPage(true, false));
+  .add('anon selected', () => buildICATLoginPage(false, false, 'anon'));

--- a/src/stories/loginPage.stories.tsx
+++ b/src/stories/loginPage.stories.tsx
@@ -1,11 +1,15 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { FakeAsyncAction } from './utils';
+import { FakeAsyncAction, FakeReduxAction } from './utils';
 import { LoginPageWithStyles } from '../loginPage/loginPage.component';
 import { storybookResourceStrings } from './storybookResourceStrings';
 import { createLocation } from 'history';
 import TestAuthProvider from '../authentication/testAuthProvider';
 import { AuthProvider } from '../state/state.types';
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+
+const mock = new MockAdapter(axios);
 
 const buildLoginPage = (
   failedToLogin: boolean,
@@ -16,6 +20,9 @@ const buildLoginPage = (
     verifyUsernameAndPassword={(u, p) =>
       FakeAsyncAction(`verify username and password: ${u},${p}`)()
     }
+    changeMnemonic={m => {
+      FakeReduxAction(`change mnemonic: ${m}`)();
+    }}
     auth={{
       failedToLogin,
       signedOutDueToTokenInvalidation: false,
@@ -44,6 +51,41 @@ const buildRedirectLoginPage = (
   return buildLoginPage(failedToLogin, loading, provider);
 };
 
+const buildICATLoginPage = (
+  failedToLogin: boolean,
+  loading: boolean,
+  mnemonic?: string
+): React.ReactElement => {
+  const provider = new TestAuthProvider(null);
+  provider.mnemonic = mnemonic || '';
+  mock.onGet('/authenticators').reply(200, [
+    {
+      mnemonic: 'user/pass',
+      keys: [{ name: 'username' }, { name: 'password' }],
+    },
+    {
+      mnemonic: 'anon',
+      keys: [],
+    },
+  ]);
+  return buildLoginPage(failedToLogin, loading, provider);
+};
+
+const buildSingleICATLoginPage = (
+  failedToLogin: boolean,
+  loading: boolean
+): React.ReactElement => {
+  const provider = new TestAuthProvider(null);
+  provider.mnemonic = 'user/pass';
+  mock.onGet('/authenticators').reply(200, [
+    {
+      mnemonic: 'user/pass',
+      keys: [{ name: 'username' }, { name: 'password' }],
+    },
+  ]);
+  return buildLoginPage(failedToLogin, loading, provider);
+};
+
 storiesOf('LoginPage/credentials', module)
   .addParameters({
     info: {
@@ -63,3 +105,18 @@ storiesOf('LoginPage/redirect', module)
   .add('default', () => buildRedirectLoginPage(false, false))
   .add('loading', () => buildRedirectLoginPage(false, true))
   .add('unsuccessful', () => buildRedirectLoginPage(true, false));
+
+storiesOf('LoginPage/ICAT', module)
+  .addParameters({
+    info: {
+      text: 'This is the login page for the whole site.',
+    },
+  })
+  .add('single authenticator', () => buildSingleICATLoginPage(false, false))
+  .add('no authenticator selected', () => buildICATLoginPage(false, false))
+  .add('username/password selected', () =>
+    buildICATLoginPage(false, false, 'user/pass')
+  )
+  .add('anon selected', () => buildICATLoginPage(false, false, 'anon'))
+  .add('loading', () => buildICATLoginPage(false, true))
+  .add('unsuccessful', () => buildICATLoginPage(true, false));

--- a/yarn.lock
+++ b/yarn.lock
@@ -2059,17 +2059,10 @@
     "@types/history" "*"
     "@types/react" "*"
 
-"@types/react-dom@*":
+"@types/react-dom@*", "@types/react-dom@^16.8.5":
   version "16.9.4"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.4.tgz#0b58df09a60961dcb77f62d4f1832427513420df"
   integrity sha512-fya9xteU/n90tda0s+FtN5Ym4tbgxpq/hb/Af24dvs6uYnYn+fspaxw5USlw0R8apDNwxsqumdRoCoKitckQqw==
-  dependencies:
-    "@types/react" "*"
-
-"@types/react-dom@16.8.5":
-  version "16.8.5"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.8.5.tgz#3e3f4d99199391a7fb40aa3a155c8dd99b899cbd"
-  integrity sha512-idCEjROZ2cqh29+trmTmZhsBAUNQuYrF92JHKzZ5+aiFM1mlSk3bb23CK7HhYuOY75Apgap5y2jTyHzaM2AJGA==
   dependencies:
     "@types/react" "*"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2900,6 +2900,13 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.9.0.tgz#24390e6ad61386b0a747265754d2a17219de862c"
   integrity sha512-Uvq6hVe90D0B2WEnUqtdgY1bATGz3mw33nH9Y+dmA+w5DHvUmBgkr5rM/KCHpCsiFNRUfokW/szpPPgMK2hm4A==
 
+axios-mock-adapter@^1.17.0:
+  version "1.17.0"
+  resolved "https://registry.yarnpkg.com/axios-mock-adapter/-/axios-mock-adapter-1.17.0.tgz#0dbee43c606d4aaba5a43d88d96d6661a7cc3c04"
+  integrity sha512-q3efmwJUOO4g+wsLNSk9Ps1UlJoF3fQ3FSEe4uEEhkRtu7SoiAVPj8R3Hc/WP55MBTVFzaDP9QkdJhdVhP8A1Q==
+  dependencies:
+    deep-equal "^1.0.1"
+
 axios@^0.19.0:
   version "0.19.0"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.0.tgz#8e09bff3d9122e133f7b8101c8fbdd00ed3d2ab8"


### PR DESCRIPTION
## Description
This PR adds the icatAuthProvider and adds the ability for the login page to show a dropdown based off of the mnemonics fetched from `scigateway-auth`.

This PR relies on ral-facilities/scigateway-auth#36

## Testing instructions
- [x] Review code
- [x] Check Travis build
- [x] Review changes to test coverage
- [x] If you want to try for yourself, checkout ral-facilities/scigateway-auth#36 and run the auth server (change the port to port 8000, and rename `icat_auth_url` to `icat_url` and remove the `/session` part of the url) and also change your `"auth-provider"` in scigateway's `settings.json` to be `"icat"`

## Agile board tracking
Closes #129 
Part of #18 