### PR TITLE
Set codecov targets + thresholds

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 5
+    patch:
+      default:
+        target: 90


### PR DESCRIPTION
## Description
To stop codecov from assigning a failed status to commits and PRs due to too strict thresholds, actually set thresholds. I've set the project one to be compared against the master branch but to allow a less than 5% decrease, as well as setting code in PRs themselves to be ok as long as the PR coverage is 90%+.

Do these limits seem ok? Is the PR limit too high? We can always ignore codecov commit/PR statuses and merge anyway if there is a reason for missed coverage.

## Testing instructions
Add a set up instructions describing how the reviewer should test the code
- [x] Review code
- [x] Check Travis build
- [x] Review changes to test coverage
