### PR TITLE
#135 - check length of mnemonics before querying for authenticators

### DIFF
--- a/src/loginPage/loginPage.component.tsx
+++ b/src/loginPage/loginPage.component.tsx
@@ -284,7 +284,7 @@ const LoginPageComponent = (props: CombinedLoginProps): React.ReactElement => {
 
   const changeMnemonic = props.changeMnemonic;
   React.useEffect(() => {
-    if (typeof mnemonic !== 'undefined') {
+    if (typeof mnemonic !== 'undefined' && mnemonics.length === 0) {
       fetchMnemonics().then(mnemonics => {
         const nonAdminAuthenticators = mnemonics.filter(
           authenticator => !authenticator.admin
@@ -294,7 +294,7 @@ const LoginPageComponent = (props: CombinedLoginProps): React.ReactElement => {
           changeMnemonic(nonAdminAuthenticators[0].mnemonic);
       });
     }
-  }, [changeMnemonic, setMnemonics, mnemonic]);
+  }, [changeMnemonic, mnemonic, mnemonics]);
 
   React.useEffect(() => {
     if (


### PR DESCRIPTION
## Description
Fixes the bug (#135) that Goel found that selecting a new mnemonic retriggers a call to `/authenticators`

## Testing instructions
- [x] Review code
- [x] Check Travis build
- [x] Review changes to test coverage

## Agile board tracking
Fixes #135 