### PR TITLE
Fix multiple ICAT authenticator error messages

### DIFF
--- a/src/loginPage/loginPage.component.tsx
+++ b/src/loginPage/loginPage.component.tsx
@@ -281,20 +281,24 @@ function fetchMnemonics(): Promise<ICATAuthenticator[]> {
 const LoginPageComponent = (props: CombinedLoginProps): React.ReactElement => {
   const mnemonic = props.auth.provider.mnemonic;
   const [mnemonics, setMnemonics] = useState<ICATAuthenticator[]>([]);
+  const [fetchedMnemonics, setFetchedMnemonics] = useState<boolean>(false);
 
   const changeMnemonic = props.changeMnemonic;
   React.useEffect(() => {
-    if (typeof mnemonic !== 'undefined' && mnemonics.length === 0) {
+    console.log('mnemonic', mnemonic);
+    console.log('fetchedMnemonics', fetchedMnemonics);
+    if (typeof mnemonic !== 'undefined' && !fetchedMnemonics) {
       fetchMnemonics().then(mnemonics => {
         const nonAdminAuthenticators = mnemonics.filter(
           authenticator => !authenticator.admin
         );
         setMnemonics(nonAdminAuthenticators);
+        setFetchedMnemonics(true);
         if (nonAdminAuthenticators.length === 1)
           changeMnemonic(nonAdminAuthenticators[0].mnemonic);
       });
     }
-  }, [changeMnemonic, mnemonic, mnemonics]);
+  }, [changeMnemonic, mnemonic, fetchedMnemonics]);
 
   React.useEffect(() => {
     if (


### PR DESCRIPTION
## Description
Use a boolean variable to track whether we have already tried to fetch the mnemonics so as to prevent spamming the user with error messages.

## Testing instructions
- [x] Review code
- [x] Check Travis build
- [x] Review changes to test coverage

## Agile board tracking
Closes #138 