### PR TITLE
#143 - parse jwt + set username in icat authenticator

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
       "enzyme-to-json/serializer"
     ],
     "collectCoverageFrom": [
-      "src/**/*.{tsx,js,jsx}",
+      "src/**/*.{tsx,js,jsx,ts}",
       "!src/index.tsx",
       "!src/serviceWorker.ts",
       "!src/setupTests.js",

--- a/src/authentication/icatAuthProvider.test.tsx
+++ b/src/authentication/icatAuthProvider.test.tsx
@@ -1,6 +1,9 @@
 import mockAxios from 'axios';
 import ICATAuthProvider from './icatAuthProvider';
 import ReactGA from 'react-ga';
+import parseJwt from './parseJwt';
+
+jest.mock('./parseJwt');
 
 describe('ICAT auth provider', () => {
   let icatAuthProvider: ICATAuthProvider;
@@ -17,6 +20,9 @@ describe('ICAT auth provider', () => {
 
     icatAuthProvider = new ICATAuthProvider('mnemonic');
     ReactGA.initialize('test id', { testMode: true, titleCase: false });
+    (parseJwt as jest.Mock).mockImplementation(
+      token => `{"sessionId": "${token}", "username": "${token} username"}`
+    );
   });
 
   afterEach(() => {
@@ -58,6 +64,7 @@ describe('ICAT auth provider', () => {
     expect(localStorage.setItem).toBeCalledWith('scigateway:token', 'token');
 
     expect(icatAuthProvider.isLoggedIn()).toBeTruthy();
+    expect(icatAuthProvider.user.username).toBe('token username');
 
     expect(ReactGA.testModeAPI.calls[1][0]).toEqual('send');
     expect(ReactGA.testModeAPI.calls[1][1]).toEqual({

--- a/src/authentication/icatAuthProvider.tsx
+++ b/src/authentication/icatAuthProvider.tsx
@@ -1,6 +1,7 @@
 import Axios from 'axios';
 import BaseAuthProvider from './baseAuthProvider';
 import ReactGA from 'react-ga';
+import parseJwt from './parseJwt';
 
 export default class ICATAuthProvider extends BaseAuthProvider {
   public mnemonic: string;
@@ -28,6 +29,10 @@ export default class ICATAuthProvider extends BaseAuthProvider {
           action: 'Sucessfully logged in via JWT',
         });
         this.storeToken(res.data);
+        const payload: { sessionId: string; username: string } = JSON.parse(
+          parseJwt(res.data)
+        );
+        this.storeUser(payload.username);
         return;
       })
       .catch(err => {

--- a/src/authentication/parseJwt.test.ts
+++ b/src/authentication/parseJwt.test.ts
@@ -1,0 +1,17 @@
+import parseJwt from './parseJwt';
+
+describe('parseJwt', () => {
+  it('should parse JWT', () => {
+    const token =
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoiTG91aXNlIn0.LydxYJcsR5D5lFzF-UGiQjtqc9F58Q3kffQ3KwcEAIE';
+    const result = parseJwt(token);
+    expect(result).toBe('{"name":"Louise"}');
+  });
+
+  it('should parse JWT with unicode characters', () => {
+    const token =
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoixYHDtMO8w61zw6gifQ.59rghrFL8QwklRS1zmGggBV5hPAbhJhgtX0tjpGBJV4';
+    const result = parseJwt(token);
+    expect(result).toBe('{"name":"Łôüísè"}');
+  });
+});

--- a/src/authentication/parseJwt.ts
+++ b/src/authentication/parseJwt.ts
@@ -1,0 +1,19 @@
+// we return the payload as a string rather than JSON.parse-ing it
+// so that callers can inform TypeScript the type of their payload
+// when they JSON.parse the result of this function
+const parseJwt = (token: string): string => {
+  const base64Url = token.split('.')[1];
+  const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+  const payload = decodeURIComponent(
+    atob(base64).replace(/(.)/g, function(m, p) {
+      var code = p
+        .charCodeAt(0)
+        .toString(16)
+        .toUpperCase();
+      return '%' + ('00' + code).slice(-2);
+    })
+  );
+  return payload;
+};
+
+export default parseJwt;


### PR DESCRIPTION
## Description
This PR parses the returned JWT and sets the username of the user from the JWT payload. This results in the user profile component showing the username.

This relies on ral-facilities/scigateway-auth#40

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [x] Review code
- [x] Check Travis build
- [x] Review changes to test coverage
- [x] Test using the corresponding branch in scigateway-auth and check that logging in via your fed id in ICAT displays your fed id in the user profile component.

## Agile board tracking
Closes #143 