### PR TITLE
Fix Material-UI styling clashes with plugins

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,6 +30,7 @@ import {
 
 const generateClassName = createGenerateClassName({
   productionPrefix: 'sgw',
+  disableGlobal: true,
 });
 
 const history = createBrowserHistory();


### PR DESCRIPTION
## Description
Set `disableGlobal` to `true` in the class name generate provided to Material UI

## Testing instructions
- [ ] Review code
- [ ] Check Travis build
- [ ] Review changes to test coverage
- [ ] Read associated wiki page on how to do this in new plugins (https://github.com/ral-facilities/scigateway/wiki/Creating-a-new-plugin-app#making-sure-material-ui-styles-dont-clash)

## Agile board tracking
Closes #146