### PR TITLE
Fix uneccessary plugin remounting

### DIFF
--- a/src/routing/__snapshots__/authorisedRoute.component.test.tsx.snap
+++ b/src/routing/__snapshots__/authorisedRoute.component.test.tsx.snap
@@ -3,10 +3,10 @@
 exports[`AuthorisedRoute component renders component when user logged in 1`] = `
 <div>
   <ComponentToProtect
+    dispatch={[Function]}
     loading={false}
     location="/"
     loggedIn={true}
-    requestPluginRerender={[Function]}
     store={
       Object {
         "clearActions": [Function],

--- a/src/routing/__snapshots__/routing.component.test.tsx.snap
+++ b/src/routing/__snapshots__/routing.component.test.tsx.snap
@@ -1,5 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Routing component renders a route for a plugin 1`] = `
+<Route
+  component={
+    Object {
+      "$$typeof": Symbol(react.memo),
+      "WrappedComponent": [Function],
+      "compare": null,
+      "displayName": "Connect(WithAuthComponent)",
+      "type": [Function],
+    }
+  }
+  path="test-link"
+/>
+`;
+
 exports[`Routing component renders component with no plugin routes 1`] = `
 <div
   className="container-class"
@@ -103,31 +118,29 @@ exports[`Routing component renders component with plugins 1`] = `
       exact={true}
       path="/cookies"
     />
-    <Route
-      component={
-        Object {
-          "$$typeof": Symbol(react.memo),
-          "WrappedComponent": [Function],
-          "compare": null,
-          "displayName": "Connect(WithAuthComponent)",
-          "type": [Function],
-        }
-      }
+    <PluginRoute
       key="test section_test link"
-      path="test link"
-    />
-    <Route
-      component={
+      plugin={
         Object {
-          "$$typeof": Symbol(react.memo),
-          "WrappedComponent": [Function],
-          "compare": null,
-          "displayName": "Connect(WithAuthComponent)",
-          "type": [Function],
+          "displayName": "Test Plugin",
+          "link": "test link",
+          "order": 1,
+          "plugin": "test_plugin_name",
+          "section": "test section",
         }
       }
+    />
+    <PluginRoute
       key="test section 2_test link 2"
-      path="test link 2"
+      plugin={
+        Object {
+          "displayName": "Test Plugin 2",
+          "link": "test link 2",
+          "order": 2,
+          "plugin": "test_plugin_name_2",
+          "section": "test section 2",
+        }
+      }
     />
     <Route
       component={

--- a/src/routing/authorisedRoute.component.tsx
+++ b/src/routing/authorisedRoute.component.tsx
@@ -1,8 +1,6 @@
 import React, { Component, ComponentType } from 'react';
 import { Redirect } from 'react-router-dom';
 import { StateType, AuthState } from '../state/state.types';
-import { AnyAction, Dispatch } from 'redux';
-import { requestPluginRerender } from '../state/actions/scigateway.actions';
 import { connect } from 'react-redux';
 import LoadingAuthProvider from '../authentication/loadingAuthProvider';
 
@@ -10,10 +8,6 @@ interface WithAuthProps {
   loading: boolean;
   loggedIn: boolean;
   location: string;
-}
-
-interface WithAuthDispatchProps {
-  requestPluginRerender: () => AnyAction;
 }
 
 const isStartingUpOrLoading = (auth: AuthState): boolean =>
@@ -25,21 +19,11 @@ const mapStateToProps = (state: StateType): WithAuthProps => ({
   location: state.router.location.pathname,
 });
 
-const mapDispatchToProps = (dispatch: Dispatch): WithAuthDispatchProps => ({
-  requestPluginRerender: () => dispatch(requestPluginRerender()),
-});
-
 // generator function to create an authentication layer around the given component
 export default function withAuth(
   ComponentToProtect: ComponentType
 ): ComponentType {
-  class WithAuthComponent extends Component<
-    WithAuthProps & WithAuthDispatchProps
-  > {
-    public componentDidMount(): void {
-      this.props.requestPluginRerender();
-    }
-
+  class WithAuthComponent extends Component<WithAuthProps> {
     public render(): React.ReactElement {
       const { props } = this;
       return (
@@ -61,5 +45,5 @@ export default function withAuth(
     }
   }
 
-  return connect(mapStateToProps, mapDispatchToProps)(WithAuthComponent);
+  return connect(mapStateToProps)(WithAuthComponent);
 }

--- a/src/routing/routing.component.test.tsx
+++ b/src/routing/routing.component.test.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
-import Routing, { PluginPlaceHolder } from './routing.component';
+import Routing, { PluginPlaceHolder, PluginRoute } from './routing.component';
 import { createShallow } from '@material-ui/core/test-utils';
 import configureStore from 'redux-mock-store';
 import { StateType } from '../state/state.types';
 import { initialState } from '../state/reducers/scigateway.reducer';
 import { createLocation } from 'history';
+import { MemoryRouter } from 'react-router';
 
 // this removes a lot of unnecessary styling information in the snapshots
 jest.mock('@material-ui/core/styles', () => ({
@@ -62,6 +63,25 @@ describe('Routing component', () => {
     ];
     const wrapper = shallow(
       <Routing store={mockStore(state)} classes={classes} />
+    );
+
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('renders a route for a plugin', () => {
+    shallow = createShallow({ untilSelector: 'PluginRoute' });
+    const wrapper = shallow(
+      <MemoryRouter initialEntries={['/test-link']}>
+        <PluginRoute
+          plugin={{
+            section: 'test section',
+            link: 'test-link',
+            plugin: 'test_plugin_name',
+            displayName: 'Test Plugin',
+            order: 1,
+          }}
+        />
+      </MemoryRouter>
     );
 
     expect(wrapper).toMatchSnapshot();

--- a/src/routing/routing.component.tsx
+++ b/src/routing/routing.component.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {
   withStyles,
   createStyles,
@@ -47,6 +47,15 @@ export const PluginPlaceHolder = (id: string): (() => React.ReactElement) =>
   /* eslint-disable-next-line react/display-name */
   () => <div id={id}>{id} failed to load correctly</div>;
 
+export class PluginRoute extends React.PureComponent<{ plugin: PluginConfig }> {
+  public render(): React.ReactNode {
+    const p = this.props.plugin;
+    return (
+      <Route path={p.link} component={withAuth(PluginPlaceHolder(p.plugin))} />
+    );
+  }
+}
+
 class Routing extends React.Component<
   RoutingProps & WithStyles<typeof styles>
 > {
@@ -66,11 +75,7 @@ class Routing extends React.Component<
           <Route exact path="/login" component={LoginPage} />
           <Route exact path="/cookies" component={CookiesPage} />
           {this.props.plugins.map(p => (
-            <Route
-              key={`${p.section}_${p.link}`}
-              path={p.link}
-              component={withAuth(PluginPlaceHolder(p.plugin))}
-            />
+            <PluginRoute key={`${p.section}_${p.link}`} plugin={p} />
           ))}
           <Route component={withAuth(PageNotFound)} />
         </Switch>

--- a/src/state/middleware/scigateway.middleware.test.tsx
+++ b/src/state/middleware/scigateway.middleware.test.tsx
@@ -4,7 +4,7 @@ import configureStore, { MockStoreEnhanced } from 'redux-mock-store';
 import log from 'loglevel';
 import ReactGA from 'react-ga';
 import { createLocation } from 'history';
-import { InvalidateTokenType } from '../scigateway.types';
+import { InvalidateTokenType, ToggleDrawerType } from '../scigateway.types';
 import { toastr } from 'react-redux-toastr';
 import { AddHelpTourStepsType } from '../scigateway.types';
 import { StateType } from '../state.types';
@@ -144,6 +144,17 @@ describe('scigateway middleware', () => {
     });
 
     expect(ReactGA.testModeAPI.calls.length).toEqual(3);
+  });
+
+  it('should also send request plugin rerender action when ToggleDrawer action is sent', () => {
+    const toggleDrawerAction = {
+      type: ToggleDrawerType,
+    };
+    ScigatewayMiddleware(store)(store.dispatch)(toggleDrawerAction);
+
+    expect(store.getActions().length).toEqual(2);
+    expect(store.getActions()[0]).toEqual(toggleDrawerAction);
+    expect(store.getActions()[1]).toEqual(requestPluginRerenderAction);
   });
 
   it('should listen for events and fire registerroute action', () => {

--- a/src/state/middleware/scigateway.middleware.tsx
+++ b/src/state/middleware/scigateway.middleware.tsx
@@ -4,10 +4,14 @@ import {
   RegisterRouteType,
   InvalidateTokenType,
   RequestPluginRerenderType,
+  ToggleDrawerType,
 } from '../scigateway.types';
 import log from 'loglevel';
 import { toastr } from 'react-redux-toastr';
-import { addHelpTourSteps } from '../actions/scigateway.actions';
+import {
+  addHelpTourSteps,
+  requestPluginRerender,
+} from '../actions/scigateway.actions';
 import ReactGA from 'react-ga';
 import { StateType } from '../state.types';
 
@@ -125,6 +129,11 @@ const ScigatewayMiddleware: Middleware = ((
       currentPage = nextPage;
       trackPage(nextPage);
     }
+  }
+
+  if (action.type === ToggleDrawerType) {
+    next(action);
+    return store.dispatch(requestPluginRerender());
   }
 
   return next(action);


### PR DESCRIPTION
## Description
This fixes the plugin remounting issue described in #145, via implementing the solution I described here: https://github.com/ral-facilities/scigateway/issues/145#issuecomment-581833290. This is due to the DAaaS project preferring the current toggle-able behaviour rather than an overlay, so this just fixes the base issue of using a memoised component.

## Testing instructions
- [x] Review code
- [x] Check Travis build
- [x] Review changes to test coverage
- [x] Check that this actually fixes the issue by loading `datagateway-dataview` (or another plugin) and checking opening the drawer does not unmount the plugin (aka the plugin retains its state).

## Agile board tracking
Fixes #145 