### PR TITLE
moved browser settings to new menu #426

### DIFF
--- a/public/res/default.json
+++ b/public/res/default.json
@@ -1,7 +1,9 @@
 {
   "main-appbar": {
     "title": "SciGateway",
-    "contact": "Contact"
+    "contact": "Contact",
+    "manage-cookies-button": "Manage cookies",
+    "toggle-dark-mode": "Toggle Dark Mode"
   },
   "login": {
     "title": "Sign in",
@@ -11,9 +13,7 @@
     "logout-button": "Sign out",
     "login-error-msg": "Failed to log in. Invalid username or password.",
     "login-redirect-error-msg": "Failed to log in. Re-direct token is invalid.",
-    "token-invalid-msg": "Your session token has expired or been invalidated, please sign in again.",
-    "manage-cookies-button": "Manage cookies",
-    "toggle-dark-mode": "Toggle Dark Mode"
+    "token-invalid-msg": "Your session token has expired or been invalidated, please sign in again."
   },
   "home-page": {
     "title": "SciGateway",

--- a/public/settings.example.json
+++ b/public/settings.example.json
@@ -25,6 +25,10 @@
       "content": "Click here to see any notifications you have"
     },
     {
+      "target": ".tour-settings",
+      "content": "Click here to change settings for cookies and darkmode"
+    },
+    {
       "target": ".tour-contact",
       "content": "Click here to contact the support team with any issues or feedback"
     },

--- a/server/e2e-settings.json
+++ b/server/e2e-settings.json
@@ -28,6 +28,10 @@
       "content": "Click here to see any notifications you have"
     },
     {
+      "target": ".tour-settings",
+      "content": "Click here to change settings for cookies and darkmode"
+    },
+    {
       "target": ".tour-contact",
       "content": "Click here to contact the support team with any issues or feedback"
     },

--- a/src/mainAppBar/__snapshots__/mainAppBar.component.test.tsx.snap
+++ b/src/mainAppBar/__snapshots__/mainAppBar.component.test.tsx.snap
@@ -60,6 +60,42 @@ exports[`Main app bar component app bar indented when drawer is open 1`] = `
       </WithStyles(ForwardRef(IconButton))>
       <Connect(WithStyles(NotificationBadge)) />
       <Connect(WithStyles(UserProfileComponent)) />
+      <WithStyles(ForwardRef(IconButton))
+        aria-label="Open browser settings"
+        className="MainAppBar-button-6"
+        onClick={[Function]}
+      >
+        <SettingsIcon />
+      </WithStyles(ForwardRef(IconButton))>
+      <WithStyles(ForwardRef(Menu))
+        anchorEl={null}
+        id="settings"
+        onClose={[Function]}
+        open={false}
+      >
+        <WithStyles(ForwardRef(MenuItem))
+          id="item-manage-cookies"
+          onClick={[Function]}
+        >
+          <WithStyles(ForwardRef(ListItemIcon))>
+            <TuneIcon />
+          </WithStyles(ForwardRef(ListItemIcon))>
+          <WithStyles(ForwardRef(ListItemText))
+            primary="manage-cookies-button"
+          />
+        </WithStyles(ForwardRef(MenuItem))>
+        <WithStyles(ForwardRef(MenuItem))
+          id="item-dark-mode"
+          onClick={[Function]}
+        >
+          <WithStyles(ForwardRef(ListItemIcon))>
+            <Brightness4Icon />
+          </WithStyles(ForwardRef(ListItemIcon))>
+          <WithStyles(ForwardRef(ListItemText))
+            primary="toggle-dark-mode"
+          />
+        </WithStyles(ForwardRef(MenuItem))>
+      </WithStyles(ForwardRef(Menu))>
     </WithStyles(ForwardRef(Toolbar))>
   </WithStyles(ForwardRef(AppBar))>
 </div>
@@ -125,6 +161,42 @@ exports[`Main app bar component app bar renders correctly 1`] = `
       </WithStyles(ForwardRef(IconButton))>
       <Connect(WithStyles(NotificationBadge)) />
       <Connect(WithStyles(UserProfileComponent)) />
+      <WithStyles(ForwardRef(IconButton))
+        aria-label="Open browser settings"
+        className="MainAppBar-button-6"
+        onClick={[Function]}
+      >
+        <SettingsIcon />
+      </WithStyles(ForwardRef(IconButton))>
+      <WithStyles(ForwardRef(Menu))
+        anchorEl={null}
+        id="settings"
+        onClose={[Function]}
+        open={false}
+      >
+        <WithStyles(ForwardRef(MenuItem))
+          id="item-manage-cookies"
+          onClick={[Function]}
+        >
+          <WithStyles(ForwardRef(ListItemIcon))>
+            <TuneIcon />
+          </WithStyles(ForwardRef(ListItemIcon))>
+          <WithStyles(ForwardRef(ListItemText))
+            primary="manage-cookies-button"
+          />
+        </WithStyles(ForwardRef(MenuItem))>
+        <WithStyles(ForwardRef(MenuItem))
+          id="item-dark-mode"
+          onClick={[Function]}
+        >
+          <WithStyles(ForwardRef(ListItemIcon))>
+            <Brightness4Icon />
+          </WithStyles(ForwardRef(ListItemIcon))>
+          <WithStyles(ForwardRef(ListItemText))
+            primary="toggle-dark-mode"
+          />
+        </WithStyles(ForwardRef(MenuItem))>
+      </WithStyles(ForwardRef(Menu))>
     </WithStyles(ForwardRef(Toolbar))>
   </WithStyles(ForwardRef(AppBar))>
 </div>
@@ -169,6 +241,42 @@ exports[`Main app bar component does not render contact button when feature is f
       </WithStyles(ForwardRef(IconButton))>
       <Connect(WithStyles(NotificationBadge)) />
       <Connect(WithStyles(UserProfileComponent)) />
+      <WithStyles(ForwardRef(IconButton))
+        aria-label="Open browser settings"
+        className="MainAppBar-button-6"
+        onClick={[Function]}
+      >
+        <SettingsIcon />
+      </WithStyles(ForwardRef(IconButton))>
+      <WithStyles(ForwardRef(Menu))
+        anchorEl={null}
+        id="settings"
+        onClose={[Function]}
+        open={false}
+      >
+        <WithStyles(ForwardRef(MenuItem))
+          id="item-manage-cookies"
+          onClick={[Function]}
+        >
+          <WithStyles(ForwardRef(ListItemIcon))>
+            <TuneIcon />
+          </WithStyles(ForwardRef(ListItemIcon))>
+          <WithStyles(ForwardRef(ListItemText))
+            primary="manage-cookies-button"
+          />
+        </WithStyles(ForwardRef(MenuItem))>
+        <WithStyles(ForwardRef(MenuItem))
+          id="item-dark-mode"
+          onClick={[Function]}
+        >
+          <WithStyles(ForwardRef(ListItemIcon))>
+            <Brightness4Icon />
+          </WithStyles(ForwardRef(ListItemIcon))>
+          <WithStyles(ForwardRef(ListItemText))
+            primary="toggle-dark-mode"
+          />
+        </WithStyles(ForwardRef(MenuItem))>
+      </WithStyles(ForwardRef(Menu))>
     </WithStyles(ForwardRef(Toolbar))>
   </WithStyles(ForwardRef(AppBar))>
 </div>

--- a/src/mainAppBar/__snapshots__/mainAppBar.component.test.tsx.snap
+++ b/src/mainAppBar/__snapshots__/mainAppBar.component.test.tsx.snap
@@ -60,7 +60,7 @@ exports[`Main app bar component app bar indented when drawer is open 1`] = `
       </WithStyles(ForwardRef(IconButton))>
       <WithStyles(ForwardRef(IconButton))
         aria-label="Open browser settings"
-        className="MainAppBar-button-6"
+        className="MainAppBar-button-6 tour-settings"
         onClick={[Function]}
       >
         <SettingsIcon />
@@ -161,7 +161,7 @@ exports[`Main app bar component app bar renders correctly 1`] = `
       </WithStyles(ForwardRef(IconButton))>
       <WithStyles(ForwardRef(IconButton))
         aria-label="Open browser settings"
-        className="MainAppBar-button-6"
+        className="MainAppBar-button-6 tour-settings"
         onClick={[Function]}
       >
         <SettingsIcon />
@@ -241,7 +241,7 @@ exports[`Main app bar component does not render contact button when feature is f
       </WithStyles(ForwardRef(IconButton))>
       <WithStyles(ForwardRef(IconButton))
         aria-label="Open browser settings"
-        className="MainAppBar-button-6"
+        className="MainAppBar-button-6 tour-settings"
         onClick={[Function]}
       >
         <SettingsIcon />

--- a/src/mainAppBar/__snapshots__/mainAppBar.component.test.tsx.snap
+++ b/src/mainAppBar/__snapshots__/mainAppBar.component.test.tsx.snap
@@ -58,8 +58,6 @@ exports[`Main app bar component app bar indented when drawer is open 1`] = `
       >
         <HelpOutlineIcon />
       </WithStyles(ForwardRef(IconButton))>
-      <Connect(WithStyles(NotificationBadge)) />
-      <Connect(WithStyles(UserProfileComponent)) />
       <WithStyles(ForwardRef(IconButton))
         aria-label="Open browser settings"
         className="MainAppBar-button-6"
@@ -96,6 +94,8 @@ exports[`Main app bar component app bar indented when drawer is open 1`] = `
           />
         </WithStyles(ForwardRef(MenuItem))>
       </WithStyles(ForwardRef(Menu))>
+      <Connect(WithStyles(NotificationBadge)) />
+      <Connect(WithStyles(UserProfileComponent)) />
     </WithStyles(ForwardRef(Toolbar))>
   </WithStyles(ForwardRef(AppBar))>
 </div>
@@ -159,8 +159,6 @@ exports[`Main app bar component app bar renders correctly 1`] = `
       >
         <HelpOutlineIcon />
       </WithStyles(ForwardRef(IconButton))>
-      <Connect(WithStyles(NotificationBadge)) />
-      <Connect(WithStyles(UserProfileComponent)) />
       <WithStyles(ForwardRef(IconButton))
         aria-label="Open browser settings"
         className="MainAppBar-button-6"
@@ -197,6 +195,8 @@ exports[`Main app bar component app bar renders correctly 1`] = `
           />
         </WithStyles(ForwardRef(MenuItem))>
       </WithStyles(ForwardRef(Menu))>
+      <Connect(WithStyles(NotificationBadge)) />
+      <Connect(WithStyles(UserProfileComponent)) />
     </WithStyles(ForwardRef(Toolbar))>
   </WithStyles(ForwardRef(AppBar))>
 </div>
@@ -239,8 +239,6 @@ exports[`Main app bar component does not render contact button when feature is f
       >
         <HelpOutlineIcon />
       </WithStyles(ForwardRef(IconButton))>
-      <Connect(WithStyles(NotificationBadge)) />
-      <Connect(WithStyles(UserProfileComponent)) />
       <WithStyles(ForwardRef(IconButton))
         aria-label="Open browser settings"
         className="MainAppBar-button-6"
@@ -277,6 +275,8 @@ exports[`Main app bar component does not render contact button when feature is f
           />
         </WithStyles(ForwardRef(MenuItem))>
       </WithStyles(ForwardRef(Menu))>
+      <Connect(WithStyles(NotificationBadge)) />
+      <Connect(WithStyles(UserProfileComponent)) />
     </WithStyles(ForwardRef(Toolbar))>
   </WithStyles(ForwardRef(AppBar))>
 </div>

--- a/src/mainAppBar/__snapshots__/userProfile.component.test.tsx.snap
+++ b/src/mainAppBar/__snapshots__/userProfile.component.test.tsx.snap
@@ -32,29 +32,6 @@ exports[`User profile component renders default avatar if signed in 1`] = `
       </div>
       <WithStyles(ForwardRef(Divider)) />
       <WithStyles(ForwardRef(MenuItem))
-        id="item-manage-cookies"
-        onClick={[Function]}
-      >
-        <WithStyles(ForwardRef(ListItemIcon))>
-          <SettingsIcon />
-        </WithStyles(ForwardRef(ListItemIcon))>
-        <WithStyles(ForwardRef(ListItemText))
-          primary="manage-cookies-button"
-        />
-      </WithStyles(ForwardRef(MenuItem))>
-      <WithStyles(ForwardRef(MenuItem))
-        id="item-dark-mode"
-        onClick={[Function]}
-      >
-        <WithStyles(ForwardRef(ListItemIcon))>
-          <Brightness4Icon />
-        </WithStyles(ForwardRef(ListItemIcon))>
-        <WithStyles(ForwardRef(ListItemText))
-          primary="toggle-dark-mode"
-        />
-      </WithStyles(ForwardRef(MenuItem))>
-      <WithStyles(ForwardRef(Divider)) />
-      <WithStyles(ForwardRef(MenuItem))
         id="item-sign-out"
         onClick={[Function]}
       >
@@ -146,29 +123,6 @@ exports[`User profile component renders user avatar if signed in with avatar url
           test
         </WithStyles(ForwardRef(Typography))>
       </div>
-      <WithStyles(ForwardRef(Divider)) />
-      <WithStyles(ForwardRef(MenuItem))
-        id="item-manage-cookies"
-        onClick={[Function]}
-      >
-        <WithStyles(ForwardRef(ListItemIcon))>
-          <SettingsIcon />
-        </WithStyles(ForwardRef(ListItemIcon))>
-        <WithStyles(ForwardRef(ListItemText))
-          primary="manage-cookies-button"
-        />
-      </WithStyles(ForwardRef(MenuItem))>
-      <WithStyles(ForwardRef(MenuItem))
-        id="item-dark-mode"
-        onClick={[Function]}
-      >
-        <WithStyles(ForwardRef(ListItemIcon))>
-          <Brightness4Icon />
-        </WithStyles(ForwardRef(ListItemIcon))>
-        <WithStyles(ForwardRef(ListItemText))
-          primary="toggle-dark-mode"
-        />
-      </WithStyles(ForwardRef(MenuItem))>
       <WithStyles(ForwardRef(Divider)) />
       <WithStyles(ForwardRef(MenuItem))
         id="item-sign-out"

--- a/src/mainAppBar/mainAppBar.component.test.tsx
+++ b/src/mainAppBar/mainAppBar.component.test.tsx
@@ -11,6 +11,7 @@ import TestAuthProvider from '../authentication/testAuthProvider';
 import { buildTheme } from '../theming';
 import { MuiThemeProvider } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
+import { loadDarkModePreference } from '../state/actions/scigateway.actions';
 
 describe('Main app bar component', () => {
   let shallow;
@@ -97,5 +98,64 @@ describe('Main app bar component', () => {
 
     expect(testStore.getActions().length).toEqual(1);
     expect(testStore.getActions()[0]).toEqual(toggleHelp());
+  });
+
+  it('opens settings when button clicked', () => {
+    const testStore = mockStore(state);
+    const wrapper = mount(
+      <MuiThemeProvider theme={theme}>
+        <Provider store={testStore}>
+          <MainAppBarComponent />
+        </Provider>
+      </MuiThemeProvider>
+    );
+
+    expect(wrapper.find('#settings').first().prop('open')).toBeFalsy();
+
+    wrapper
+      .find('button[aria-label="Open browser settings"]')
+      .simulate('click');
+
+    expect(wrapper.find('#settings').first().prop('open')).toBeTruthy();
+  });
+
+  it('opens cookie policy/management page if manage cookies clicked', () => {
+    const testStore = mockStore(state);
+    const wrapper = mount(
+      <MuiThemeProvider theme={theme}>
+        <Provider store={testStore}>
+          <MainAppBarComponent />
+        </Provider>
+      </MuiThemeProvider>
+    );
+
+    // Click the user menu button and click on the manage cookies menu item.
+    wrapper
+      .find('button[aria-label="Open browser settings"]')
+      .simulate('click');
+    wrapper.find('#item-manage-cookies').first().simulate('click');
+
+    expect(testStore.getActions().length).toEqual(1);
+    expect(testStore.getActions()[0]).toEqual(push('/cookies'));
+  });
+
+  it('sends load dark mode prefrence action if toggle dark mode is clicked', () => {
+    const testStore = mockStore(state);
+    const wrapper = mount(
+      <MuiThemeProvider theme={theme}>
+        <Provider store={testStore}>
+          <MainAppBarComponent />
+        </Provider>
+      </MuiThemeProvider>
+    );
+
+    // Click the user menu button and click on the manage cookies menu item.
+    wrapper
+      .find('button[aria-label="Open browser settings"]')
+      .simulate('click');
+    wrapper.find('#item-dark-mode').first().simulate('click');
+
+    expect(testStore.getActions().length).toEqual(1);
+    expect(testStore.getActions()[0]).toEqual(loadDarkModePreference(true));
   });
 });

--- a/src/mainAppBar/mainAppBar.component.tsx
+++ b/src/mainAppBar/mainAppBar.component.tsx
@@ -170,7 +170,7 @@ const MainAppBar = (props: CombinedMainAppBarProps): React.ReactElement => {
             <HelpIcon />
           </IconButton>
           <IconButton
-            className={props.classes.button}
+            className={classNames(props.classes.button, 'tour-settings')}
             onClick={(e) => setMenuAnchor(e.currentTarget)}
             aria-label="Open browser settings"
           >

--- a/src/mainAppBar/mainAppBar.component.tsx
+++ b/src/mainAppBar/mainAppBar.component.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Dispatch, Action } from 'redux';
 import { connect } from 'react-redux';
 import AppBar from '@material-ui/core/AppBar';
@@ -8,6 +8,10 @@ import Button from '@material-ui/core/Button';
 import IconButton from '@material-ui/core/IconButton';
 import HelpIcon from '@material-ui/icons/HelpOutline';
 import MenuIcon from '@material-ui/icons/Menu';
+import BrightnessIcon from '@material-ui/icons/Brightness4';
+import TuneIcon from '@material-ui/icons/Tune';
+import SettingsIcon from '@material-ui/icons/Settings';
+import { Menu, MenuItem, ListItemIcon, ListItemText } from '@material-ui/core';
 import {
   withStyles,
   createStyles,
@@ -16,7 +20,11 @@ import {
   WithStyles,
 } from '@material-ui/core/styles';
 import classNames from 'classnames';
-import { toggleDrawer, toggleHelp } from '../state/actions/scigateway.actions';
+import {
+  toggleDrawer,
+  toggleHelp,
+  loadDarkModePreference,
+} from '../state/actions/scigateway.actions';
 import { AppStrings } from '../state/scigateway.types';
 import { StateType } from '../state/state.types';
 import { push } from 'connected-react-router';
@@ -30,12 +38,15 @@ interface MainAppProps {
   res: AppStrings | undefined;
   showContactButton: boolean;
   loggedIn: boolean;
+  darkMode: boolean;
 }
 
 interface MainAppDispatchProps {
   toggleDrawer: () => Action;
   navigateToHome: () => Action;
   toggleHelp: () => Action;
+  manageCookies: () => Action;
+  toggleDarkMode: (preference: boolean) => Action;
 }
 
 const styles = (theme: Theme): StyleRules =>
@@ -92,78 +103,125 @@ type CombinedMainAppBarProps = MainAppProps &
   MainAppDispatchProps &
   WithStyles<typeof styles>;
 
-const MainAppBar = (props: CombinedMainAppBarProps): React.ReactElement => (
-  <div className={props.classes.root}>
-    <AppBar
-      position="static"
-      className={classNames(props.classes.appBar, {
-        [props.classes.appBarShift]: props.drawerOpen,
-      })}
-    >
-      <Toolbar>
-        {props.loggedIn ? (
-          <IconButton
-            className={classNames(
-              props.classes.menuButton,
-              props.drawerOpen && props.classes.hide,
-              'tour-nav-menu'
-            )}
+const MainAppBar = (props: CombinedMainAppBarProps): React.ReactElement => {
+  const [getMenuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
+  const closeMenu = (): void => setMenuAnchor(null);
+  const manageCookies = (): void => {
+    closeMenu();
+    props.manageCookies();
+  };
+  const toggleDarkMode = (): void => {
+    const toggledPreference = !props.darkMode;
+    localStorage.setItem('darkMode', toggledPreference.toString());
+    props.toggleDarkMode(toggledPreference);
+  };
+  return (
+    <div className={props.classes.root}>
+      <AppBar
+        position="static"
+        className={classNames(props.classes.appBar, {
+          [props.classes.appBarShift]: props.drawerOpen,
+        })}
+      >
+        <Toolbar>
+          {props.loggedIn ? (
+            <IconButton
+              className={classNames(
+                props.classes.menuButton,
+                props.drawerOpen && props.classes.hide,
+                'tour-nav-menu'
+              )}
+              color="inherit"
+              onClick={props.toggleDrawer}
+              aria-label="Open navigation menu"
+            >
+              <MenuIcon />
+            </IconButton>
+          ) : (
+            <div className={props.classes.menuButtonPlaceholder} />
+          )}
+          <Typography
+            className={classNames(props.classes.title, 'tour-title')}
+            variant="h6"
             color="inherit"
-            onClick={props.toggleDrawer}
-            aria-label="Open navigation menu"
+            noWrap
+            onClick={props.navigateToHome}
+            aria-label="Homepage"
           >
-            <MenuIcon />
+            {getString(props.res, 'title')}
+          </Typography>
+          {props.showContactButton ? (
+            <Button
+              className={classNames(props.classes.button, 'tour-contact')}
+              style={{ paddingTop: 3 }}
+              aria-label="Contact"
+            >
+              <Typography color="inherit" noWrap style={{ marginTop: 3 }}>
+                {getString(props.res, 'contact')}
+              </Typography>
+            </Button>
+          ) : null}
+          <div className={props.classes.grow} />
+          <IconButton
+            className={props.classes.button}
+            onClick={props.toggleHelp}
+            aria-label="Help"
+          >
+            <HelpIcon />
           </IconButton>
-        ) : (
-          <div className={props.classes.menuButtonPlaceholder} />
-        )}
-        <Typography
-          className={classNames(props.classes.title, 'tour-title')}
-          variant="h6"
-          color="inherit"
-          noWrap
-          onClick={props.navigateToHome}
-          aria-label="Homepage"
-        >
-          {getString(props.res, 'title')}
-        </Typography>
-        {props.showContactButton ? (
-          <Button
-            className={classNames(props.classes.button, 'tour-contact')}
-            style={{ paddingTop: 3 }}
-            aria-label="Contact"
+          {props.loggedIn ? <NotificationBadgeComponent /> : null}
+          <UserProfileComponent />
+          <IconButton
+            className={props.classes.button}
+            onClick={(e) => setMenuAnchor(e.currentTarget)}
+            aria-label="Open browser settings"
           >
-            <Typography color="inherit" noWrap style={{ marginTop: 3 }}>
-              {getString(props.res, 'contact')}
-            </Typography>
-          </Button>
-        ) : null}
-        <div className={props.classes.grow} />
-        <IconButton
-          className={props.classes.button}
-          onClick={props.toggleHelp}
-          aria-label="Help"
-        >
-          <HelpIcon />
-        </IconButton>
-        {props.loggedIn ? <NotificationBadgeComponent /> : null}
-        <UserProfileComponent />
-      </Toolbar>
-    </AppBar>
-  </div>
-);
+            <SettingsIcon />
+          </IconButton>
+          <Menu
+            id="settings"
+            anchorEl={getMenuAnchor}
+            open={getMenuAnchor !== null}
+            onClose={closeMenu}
+          >
+            <MenuItem id="item-manage-cookies" onClick={manageCookies}>
+              <ListItemIcon>
+                <TuneIcon />
+              </ListItemIcon>
+              <ListItemText
+                primary={getString(props.res, 'manage-cookies-button')}
+              />
+            </MenuItem>
+            <MenuItem id="item-dark-mode" onClick={toggleDarkMode}>
+              <ListItemIcon>
+                <BrightnessIcon />
+              </ListItemIcon>
+              <ListItemText
+                primary={getString(props.res, 'toggle-dark-mode')}
+              />
+            </MenuItem>
+          </Menu>
+        </Toolbar>
+      </AppBar>
+    </div>
+  );
+};
 
 const mapStateToProps = (state: StateType): MainAppProps => ({
   drawerOpen: state.scigateway.drawerOpen,
   showContactButton: state.scigateway.features.showContactButton,
   loggedIn: state.scigateway.authorisation.provider.isLoggedIn(),
   res: getAppStrings(state, 'main-appbar'),
+  darkMode: state.scigateway.darkMode,
 });
 
 const mapDispatchToProps = (dispatch: Dispatch): MainAppDispatchProps => ({
   toggleDrawer: () => dispatch(toggleDrawer()),
   navigateToHome: () => dispatch(push('/')),
   toggleHelp: () => dispatch(toggleHelp()),
+  manageCookies: () => dispatch(push('/cookies')),
+  toggleDarkMode: (preference: boolean) =>
+    dispatch(loadDarkModePreference(preference)),
 });
 
 export const MainAppBarWithStyles = withStyles(styles)(MainAppBar);

--- a/src/mainAppBar/mainAppBar.component.tsx
+++ b/src/mainAppBar/mainAppBar.component.tsx
@@ -169,8 +169,6 @@ const MainAppBar = (props: CombinedMainAppBarProps): React.ReactElement => {
           >
             <HelpIcon />
           </IconButton>
-          {props.loggedIn ? <NotificationBadgeComponent /> : null}
-          <UserProfileComponent />
           <IconButton
             className={props.classes.button}
             onClick={(e) => setMenuAnchor(e.currentTarget)}
@@ -201,6 +199,8 @@ const MainAppBar = (props: CombinedMainAppBarProps): React.ReactElement => {
               />
             </MenuItem>
           </Menu>
+          {props.loggedIn ? <NotificationBadgeComponent /> : null}
+          <UserProfileComponent />
         </Toolbar>
       </AppBar>
     </div>

--- a/src/mainAppBar/userProfile.component.test.tsx
+++ b/src/mainAppBar/userProfile.component.test.tsx
@@ -9,7 +9,6 @@ import { push } from 'connected-react-router';
 import { Avatar } from '@material-ui/core';
 import thunk from 'redux-thunk';
 import TestAuthProvider from '../authentication/testAuthProvider';
-import { loadDarkModePreference } from '../state/actions/scigateway.actions';
 
 describe('User profile component', () => {
   let shallow;
@@ -95,22 +94,6 @@ describe('User profile component', () => {
     expect(wrapper.find('#simple-menu').first().prop('open')).toBeTruthy();
   });
 
-  it('opens cookie policy/management page if manage cookies clicked', () => {
-    const testStore = mockStore(state);
-    const wrapper = mount(
-      <Provider store={testStore}>
-        <UserProfileComponent />
-      </Provider>
-    );
-
-    // Click the user menu button and click on the manage cookies menu item.
-    wrapper.find('button').simulate('click');
-    wrapper.find('#item-manage-cookies').first().simulate('click');
-
-    expect(testStore.getActions().length).toEqual(1);
-    expect(testStore.getActions()[0]).toEqual(push('/cookies'));
-  });
-
   it('signs out if sign out clicked', () => {
     const testStore = mockStore(state);
     const wrapper = mount(
@@ -126,21 +109,5 @@ describe('User profile component', () => {
     expect(testStore.getActions().length).toEqual(2);
     expect(testStore.getActions()[0]).toEqual({ type: 'scigateway:signout' });
     expect(testStore.getActions()[1]).toEqual(push('/'));
-  });
-
-  it('sends load dark mode prefrence action if toggle dark mode is clicked', () => {
-    const testStore = mockStore(state);
-    const wrapper = mount(
-      <Provider store={testStore}>
-        <UserProfileComponent />
-      </Provider>
-    );
-
-    // Click the user menu button and click on the manage cookies menu item.
-    wrapper.find('button').simulate('click');
-    wrapper.find('#item-dark-mode').first().simulate('click');
-
-    expect(testStore.getActions().length).toEqual(1);
-    expect(testStore.getActions()[0]).toEqual(loadDarkModePreference(true));
   });
 });

--- a/src/mainAppBar/userProfile.component.tsx
+++ b/src/mainAppBar/userProfile.component.tsx
@@ -1,9 +1,7 @@
 import React, { useState } from 'react';
 import { Dispatch, Action, AnyAction } from 'redux';
 import AccountCircleIcon from '@material-ui/icons/AccountCircle';
-import SettingsIcon from '@material-ui/icons/Settings';
 import LogoutIcon from '@material-ui/icons/ExitToApp';
-import BrightnessIcon from '@material-ui/icons/Brightness4';
 import {
   IconButton,
   withStyles,
@@ -22,10 +20,7 @@ import {
 import { StyleRules } from '@material-ui/core/styles';
 import { StateType, User } from '../state/state.types';
 import { getAppStrings, getString } from '../state/strings';
-import {
-  signOut,
-  loadDarkModePreference,
-} from '../state/actions/scigateway.actions';
+import { signOut } from '../state/actions/scigateway.actions';
 import { connect } from 'react-redux';
 import { AppStrings } from '../state/scigateway.types';
 import { ThunkDispatch } from 'redux-thunk';
@@ -37,14 +32,11 @@ interface UserProfileProps {
   loggedIn: boolean;
   user: User;
   res: AppStrings | undefined;
-  darkMode: boolean;
 }
 
 interface UserProfileDispatchProps {
   signIn: () => Action;
   signOut: () => void;
-  manageCookies: () => Action;
-  toggleDarkMode: (preference: boolean) => Action;
 }
 
 const styles = (theme: Theme): StyleRules =>
@@ -83,15 +75,6 @@ const UserProfileComponent = (
     closeMenu();
     props.signOut();
   };
-  const manageCookies = (): void => {
-    closeMenu();
-    props.manageCookies();
-  };
-  const toggleDarkMode = (): void => {
-    const toggledPreference = !props.darkMode;
-    localStorage.setItem('darkMode', toggledPreference.toString());
-    props.toggleDarkMode(toggledPreference);
-  };
   return (
     <div className="tour-user-profile">
       {props.loggedIn ? (
@@ -125,23 +108,6 @@ const UserProfileComponent = (
                 {props.user.username}
               </Typography>
             </div>
-            <Divider />
-            <MenuItem id="item-manage-cookies" onClick={manageCookies}>
-              <ListItemIcon>
-                <SettingsIcon />
-              </ListItemIcon>
-              <ListItemText
-                primary={getString(props.res, 'manage-cookies-button')}
-              />
-            </MenuItem>
-            <MenuItem id="item-dark-mode" onClick={toggleDarkMode}>
-              <ListItemIcon>
-                <BrightnessIcon />
-              </ListItemIcon>
-              <ListItemText
-                primary={getString(props.res, 'toggle-dark-mode')}
-              />
-            </MenuItem>
             <Divider />
             <MenuItem id="item-sign-out" onClick={logout}>
               <ListItemIcon>
@@ -182,7 +148,6 @@ const mapStateToProps = (state: StateType): UserProfileProps => ({
   user:
     state.scigateway.authorisation.provider.user || new UserInfo('anonymous'),
   res: getAppStrings(state, 'login'),
-  darkMode: state.scigateway.darkMode,
 });
 
 const mapDispatchToProps = (dispatch: Dispatch): UserProfileDispatchProps => ({
@@ -191,9 +156,6 @@ const mapDispatchToProps = (dispatch: Dispatch): UserProfileDispatchProps => ({
     const thunkDispatch = dispatch as ThunkDispatch<StateType, null, AnyAction>;
     thunkDispatch(signOut());
   },
-  manageCookies: () => dispatch(push('/cookies')),
-  toggleDarkMode: (preference: boolean) =>
-    dispatch(loadDarkModePreference(preference)),
 });
 
 export default connect(


### PR DESCRIPTION
## Description
Moved the options for darkmode and cookies to a seperate menu outside of the user/account menu so they can be accessed without logging in.

EDIT:
In light of ral-facilities/datagateway#430 have added the settings button to the tour/help.

## Testing instructions
- [ ] Review code
- [ ] Check Travis build
- [ ] Review changes to test coverage
- [ ] Check dark mode and cookies options can be accessed while logged out
- [ ] Check dark mode and cookies options can be accessed while logged in

EDIT:
- [ ] Check settings icon is included in the tour when using the updated `settings.json`

## Agile board tracking
connect to #426