### PR TITLE
override MuiBadge style for colorPrimary #440

### DIFF
--- a/src/notifications/__snapshots__/notificationBadge.component.test.tsx.snap
+++ b/src/notifications/__snapshots__/notificationBadge.component.test.tsx.snap
@@ -11,11 +11,6 @@ exports[`Notification Badge component Notification badge renders correctly 1`] =
   >
     <WithStyles(ForwardRef(Badge))
       badgeContent={1}
-      classes={
-        Object {
-          "colorPrimary": "badge-class",
-        }
-      }
       color="primary"
     >
       <NotificationsIcon />

--- a/src/notifications/notificationBadge.component.tsx
+++ b/src/notifications/notificationBadge.component.tsx
@@ -11,7 +11,6 @@ import {
   createStyles,
 } from '@material-ui/core';
 import { StyleRules } from '@material-ui/core/styles';
-import { UKRITheme } from '../theming';
 import { StateType, ScigatewayNotification } from '../state/state.types';
 import { Dispatch, Action } from 'redux';
 import { dismissMenuItem } from '../state/actions/scigateway.actions';
@@ -29,9 +28,6 @@ const styles = (theme: Theme): StyleRules =>
   createStyles({
     button: {
       color: theme.palette.primary.contrastText,
-    },
-    badge: {
-      background: (theme as UKRITheme).ukri.bright.orange,
     },
     menuItem: {
       display: 'flex',
@@ -76,7 +72,7 @@ const NotificationBadge = (
     <div className="tour-notifications">
       <IconButton
         className={props.classes.button}
-        onClick={e => setMenuAnchor(e.currentTarget)}
+        onClick={(e) => setMenuAnchor(e.currentTarget)}
         aria-label="Open notification menu"
       >
         <Badge
@@ -84,9 +80,6 @@ const NotificationBadge = (
             props.notifications.length > 0 ? props.notifications.length : null
           }
           color="primary"
-          classes={{
-            colorPrimary: props.classes.badge,
-          }}
         >
           <NotificationsIcon />
         </Badge>

--- a/src/theming.tsx
+++ b/src/theming.tsx
@@ -97,6 +97,11 @@ export const buildTheme = (darkModePreference: boolean): Theme => {
             textDecoration: 'underline',
           },
         },
+        MuiBadge: {
+          colorPrimary: {
+            backgroundColor: '#FF6900',
+          },
+        },
       },
     };
   } else {
@@ -130,6 +135,13 @@ export const buildTheme = (darkModePreference: boolean): Theme => {
         },
       },
       drawerWidth: 300,
+      overrides: {
+        MuiBadge: {
+          colorPrimary: {
+            backgroundColor: '#FF6900',
+          },
+        },
+      },
     };
   }
 


### PR DESCRIPTION
## Description
Added an override to MuiBadge theming that replaces how the notification badge was currently being coloured and allows DG badges to use the same colour.

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Travis build
- [ ] Review changes to test coverage
- [ ] Check SG notification badge is unaffected in LM/DM
- [ ] Badge(s) should also be checked in DG, but this is dependent on code from in progress PRs (see below)

## Agile board tracking
connect to #440, ral-facilities/datagateway#415, ral-facilities/datagateway#419