### PR TITLE
allow optional redirect to plugin from homepage #427

### DIFF
--- a/src/routing/__snapshots__/authorisedRoute.component.test.tsx.snap
+++ b/src/routing/__snapshots__/authorisedRoute.component.test.tsx.snap
@@ -23,6 +23,19 @@ exports[`AuthorisedRoute component renders nothing when site is loading due to l
 
 exports[`AuthorisedRoute component renders nothing when site is loading due to siteLoading prop 1`] = `<div />`;
 
+exports[`AuthorisedRoute component renders redirect when startUrl is configured and logged in 1`] = `
+<div>
+  <Redirect
+    push={true}
+    to={
+      Object {
+        "pathname": "/test",
+      }
+    }
+  />
+</div>
+`;
+
 exports[`AuthorisedRoute component renders redirect when user not logged in 1`] = `
 <div>
   <Redirect

--- a/src/routing/authorisedRoute.component.test.tsx
+++ b/src/routing/authorisedRoute.component.test.tsx
@@ -44,6 +44,20 @@ describe('AuthorisedRoute component', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
+  it('renders redirect when startUrl is configured and logged in', () => {
+    state.scigateway.siteLoading = false;
+    state.scigateway.authorisation.loading = false;
+    state.scigateway.authorisation.provider = new TestAuthProvider(
+      'test-token'
+    );
+    state.router.location.state = { scigateway: { startUrl: '/test' } };
+
+    const AuthorisedComponent = withAuth(ComponentToProtect);
+    const wrapper = shallow(<AuthorisedComponent store={mockStore(state)} />);
+
+    expect(wrapper).toMatchSnapshot();
+  });
+
   it('renders redirect when user not logged in', () => {
     state.scigateway.siteLoading = false;
     state.scigateway.authorisation.loading = false;

--- a/src/routing/authorisedRoute.component.tsx
+++ b/src/routing/authorisedRoute.component.tsx
@@ -10,6 +10,7 @@ interface WithAuthStateProps {
   loading: boolean;
   loggedIn: boolean;
   location: string;
+  startUrlState?: StateType;
 }
 
 interface WithAuthDispatchProps {
@@ -27,6 +28,7 @@ const mapStateToProps = (state: StateType): WithAuthStateProps => ({
     isStartingUpOrLoading(state.scigateway.authorisation),
   loggedIn: state.scigateway.authorisation.provider.isLoggedIn(),
   location: state.router.location.pathname,
+  startUrlState: state.router.location.state,
 });
 
 const mapDispatchToProps = (dispatch: Dispatch): WithAuthDispatchProps => ({
@@ -43,6 +45,7 @@ export default function withAuth<T>(
         loading,
         loggedIn,
         location,
+        startUrlState,
         requestPluginRerender,
         ...componentProps
       } = this.props;
@@ -57,8 +60,16 @@ export default function withAuth<T>(
               }}
             />
           ) : null}
+          {/* If using a plugin as the start page, redirect here so the plugin renders with the redirected url */}
           {!loading && loggedIn ? (
-            <ComponentToProtect {...(componentProps as T)} />
+            startUrlState && startUrlState.scigateway.startUrl ? (
+              <Redirect
+                push
+                to={{ pathname: startUrlState.scigateway.startUrl }}
+              />
+            ) : (
+              <ComponentToProtect {...(componentProps as T)} />
+            )
           ) : null}
         </div>
       );

--- a/src/state/actions/scigateway.actions.test.tsx
+++ b/src/state/actions/scigateway.actions.test.tsx
@@ -17,6 +17,7 @@ import {
   invalidToken,
   loadedAuthentication,
   loadDarkModePreference,
+  registerStartUrl,
 } from './scigateway.actions';
 import {
   ToggleDrawerType,
@@ -192,6 +193,25 @@ describe('scigateway actions', () => {
     expect(actions[2]).toEqual(
       loadFeatureSwitches({ showContactButton: true })
     );
+  });
+
+  it('given a startUrl registration is run', async () => {
+    (mockAxios.get as jest.Mock).mockImplementation(() =>
+      Promise.resolve({
+        data: {
+          startUrl: '/test',
+        },
+      })
+    );
+
+    const asyncAction = configureSite();
+    const actions: Action[] = [];
+    const dispatch = (action: Action): number => actions.push(action);
+    const getState = (): Partial<StateType> => ({ scigateway: initialState });
+
+    await asyncAction(dispatch, getState);
+
+    expect(actions[3]).toEqual(registerStartUrl('/test'));
   });
 
   it('given a ga-tracking-id configureAnalytics is run', async () => {

--- a/src/state/actions/scigateway.actions.tsx
+++ b/src/state/actions/scigateway.actions.tsx
@@ -32,6 +32,8 @@ import {
   SendThemeOptionsPayload,
   LoadDarkModePreferenceType,
   LoadDarkModePreferencePayload,
+  StartUrlPayload,
+  RegisterStartUrlType,
 } from '../scigateway.types';
 import { ActionType, ThunkResult, StateType } from '../state.types';
 import loadMicroFrontends from './loadMicroFrontends';
@@ -68,6 +70,15 @@ export const loadFeatureSwitches = (
   type: ConfigureFeatureSwitchesType,
   payload: {
     switches: featureSwitches,
+  },
+});
+
+export const registerStartUrl = (
+  startUrl: string
+): ActionType<StartUrlPayload> => ({
+  type: RegisterStartUrlType,
+  payload: {
+    startUrl: startUrl,
   },
 });
 
@@ -213,6 +224,10 @@ export const configureSite = (): ThunkResult<Promise<void>> => {
         }
 
         dispatch(addHelpTourSteps(settings['help-tour-steps']));
+
+        if (settings['startUrl']) {
+          dispatch(registerStartUrl(settings['startUrl']));
+        }
 
         const uiStringResourcesPath = !settings['ui-strings'].startsWith('/')
           ? '/' + settings['ui-strings']

--- a/src/state/middleware/scigateway.middleware.test.tsx
+++ b/src/state/middleware/scigateway.middleware.test.tsx
@@ -317,6 +317,41 @@ describe('scigateway middleware', () => {
     );
   });
 
+  it('should listen for events and fire registerroute action and redirect to startUrl', () => {
+    const getState: () => StateType = () => ({
+      scigateway: { ...initialState, startUrl: '/plugin1/analysis2' },
+      router: {
+        action: 'POP',
+        location: createLocation('/'),
+      },
+    });
+
+    listenToPlugins(store.dispatch, getState);
+
+    handler(
+      new CustomEvent('test', {
+        detail: registerRouteAction,
+      })
+    );
+
+    expect(document.addEventListener).toHaveBeenCalled();
+    expect(store.getActions().length).toEqual(3);
+    expect(store.getActions()[0]).toEqual(registerRouteAction);
+    expect(store.getActions()[1]).toEqual({
+      type: '@@router/CALL_HISTORY_METHOD',
+      payload: {
+        method: 'push',
+        args: [
+          '/plugin1/analysis2',
+          { scigateway: { startUrl: '/plugin1/analysis2' } },
+        ],
+      },
+    });
+    expect(JSON.stringify(store.getActions()[2])).toEqual(
+      JSON.stringify(sendThemeOptionsAction)
+    );
+  });
+
   describe('notifications', () => {
     it('should listen for notification events and fire notification action even if no severity', () => {
       listenToPlugins(store.dispatch, getState);

--- a/src/state/middleware/scigateway.middleware.tsx
+++ b/src/state/middleware/scigateway.middleware.tsx
@@ -18,6 +18,7 @@ import {
 import ReactGA from 'react-ga';
 import { StateType } from '../state.types';
 import { buildTheme } from '../../theming';
+import { push } from 'connected-react-router';
 
 const trackPage = (page: string): void => {
   ReactGA.set({
@@ -87,6 +88,18 @@ export const listenToPlugins = (
                   content: pluginMessage.detail.payload.helpText,
                 },
               ])
+            );
+          }
+
+          // Redirect to optional startUrl if set and current url is the normal homepage '/'
+          if (
+            getState().router.location.pathname === '/' &&
+            getState().scigateway.startUrl === pluginMessage.detail.payload.link
+          ) {
+            dispatch(
+              push(pluginMessage.detail.payload.link, {
+                scigateway: { startUrl: pluginMessage.detail.payload.link },
+              })
             );
           }
 

--- a/src/state/reducers/scigateway.reducer.test.tsx
+++ b/src/state/reducers/scigateway.reducer.test.tsx
@@ -16,6 +16,7 @@ import {
   invalidToken,
   loadedAuthentication,
   loadDarkModePreference,
+  registerStartUrl,
 } from '../actions/scigateway.actions';
 import ScigatewayReducer, {
   initialState,
@@ -281,6 +282,14 @@ describe('scigateway reducer', () => {
     );
 
     expect(updatedState.features.showContactButton).toBeFalsy();
+  });
+
+  it('should register the startUrl when provided', () => {
+    expect(state.startUrl).toBeFalsy();
+
+    const updatedState = ScigatewayReducer(state, registerStartUrl('/test'));
+
+    expect(updatedState.startUrl).toEqual('/test');
   });
 
   it('dismissNotification should remove the referenced notification from the notifications list in State', () => {

--- a/src/state/reducers/scigateway.reducer.tsx
+++ b/src/state/reducers/scigateway.reducer.tsx
@@ -29,6 +29,8 @@ import {
   LoadedAuthType,
   LoadDarkModePreferenceType,
   LoadDarkModePreferencePayload,
+  StartUrlPayload,
+  RegisterStartUrlType,
 } from '../scigateway.types';
 import { ScigatewayState, AuthState } from '../state.types';
 import { buildPluginConfig } from '../pluginhelper';
@@ -199,6 +201,16 @@ export function handleConfigureFeatureSwitches(
   };
 }
 
+export function handleRegisterStartUrl(
+  state: ScigatewayState,
+  payload: StartUrlPayload
+): ScigatewayState {
+  return {
+    ...state,
+    startUrl: payload.startUrl,
+  };
+}
+
 export function handleDismissNotification(
   state: ScigatewayState,
   payload: { index: number }
@@ -360,6 +372,7 @@ const ScigatewayReducer = createReducer(initialState, {
   [ToggleHelpType]: handleToggleHelp,
   [AddHelpTourStepsType]: handleAddHelpTourSteps,
   [LoadDarkModePreferenceType]: handleLoadDarkModePreference,
+  [RegisterStartUrlType]: handleRegisterStartUrl,
 });
 
 export default ScigatewayReducer;

--- a/src/state/scigateway.types.tsx
+++ b/src/state/scigateway.types.tsx
@@ -25,6 +25,7 @@ export const ConfigureAnalyticsType = 'scigateway:configure_analytics';
 export const InitialiseAnalyticsType = 'scigateway:initialise_analytics';
 export const ToggleHelpType = 'scigateway:toggle_help';
 export const AddHelpTourStepsType = 'scigateway:add_help_tour_steps';
+export const RegisterStartUrlType = 'scigateway:register_start_url';
 
 export interface NotificationPayload {
   message: string;
@@ -53,6 +54,10 @@ export interface FeatureSwitchesPayload {
 
 export interface FeatureSwitches {
   showContactButton: boolean;
+}
+
+export interface StartUrlPayload {
+  startUrl: string;
 }
 
 export interface RegisterRoutePayload {

--- a/src/state/state.types.tsx
+++ b/src/state/state.types.tsx
@@ -32,6 +32,7 @@ export interface ScigatewayState {
   features: FeatureSwitches;
   analytics?: AnalyticsState;
   darkMode: boolean;
+  startUrl?: string;
 }
 
 export interface StateType {


### PR DESCRIPTION
## Description
Added `startUrl` to `settings.json` as an optional setting. When provided, if one of the plugins has the same `link` as `startUrl`, and the current path is the homepage (`/`), then a redirect to the plugin will be triggered.

If the user needs to login, the referring path will be the plugin link, so after the login redirect the plugin will be loaded.

If the user is already logged in, then a redirect is needed to ensure the plugin renders the updated path (and not what it would show for a path of `/`. This happens at the same place as the login redirect (if the `startUrl` is enabled).

If `startUrl` is not set, or no plugin matches the url, then nothing should happen (previous behaviour maintained).

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [x] Review code
- [x] Check Travis build
- [x] Review changes to test coverage
- [x] Check that navigating to the homepage without a startUrl specified has no change
- [x] Check that when navigating to the homepage with the startUrl and corresponding plugin enabled, you are redirected to the plugin
- [x] Check that clicking the home (SciGateway) button does not trigger a redirect and still allows access to the normal homepage
- [x] Check that navigating to a specific page (e.g. `/cookies` doesn't trigger a redirect)

## Agile board tracking
connect to #427, ral-facilities/datagateway#431