### PR TITLE
Add footer to display external links at bottom of pages

### DIFF
--- a/public/res/default.json
+++ b/public/res/default.json
@@ -46,5 +46,8 @@
     "link-text": "Learn more",
     "accept-button": "Accept",
     "manage-preferences-button": "Manage Preferences"
+  },
+  "footer": {
+    "html": "<a href=\"#\">Facility Name</a> | <a href=\"#\">Privacy Policy</a> | <a href=\"#\">About Us</a>"
   }
 }

--- a/src/__snapshots__/pageContainer.test.tsx.snap
+++ b/src/__snapshots__/pageContainer.test.tsx.snap
@@ -10,5 +10,6 @@ exports[`PageContainer - Tests renders correctly 1`] = `
   <Connect(WithTheme(Tour)) />
   <Connect(WithStyles(CookieConsent)) />
   <Connect(WithStyles(Routing)) />
+  <Connect(WithStyles(Footer)) />
 </div>
 `;

--- a/src/footer/__snapshots__/footer.component.test.tsx.snap
+++ b/src/footer/__snapshots__/footer.component.test.tsx.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Footer component footer renders correctly 1`] = `
+<div
+  className="root-class"
+  dangerouslySetInnerHTML={
+    Object {
+      "__html": "html",
+    }
+  }
+/>
+`;

--- a/src/footer/footer.component.test.tsx
+++ b/src/footer/footer.component.test.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { createMount, createShallow } from '@material-ui/core/test-utils';
+import { FooterWithoutStyles, CombinedFooterProps } from './footer.component';
+
+describe('Footer component', () => {
+  let shallow;
+  let mount;
+  let props: CombinedFooterProps;
+
+  beforeEach(() => {
+    shallow = createShallow({ untilSelector: 'div' });
+    mount = createMount();
+
+    props = {
+      res: undefined,
+      classes: {
+        root: 'root-class',
+      },
+    };
+  });
+
+  afterEach(() => {
+    mount.cleanUp();
+  });
+
+  it('footer renders correctly', () => {
+    const wrapper = shallow(<FooterWithoutStyles {...props} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/src/footer/footer.component.tsx
+++ b/src/footer/footer.component.tsx
@@ -21,6 +21,17 @@ const styles = (theme: Theme): StyleRules =>
       fontSize: 14,
       textAlign: 'center',
       backgroundColor: theme.palette.background.default,
+      '& a': {
+        '&:link': {
+          color: '#1E5DF8',
+        },
+        '&:visited': {
+          color: '#BE2BBB',
+        },
+        '&:active': {
+          color: '#E94D36',
+        },
+      },
     },
   });
 

--- a/src/footer/footer.component.tsx
+++ b/src/footer/footer.component.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import Typography from '@material-ui/core/Typography';
+import {
+  createStyles,
+  StyleRules,
+  Theme,
+  withStyles,
+  WithStyles,
+} from '@material-ui/core/styles';
+import { getAppStrings, getString } from '../state/strings';
+import { connect } from 'react-redux';
+import { StateType } from '../state/state.types';
+import { AppStrings } from '../state/scigateway.types';
+
+const styles = (theme: Theme): StyleRules =>
+  createStyles({
+    root: {
+      position: 'absolute',
+      bottom: 0,
+      width: '100%',
+      height: '60px',
+      textAlign: 'center',
+      backgroundColor: theme.palette.background.default,
+    },
+  });
+
+interface FooterProps {
+  res: AppStrings | undefined;
+}
+
+export type CombinedFooterProps = FooterProps & WithStyles<typeof styles>;
+
+const Footer = (props: CombinedFooterProps): React.ReactElement => {
+  return (
+    <div className={props.classes.root}>
+      <Typography
+        variant="body1"
+        dangerouslySetInnerHTML={{
+          __html: getString(props.res, 'html'),
+        }}
+      />
+    </div>
+  );
+};
+
+const mapStateToProps = (state: StateType): FooterProps => ({
+  res: getAppStrings(state, 'footer'),
+});
+
+export const FooterWithoutStyles = Footer;
+export const FooterWithStyles = withStyles(styles)(Footer);
+
+export default connect(mapStateToProps)(FooterWithStyles);

--- a/src/footer/footer.component.tsx
+++ b/src/footer/footer.component.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import Typography from '@material-ui/core/Typography';
 import {
   createStyles,
   StyleRules,
@@ -17,8 +16,9 @@ const styles = (theme: Theme): StyleRules =>
     root: {
       position: 'absolute',
       bottom: 0,
+      paddingBottom: '5px',
       width: '100%',
-      height: '60px',
+      fontSize: 14,
       textAlign: 'center',
       backgroundColor: theme.palette.background.default,
     },
@@ -32,14 +32,12 @@ export type CombinedFooterProps = FooterProps & WithStyles<typeof styles>;
 
 const Footer = (props: CombinedFooterProps): React.ReactElement => {
   return (
-    <div className={props.classes.root}>
-      <Typography
-        variant="body1"
-        dangerouslySetInnerHTML={{
-          __html: getString(props.res, 'html'),
-        }}
-      />
-    </div>
+    <div
+      className={props.classes.root}
+      dangerouslySetInnerHTML={{
+        __html: getString(props.res, 'html'),
+      }}
+    />
   );
 };
 

--- a/src/pageContainer.component.tsx
+++ b/src/pageContainer.component.tsx
@@ -11,9 +11,11 @@ import NavigationDrawer from './navigationDrawer/navigationDrawer.component';
 import Routing from './routing/routing.component';
 import Tour from './tour/tour.component';
 import CookieConsent from './cookieConsent/cookieConsent.component';
+import Footer from './footer/footer.component';
 
 const styles = (theme: Theme): StyleRules => ({
   root: {
+    position: 'relative',
     background: theme.palette.background.default,
     minHeight: '100vh',
   },
@@ -30,6 +32,7 @@ const PageContainer = (
       <Tour />
       <CookieConsent />
       <Routing />
+      <Footer />
     </div>
   );
 };

--- a/src/routing/routing.component.tsx
+++ b/src/routing/routing.component.tsx
@@ -21,7 +21,7 @@ import withAuth from './authorisedRoute.component';
 const styles = (theme: Theme): StyleRules =>
   createStyles({
     container: {
-      paddingBottom: '80px',
+      paddingBottom: '30px',
       width: '100%',
       transition: theme.transitions.create(['margin', 'width'], {
         easing: theme.transitions.easing.easeIn,

--- a/src/routing/routing.component.tsx
+++ b/src/routing/routing.component.tsx
@@ -21,6 +21,7 @@ import withAuth from './authorisedRoute.component';
 const styles = (theme: Theme): StyleRules =>
   createStyles({
     container: {
+      paddingBottom: '80px',
       width: '100%',
       transition: theme.transitions.create(['margin', 'width'], {
         easing: theme.transitions.easing.easeIn,
@@ -70,7 +71,7 @@ class Routing extends React.Component<
           <Route exact path="/" component={HomePage} />
           <Route exact path="/login" component={LoginPage} />
           <Route exact path="/cookies" component={CookiesPage} />
-          {this.props.plugins.map(p => (
+          {this.props.plugins.map((p) => (
             <Route
               key={`${p.section}_${p.link}`}
               path={p.link}


### PR DESCRIPTION
## Description
Adds a footer component that displays external links that direct the user to the facility home, cookie policy and about us pages. To allow facilities to configure these external links and their names, a raw HTML is stored in in the `default.json` file. I noticed that the link names change colour after they have been clicked (which is normal behaviour), so I just wanted to get people's view on whether we want to override this? It seems that is overridden in TopCAT and `text-decoration` is set to `none` to remove the lines under the link names. Given that there are some hyperlinks in the _Cookies_ page, it might better to globalise this if we want the same behaviour there.

The footer component is not tested as I wanted to check whether what I have done so far meets the requirements before writing any tests.

![image](https://user-images.githubusercontent.com/45173816/100331237-ced51300-2fc7-11eb-8714-1e2db3b5a922.png)

## Testing instructions
- [ ] Review code
- [ ] Check Travis build
- [ ] Review changes to test coverage
- [ ] Change the `html` value of `footer` inside `default.json` to 
```
<a href=\"http://www.diamond.ac.uk\">Diamond Light Source</a> | <a href=\"http://www.diamond.ac.uk/Legal.html\">Privacy Policy</a> | <a href=\"http://www.diamond.ac.uk/Home/About.html\">About Us</a>
``` 
or a raw HTML value of your own choice.
- [ ] Check that the external links are displayed at the bottom of the pages.
- [ ] Check that you are successfully redirected to the external web page when you click on an external link.
## Agile board tracking
connect to #479 