### PR TITLE
Trigger CI build workflow when a PR is merged into Master

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -1,5 +1,10 @@
 name: CI Build
-on: [pull_request]
+on: 
+  pull_request:
+  # By default, the pull_request event type is not triggered when a PR is merged into master
+  push:
+    branches:
+      - master
 
 jobs:
   test:


### PR DESCRIPTION
## Description
Triggers the CI build workflow when a PR is merged into master. It was noticed that that the CI build workflow builds only PRs and not branches. This means that master is not tested when something is merged and therefore the status badge does not work.

A merge into master results into a push commit to master, therefore the proposed changes should address this "issue".

## Testing instructions
- [ ] Review code
- [ ] Check Actions build
- [ ] CI build runs when a PR is merged into master - this can only be done once the PR is merged

## Agile board tracking
closes #525 