### PR TITLE
Prevent duplicate banners from displaying multiple times

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -62,6 +62,7 @@ const toastrConfig = (): React.ReactElement => (
     newestOnTop={false}
     closeOnToastrClick={true}
     position="top-center"
+    preventDuplicates
     transitionIn="fadeIn"
     transitionOut="fadeOut"
   />

--- a/src/state/reducers/scigateway.reducer.test.tsx
+++ b/src/state/reducers/scigateway.reducer.test.tsx
@@ -261,6 +261,24 @@ describe('scigateway reducer', () => {
     });
   });
 
+  it('dismissNotification should remove the referenced notification from the notifications list in State', () => {
+    const notificationsInState = {
+      notifications: [{ message: 'test notification', severity: 'success' }],
+    };
+    const action = {
+      type: 'scigateway:api:notification',
+      payload: { message: 'test notification', severity: 'success' },
+    };
+
+    const updatedState = ScigatewayReducer(notificationsInState, action);
+
+    expect(updatedState.notifications.length).toEqual(1);
+    expect(updatedState.notifications[0]).toEqual({
+      message: 'test notification',
+      severity: 'success',
+    });
+  });
+
   it('should set res property when configure strings action is sent', () => {
     expect(state).not.toHaveProperty('res');
 

--- a/src/state/reducers/scigateway.reducer.test.tsx
+++ b/src/state/reducers/scigateway.reducer.test.tsx
@@ -261,7 +261,7 @@ describe('scigateway reducer', () => {
     });
   });
 
-  it('dismissNotification should remove the referenced notification from the notifications list in State', () => {
+  it('should not update notification list when new notification is a duplicate', () => {
     const notificationsInState = {
       notifications: [{ message: 'test notification', severity: 'success' }],
     };

--- a/src/state/reducers/scigateway.reducer.tsx
+++ b/src/state/reducers/scigateway.reducer.tsx
@@ -67,6 +67,12 @@ export function handleNotification(
   state: ScigatewayState,
   payload: NotificationPayload
 ): ScigatewayState {
+  // Do not add the notification to state if a notification
+  // with the same message already exists.
+  if (state.notifications.some((n) => n.message === payload.message)) {
+    return state;
+  }
+
   return {
     ...state,
     notifications: [


### PR DESCRIPTION
## Description
Prevents identical banners and notification from being displayed multiple times. Refer to the issue for background information and before screenshots.

![image](https://user-images.githubusercontent.com/45173816/105983758-1a23a480-6091-11eb-8b4b-eff42679d67f.png) 
![image](https://user-images.githubusercontent.com/45173816/105983775-227bdf80-6091-11eb-9fcc-b7c8480f0749.png)

## Testing instructions
- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] Identical banners and notification are not displayed multiple times
- [ ] The notification number is the same as the number of banners displayed

## Agile board tracking
closes #542 