### PR TITLE
Add actions workflow for creating releases

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -1,0 +1,75 @@
+name: Release Build
+on: 
+  push:
+    branches: master
+    tags: '*'
+
+jobs:
+  build:
+    name: Release Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '14.x'
+
+      # Cache yarn dependencies/ restore the cached dependencies during future workflows
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - name: Cache yarn dependencies
+        uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Install dependencies
+        # Ubuntu 16+ does not install libgconf-2-4 by default, so we need to install it ourselves (for Cypress)
+        run: |
+          npm config set scripts-prepend-node-path true
+          sudo apt-get install libgconf-2-4
+          yarn --frozen-lockfile
+
+      - name: Build
+        run: yarn build
+
+      - name: Determine tag name
+        run: |
+          if [ "${{ github.ref }}" = "refs/heads/master" ]
+          then
+            echo TAG_NAME=snapshot >> $GITHUB_ENV
+          else
+            echo TAG_NAME=`basename ${{ github.ref }}` >> $GITHUB_ENV
+          fi
+
+      - name: Create tarball
+        run: |
+          mv build scigateway-$TAG_NAME
+          tar -czf scigateway-$TAG_NAME.tar.gz scigateway-$TAG_NAME
+
+      - name: Update snapshot tag
+        uses: richardsimko/update-tag@v1
+        with:
+          tag_name: ${{ env.TAG_NAME }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        if: ${{ github.ref == 'refs/heads/master' }}
+
+      - name: Create/update release
+        uses: johnwbyrd/update-release@v1.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          files: ./scigateway-${{ env.TAG_NAME }}.tar.gz
+          release: Release ${{ env.TAG_NAME }}
+          tag: ${{ env.TAG_NAME }}
+          prerelease: ${{ github.ref == 'refs/heads/master' }}
+          draft: false


### PR DESCRIPTION
## Description
This adds an actions workflow that runs for master and all tags that:
 - Runs `yarn build`
 - Creates a tarball from the `build` directory
 - If triggered by a push / PR to master, updates the snapshot tag to point to master
 - Creates a release and adds the tarball to the release

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review release-build.yml
- [ ] Check actions run (https://github.com/ajkyffin/scigateway/actions/workflows/release-build.yml)
- [ ] Check created releases (https://github.com/ajkyffin/scigateway/releases)