### PR TITLE
Add singleSpa.start() to relevant tests #613

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { act } from 'react-dom/test-utils';
 import { Provider } from 'react-redux';
+import * as singleSpa from 'single-spa';
 import App from './App';
 import { flushPromises } from './setupTests';
 import { loadAuthProvider } from './state/actions/scigateway.actions';
@@ -13,6 +14,7 @@ describe('App', () => {
 
   beforeEach(() => {
     mount = createMount();
+    singleSpa.start();
   });
 
   afterEach(() => {

--- a/src/loginPage/loginPage.component.test.tsx
+++ b/src/loginPage/loginPage.component.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import * as singleSpa from 'single-spa';
 import LoginPage, {
   LoginPageWithoutStyles,
   LoginPageWithStyles,
@@ -72,6 +73,8 @@ describe('Login page component', () => {
     };
 
     state.scigateway.authorisation = props.auth;
+
+    singleSpa.start();
   });
 
   const theme = buildTheme(false);


### PR DESCRIPTION
## Description
Calling `singleSpa.start()` prevents warnings when running the unit tests.

## Testing instructions

- [x] Review code
- [x] Check Actions build
- [x] Review changes to test coverage
- [x] Run the unit tests and check there are no warnings logged when they pass

## Agile board tracking
closes #613 