### PR TITLE
Persistent login between page refreshes/re-routing #641

### DIFF
--- a/cypress/integration/login.spec.ts
+++ b/cypress/integration/login.spec.ts
@@ -109,6 +109,57 @@ describe('Login', () => {
     );
     cy.get('button[aria-label="Open navigation menu"]').should('be.visible');
   });
+  
+  it('should remain logged in following page refresh or redirect', () => {
+    cy.visit('/login');
+    cy.contains('Sign in').should('be.visible');
+    cy.get('button[aria-label="Open navigation menu"]').should(
+      'not.exist'
+    );
+
+    cy.contains('Username*').parent().find('input').type(' username');
+    cy.contains('Password*').parent().find('input').type('password');
+
+    cy.contains('Username*')
+      .parent()
+      .parent()
+      .contains('button', 'Sign in')
+      .click();
+
+    cy.url().should('eq', 'http://127.0.0.1:3000/');
+
+    let storedToken: string | null;
+
+    cy.window().then(
+      (window) => {
+        expect(window.localStorage.getItem('scigateway:token')).not.be.null;
+        storedToken = window.localStorage.getItem('scigateway:token');
+      });
+    cy.get('button[aria-label="Open navigation menu"]').should('be.visible');
+
+    cy.reload();
+    cy.window().then(
+      (window) => {
+        expect(window.localStorage.getItem('scigateway:token')).not.be.null;
+        expect(storedToken).to.equal(window.localStorage.getItem('scigateway:token'));
+      });
+    cy.window().then((window) =>
+      expect(storedToken).to.equal(
+        window.localStorage.getItem('scigateway:token')
+      )
+    );
+    cy.get('button[aria-label="Open navigation menu"]').should('be.visible');
+    cy.contains('Sign in').should('not.exist');
+
+    cy.visit('/login');
+    cy.window().then(
+      (window) => {
+        expect(window.localStorage.getItem('scigateway:token')).not.be.null;
+        expect(storedToken).to.equal(window.localStorage.getItem('scigateway:token'));
+      });
+    cy.get('button[aria-label="Open navigation menu"]').should('be.visible');
+    cy.contains('Sign in').should('not.exist');
+  });
 
   it('should logout successfully', () => {
     cy.login('username', 'password');

--- a/cypress/integration/login.spec.ts
+++ b/cypress/integration/login.spec.ts
@@ -151,7 +151,7 @@ describe('Login', () => {
     cy.get('button[aria-label="Open navigation menu"]').should('be.visible');
     cy.contains('Sign in').should('not.exist');
 
-    cy.visit('/login');
+    cy.visit('/contact');
     cy.window().then(
       (window) => {
         expect(window.localStorage.getItem('scigateway:token')).not.be.null;

--- a/cypress/integration/login.spec.ts
+++ b/cypress/integration/login.spec.ts
@@ -109,7 +109,7 @@ describe('Login', () => {
     );
     cy.get('button[aria-label="Open navigation menu"]').should('be.visible');
   });
-  
+
   it('should remain logged in following page refresh or redirect', () => {
     cy.visit('/login');
     cy.contains('Sign in').should('be.visible');
@@ -143,11 +143,6 @@ describe('Login', () => {
         expect(window.localStorage.getItem('scigateway:token')).not.be.null;
         expect(storedToken).to.equal(window.localStorage.getItem('scigateway:token'));
       });
-    cy.window().then((window) =>
-      expect(storedToken).to.equal(
-        window.localStorage.getItem('scigateway:token')
-      )
-    );
     cy.get('button[aria-label="Open navigation menu"]').should('be.visible');
     cy.contains('Sign in').should('not.exist');
 
@@ -159,6 +154,29 @@ describe('Login', () => {
       });
     cy.get('button[aria-label="Open navigation menu"]').should('be.visible');
     cy.contains('Sign in').should('not.exist');
+  });
+
+  it('should not be logged in if invalid or unsigned token in localStorage', () => {
+    // if token cannot be deciphered
+    cy.contains('Sign in').should('be.visible');
+    window.localStorage.setItem('scigateway:token', 'invalidtoken');
+    cy.reload();
+    cy.contains('Sign in').should('be.visible');
+    cy.window().then(
+      (window) =>
+        expect(window.localStorage.getItem('scigateway:token')).to.be.null
+    );
+
+    // if token is recognised as a JWT but is not recognised as signed by the auth provider
+    const testInvalidToken =
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6InRlc3QiLCJpYXQiOjE2MTcyMDE4MDYsImV4cCI6MTYxNzIwMTg2Nn0.6DKXkw8zbHurAjBxDCY9zLrIB4NwPJL7GaCs_LArEmM';
+    window.localStorage.setItem('scigateway:token', testInvalidToken);
+    cy.reload();
+    cy.contains('Sign in').should('be.visible');
+    cy.window().then(
+      (window) =>
+        expect(window.localStorage.getItem('scigateway:token')).to.be.null
+    );
   });
 
   it('should logout successfully', () => {
@@ -225,14 +243,14 @@ describe('Login', () => {
 
   describe('autoLogin', () => {
     // Define responses for login attempts
-    let verifyResponse: {statusCode: Number; body: string};
-    let loginResponse: {statusCode: Number; body: string};
-    const verifySuccess = {statusCode: 200, body: ''};
-    const loginSuccess = {statusCode: 200, body: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzZXNzaW9uSWQiOiJ0ZXN0IiwidXNlcm5hbWUiOiJhbm9uL2Fub24iLCJleHAiOjkyMzQ5MjgzNDB9.KihH1oKHL3fpRG3EidyUWApAS4W-oHg7rsCM4Nuobuk'};
-    const failure = {statusCode: 403, body: ''};
+    let verifyResponse: { statusCode: Number; body: string };
+    let loginResponse: { statusCode: Number; body: string };
+    const verifySuccess = { statusCode: 200, body: '' };
+    const loginSuccess = { statusCode: 200, body: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzZXNzaW9uSWQiOiJ0ZXN0IiwidXNlcm5hbWUiOiJhbm9uL2Fub24iLCJleHAiOjkyMzQ5MjgzNDB9.KihH1oKHL3fpRG3EidyUWApAS4W-oHg7rsCM4Nuobuk' };
+    const failure = { statusCode: 403, body: '' };
 
     beforeEach(() => {
-        cy.intercept('/settings.json', {
+      cy.intercept('/settings.json', {
         plugins: [
           {
             name: 'demo_plugin',
@@ -256,8 +274,8 @@ describe('Login', () => {
           keys: [],
         },
       ]);
-      cy.intercept('POST', '/login', (req) => {req.reply(loginResponse)});
-      cy.intercept('POST', '/verify', (req) => {req.reply(verifyResponse)});
+      cy.intercept('POST', '/login', (req) => { req.reply(loginResponse) });
+      cy.intercept('POST', '/verify', (req) => { req.reply(verifyResponse) });
     });
 
     it('should show the sidebar and yet still show the Sign in button', () => {
@@ -275,7 +293,7 @@ describe('Login', () => {
 
       // test that autologin works after token valididation + refresh fail
       verifyResponse = failure;
-      cy.intercept('POST', '/refresh', {statusCode: 403 });
+      cy.intercept('POST', '/refresh', { statusCode: 403 });
       cy.reload();
       cy.get('button[aria-label="Open navigation menu"]').should('be.visible');
       cy.contains('Sign in').should('be.visible');
@@ -292,7 +310,7 @@ describe('Login', () => {
 
       // test that autologin fails after token validation + refresh fail
       verifyResponse = failure;
-      cy.intercept('POST', '/refresh', {statusCode: 403 });
+      cy.intercept('POST', '/refresh', { statusCode: 403 });
       cy.window().then(($window) =>
         $window.localStorage.setItem('scigateway:token', 'invalidtoken')
       );

--- a/cypress/integration/login.spec.ts
+++ b/cypress/integration/login.spec.ts
@@ -155,27 +155,6 @@ describe('Login', () => {
     cy.get('button[aria-label="Open navigation menu"]').should('be.visible');
     cy.contains('Sign in').should('not.exist');
   });
-  
-  it('should not be logged in if invalid or unsigned token in localStorage', () => {
-    cy.contains('Sign in').should('be.visible');
-    window.localStorage.setItem('scigateway:token', 'invalidtoken');
-    cy.reload();
-    cy.contains('Sign in').should('be.visible');
-    cy.window().then(
-      (window) =>
-        expect(window.localStorage.getItem('scigateway:token')).to.be.null
-    );
-
-    const testInvalidToken =
-      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6InRlc3QiLCJpYXQiOjE2MTcyMDE4MDYsImV4cCI6MTYxNzIwMTg2Nn0.6DKXkw8zbHurAjBxDCY9zLrIB4NwPJL7GaCs_LArEmM';
-    window.localStorage.setItem('scigateway:token', testInvalidToken);
-    cy.reload();
-    cy.contains('Sign in').should('be.visible');
-    cy.window().then(
-      (window) =>
-        expect(window.localStorage.getItem('scigateway:token')).to.be.null
-    );
-  });
 
   it('should not be logged in if invalid or unsigned token in localStorage', () => {
     // if token cannot be deciphered

--- a/src/authentication/baseAuthProvider.tsx
+++ b/src/authentication/baseAuthProvider.tsx
@@ -1,7 +1,9 @@
 import { AuthProvider, User } from '../state/state.types';
 import UserInfo from './user';
+import parseJwt from '../authentication/parseJwt';
 
 const tokenLocalStorageName = 'scigateway:token';
+const userLocalStorageName = 'scigateway: user';
 
 export default abstract class BaseAuthProvider implements AuthProvider {
   abstract logIn(username: string, password: string): Promise<void>;
@@ -14,13 +16,37 @@ export default abstract class BaseAuthProvider implements AuthProvider {
 
   public constructor(authUrl: string | undefined) {
     this.token = localStorage.getItem(tokenLocalStorageName);
-    this.user = null;
+    this.user = this.fetchUser();
     this.redirectUrl = null;
     this.authUrl = authUrl;
   }
 
+  public fetchUser(): User | null {
+    let tokenUsername: string;
+    if (this.token) {
+      const tokenObject: { username: string } = JSON.parse(
+        parseJwt(this.token)
+      );
+      tokenUsername = tokenObject.username;
+
+      const userObject: string | null = localStorage.getItem(
+        userLocalStorageName
+      );
+      if (userObject) {
+        const parsedUserObject: User | null = JSON.parse(userObject);
+        if (parsedUserObject) {
+          if (parsedUserObject.username === tokenUsername) {
+            return parsedUserObject;
+          }
+        }
+      }
+    }
+    this.logOut();
+    return null;
+  }
+
   public isLoggedIn(): boolean {
-    return this.token != null;
+    return this.token != null && this.user != null;
   }
 
   public isAdmin(): boolean {
@@ -30,6 +56,8 @@ export default abstract class BaseAuthProvider implements AuthProvider {
   public logOut(): void {
     localStorage.removeItem(tokenLocalStorageName);
     this.token = null;
+    localStorage.removeItem(userLocalStorageName);
+    this.user = null;
   }
 
   protected storeToken(token: string): void {
@@ -51,6 +79,8 @@ export default abstract class BaseAuthProvider implements AuthProvider {
     if (avatar) {
       this.user.avatarUrl = avatar;
     }
+
+    localStorage.setItem(userLocalStorageName, JSON.stringify(this.user));
   }
 
   /* eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any */

--- a/src/authentication/baseAuthProvider.tsx
+++ b/src/authentication/baseAuthProvider.tsx
@@ -15,7 +15,7 @@ export default abstract class BaseAuthProvider implements AuthProvider {
 
   public constructor(authUrl: string | undefined) {
     this.token = localStorage.getItem(tokenLocalStorageName);
-    this.user = this.token != null ? this.extractUserFromToken() : null;
+    this.user = this.extractUserFromToken();
     this.redirectUrl = null;
     this.authUrl = authUrl;
   }
@@ -28,12 +28,16 @@ export default abstract class BaseAuthProvider implements AuthProvider {
    */
   public extractUserFromToken(): User | null {
     if (this.token != null) {
-      const tokenString: string = parseJwt(this.token);
-      if (tokenString) {
-        const tokenObject = JSON.parse(tokenString);
-        const user: User = new UserInfo(tokenObject.username);
-        user.isAdmin = tokenObject.userIsAdmin;
-        return user;
+      try {
+        const tokenString: string = parseJwt(this.token);
+        if (tokenString) {
+          const tokenObject = JSON.parse(tokenString);
+          const user: User = new UserInfo(tokenObject.username);
+          user.isAdmin = tokenObject.userIsAdmin;
+          return user;
+        }
+      } catch (TypeError) {
+        // not a valid JWT, token has likely been tampered with in some way (or we are running tests)
       }
     }
 

--- a/src/authentication/baseAuthProvider.tsx
+++ b/src/authentication/baseAuthProvider.tsx
@@ -29,15 +29,16 @@ export default abstract class BaseAuthProvider implements AuthProvider {
   public extractUserFromToken(): User | null {
     if (this.token != null) {
       try {
-        const tokenString: string = parseJwt(this.token);
+        const tokenString = parseJwt(this.token);
         if (tokenString) {
           const tokenObject = JSON.parse(tokenString);
-          const user: User = new UserInfo(tokenObject.username);
+          const user = new UserInfo(tokenObject.username);
           user.isAdmin = tokenObject.userIsAdmin;
           return user;
         }
       } catch (TypeError) {
         // not a valid JWT, token has likely been tampered with in some way (or we are running tests)
+        console.error('Invalid token: failed to authenticate');
       }
     }
 

--- a/src/authentication/githubAuthProvider.test.tsx
+++ b/src/authentication/githubAuthProvider.test.tsx
@@ -4,7 +4,6 @@ import ReactGA from 'react-ga';
 
 describe('github auth provider', () => {
   let authProvider: GithubAuthProvider;
-  // payload - { 'username': 'user', 'userIsAdmin': false }
   const testToken =
     'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6InRlc3QifQ.hNQI_r8BATy1LyXPr6Zuo9X_V0kSED8ngcqQ6G-WV5w';
 

--- a/src/authentication/githubAuthProvider.test.tsx
+++ b/src/authentication/githubAuthProvider.test.tsx
@@ -4,13 +4,16 @@ import ReactGA from 'react-ga';
 
 describe('github auth provider', () => {
   let authProvider: GithubAuthProvider;
+  // payload - { 'username': 'user', 'userIsAdmin': false }
+  const testToken =
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6InRlc3QifQ.hNQI_r8BATy1LyXPr6Zuo9X_V0kSED8ngcqQ6G-WV5w';
 
   beforeEach(() => {
     jest.spyOn(window.localStorage.__proto__, 'getItem');
     window.localStorage.__proto__.getItem = jest
       .fn()
       .mockImplementation((name) =>
-        name === 'scigateway:token' ? 'token' : null
+        name === 'scigateway:token' ? testToken : null
       );
     window.localStorage.__proto__.removeItem = jest.fn();
     window.localStorage.__proto__.setItem = jest.fn();
@@ -39,7 +42,7 @@ describe('github auth provider', () => {
     (mockAxios.post as jest.Mock).mockImplementation(() =>
       Promise.resolve({
         data: {
-          token: 'token',
+          token: testToken,
           username: 'user',
           avatar: 'gravitar.com/fiowmefoimwe',
         },
@@ -51,11 +54,12 @@ describe('github auth provider', () => {
 
     await authProvider.logIn('', '?code=code12345');
 
-    expect(localStorage.setItem).toBeCalledWith('scigateway:token', 'token');
+    expect(localStorage.setItem).toBeCalledWith('scigateway:token', testToken);
 
     expect(authProvider.isLoggedIn()).toBeTruthy();
-    expect(authProvider.user.username).toBe('user');
-    expect(authProvider.user.avatarUrl).toBe('gravitar.com/fiowmefoimwe');
+    expect(authProvider.user).not.toBeNull();
+    expect(authProvider.user?.username).toBe('user');
+    expect(authProvider.user?.avatarUrl).toBe('gravitar.com/fiowmefoimwe');
 
     expect(ReactGA.testModeAPI.calls[1][0]).toEqual('send');
     expect(ReactGA.testModeAPI.calls[1][1]).toEqual({
@@ -125,8 +129,9 @@ describe('github auth provider', () => {
 
     await authProvider.verifyLogIn();
 
-    expect(authProvider.user.username).toBe('test_user');
-    expect(authProvider.user.avatarUrl).toBe('test_avatar');
+    expect(authProvider.user).not.toBeNull();
+    expect(authProvider.user?.username).toBe('test_user');
+    expect(authProvider.user?.avatarUrl).toBe('test_avatar');
   });
 
   it('should return error if refresh method is called', async () => {

--- a/src/authentication/icatAuthProvider.test.tsx
+++ b/src/authentication/icatAuthProvider.test.tsx
@@ -7,13 +7,16 @@ jest.mock('./parseJwt');
 
 describe('ICAT auth provider', () => {
   let icatAuthProvider: ICATAuthProvider;
+  // payload - { 'username': 'user', 'userIsAdmin': false }
+  const testToken =
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6InRlc3QifQ.hNQI_r8BATy1LyXPr6Zuo9X_V0kSED8ngcqQ6G-WV5w';
 
   beforeEach(() => {
     window.localStorage.__proto__.getItem = jest
       .fn()
       .mockImplementation((name) => {
         if (name === 'scigateway:token') {
-          return 'token';
+          return testToken;
         } else if (name === 'autoLogin') {
           return 'false';
         } else {
@@ -63,7 +66,7 @@ describe('ICAT auth provider', () => {
   it('should call the api to authenticate', async () => {
     (mockAxios.post as jest.Mock).mockImplementation(() =>
       Promise.resolve({
-        data: 'token',
+        data: testToken,
       })
     );
 
@@ -76,11 +79,12 @@ describe('ICAT auth provider', () => {
       mnemonic: 'mnemonic',
       credentials: { username: 'user', password: 'password' },
     });
-    expect(localStorage.setItem).toBeCalledWith('scigateway:token', 'token');
+    expect(localStorage.setItem).toBeCalledWith('scigateway:token', testToken);
     expect(localStorage.setItem).toBeCalledWith('autoLogin', 'false');
 
     expect(icatAuthProvider.isLoggedIn()).toBeTruthy();
-    expect(icatAuthProvider.user.username).toBe('token username');
+    expect(icatAuthProvider.user).not.toBeNull();
+    expect(icatAuthProvider.user?.username).toBe(testToken + ' username');
 
     expect(ReactGA.testModeAPI.calls[1][0]).toEqual('send');
     expect(ReactGA.testModeAPI.calls[1][1]).toEqual({
@@ -120,7 +124,7 @@ describe('ICAT auth provider', () => {
   it('should attempt to autologin via anon authenticator when initialised', async () => {
     (mockAxios.post as jest.Mock).mockImplementation(() =>
       Promise.resolve({
-        data: 'token',
+        data: testToken,
       })
     );
 
@@ -137,11 +141,12 @@ describe('ICAT auth provider', () => {
       mnemonic: 'anon',
       credentials: { username: '', password: '' },
     });
-    expect(localStorage.setItem).toBeCalledWith('scigateway:token', 'token');
+    expect(localStorage.setItem).toBeCalledWith('scigateway:token', testToken);
     expect(localStorage.setItem).toBeCalledWith('autoLogin', 'true');
 
     expect(icatAuthProvider.isLoggedIn()).toBeTruthy();
-    expect(icatAuthProvider.user.username).toBe('token username');
+    expect(icatAuthProvider.user).not.toBeNull();
+    expect(icatAuthProvider.user?.username).toBe(testToken + ' username');
     expect(icatAuthProvider.isAdmin()).toBeTruthy();
 
     expect(ReactGA.testModeAPI.calls[1][0]).toEqual('send');
@@ -207,7 +212,7 @@ describe('ICAT auth provider', () => {
     await icatAuthProvider.verifyLogIn();
 
     expect(mockAxios.post).toBeCalledWith('http://localhost:8000/verify', {
-      token: 'token',
+      token: testToken,
     });
   });
 
@@ -240,7 +245,7 @@ describe('ICAT auth provider', () => {
     expect(mockAxios.post).toHaveBeenCalledWith(
       'http://localhost:8000/refresh',
       {
-        token: 'token',
+        token: testToken,
       }
     );
     expect(localStorage.setItem).toBeCalledWith(
@@ -343,7 +348,7 @@ describe('ICAT auth provider', () => {
     expect(mockAxios.put).toBeCalledWith(
       'http://localhost:8000/scheduled_maintenance',
       {
-        token: 'token',
+        token: testToken,
         scheduledMaintenance: scheduledMaintenanceState,
       }
     );
@@ -376,7 +381,7 @@ describe('ICAT auth provider', () => {
     await icatAuthProvider.setMaintenanceState(maintenanceState);
 
     expect(mockAxios.put).toBeCalledWith('http://localhost:8000/maintenance', {
-      token: 'token',
+      token: testToken,
       maintenance: maintenanceState,
     });
   });

--- a/src/authentication/icatAuthProvider.test.tsx
+++ b/src/authentication/icatAuthProvider.test.tsx
@@ -7,7 +7,6 @@ jest.mock('./parseJwt');
 
 describe('ICAT auth provider', () => {
   let icatAuthProvider: ICATAuthProvider;
-  // payload - { 'username': 'user', 'userIsAdmin': false }
   const testToken =
     'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6InRlc3QifQ.hNQI_r8BATy1LyXPr6Zuo9X_V0kSED8ngcqQ6G-WV5w';
 

--- a/src/authentication/jwtAuthProvider.test.tsx
+++ b/src/authentication/jwtAuthProvider.test.tsx
@@ -4,7 +4,6 @@ import ReactGA from 'react-ga';
 
 describe('jwt auth provider', () => {
   let jwtAuthProvider: JWTAuthProvider;
-  // payload - { 'username': 'user', 'userIsAdmin': false }
   const testToken =
     'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6InVzZXIiLCJ1c2VySXNBZG1pbiI6ZmFsc2V9.PEuKaAD98doFTLyqcNFpsuv50AQR8ejrbDQ0pwazM7Q';
 

--- a/src/state/reducers/scigateway.reducer.test.tsx
+++ b/src/state/reducers/scigateway.reducer.test.tsx
@@ -220,7 +220,6 @@ describe('scigateway reducer', () => {
       GithubAuthProvider
     );
 
-    // payload - { 'username': 'user', 'userIsAdmin': false }
     const testToken =
       'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6InRlc3QifQ.hNQI_r8BATy1LyXPr6Zuo9X_V0kSED8ngcqQ6G-WV5w';
 

--- a/src/state/reducers/scigateway.reducer.test.tsx
+++ b/src/state/reducers/scigateway.reducer.test.tsx
@@ -220,12 +220,16 @@ describe('scigateway reducer', () => {
       GithubAuthProvider
     );
 
+    // payload - { 'username': 'user', 'userIsAdmin': false }
+    const testToken =
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6InRlc3QifQ.hNQI_r8BATy1LyXPr6Zuo9X_V0kSED8ngcqQ6G-WV5w';
+
     // mock localstorage so that ICAT authenticator thinks it's already logged in
     // therefore won't trigger autologin, and do some HTTP request shenanigans
     window.localStorage.__proto__.getItem = jest
       .fn()
       .mockImplementation((name) =>
-        name === 'scigateway:token' ? 'token' : null
+        name === 'scigateway:token' ? testToken : null
       );
 
     updatedState = ScigatewayReducer(state, loadAuthProvider('icat'));


### PR DESCRIPTION
## Description
Keeps the user logged in after refreshing the web page or navigating to a different address. On page refresh, when auth provider is constructed in code, a check is made for an existing token. If one is found, the user details are parsed from it and stored in code. Otherwise, user is assumed not to be logged in.

No additional data is stored locally, relies on the token being secure and signed. Any changes to the token made by the user invalidate the session and log the user out. This prevents the user from modifying their username or admin status.

Also amending test data in auth provider test code to use a valid JWT as test data instead of the string 'token'. This is to allow for testing to be carried out to confirm user login. The code is unable to parse user details from a token string equalling 'token' so a JWT with test data is used instead.

## Testing instructions
Test with JWT authenticator (username = 'username') and ICAT authenticator (username = 'root'). 

- [x] Review code
- [x] Check Actions build
- [x] After login, validate user that is logged in and their functionality. Then refresh the page or navigate to a different one to check the same functionality exists
- [x] If logged in as admin user, check navigation to /admin works after page refresh
- [x] Check token refreshing and validation is happening with requests to `/checkToken` and `/refresh` for JWT and `/verify` and `/refresh` for ICAT
- [x] Check that overwriting `scigateway:token` value in localStorage with a user-input value logs the user out on a page refresh
- [x] Review changes to test coverage

## Agile board tracking
closes #641 