### PR TITLE
Display admin functionality from plugins

### DIFF
--- a/src/adminPage/__snapshots__/adminPage.component.test.tsx.snap
+++ b/src/adminPage/__snapshots__/adminPage.component.test.tsx.snap
@@ -13,702 +13,1022 @@ exports[`Admin page component should render correctly 1`] = `
     }
   }
 >
-  <Connect(WithStyles(AdminPage))>
-    <WithStyles(AdminPage)
-      maintenance={
+  <MemoryRouter
+    initialEntries={
+      Array [
         Object {
-          "message": "",
-          "show": false,
+          "key": "testKey",
+        },
+      ]
+    }
+  >
+    <Router
+      history={
+        Object {
+          "action": "POP",
+          "block": [Function],
+          "canGo": [Function],
+          "createHref": [Function],
+          "entries": Array [
+            Object {
+              "hash": "",
+              "key": "testKey",
+              "pathname": "/",
+              "search": "",
+            },
+          ],
+          "go": [Function],
+          "goBack": [Function],
+          "goForward": [Function],
+          "index": 0,
+          "length": 1,
+          "listen": [Function],
+          "location": Object {
+            "hash": "",
+            "key": "testKey",
+            "pathname": "/",
+            "search": "",
+          },
+          "push": [Function],
+          "replace": [Function],
         }
       }
-      scheduledMaintenance={
-        Object {
-          "message": "",
-          "show": false,
-        }
-      }
-      setMaintenanceState={[Function]}
-      setScheduledMaintenanceState={[Function]}
     >
-      <AdminPage
-        classes={
-          Object {
-            "form": "AdminPage-form-4",
-            "paper": "AdminPage-paper-3",
-            "root": "AdminPage-root-1",
-            "textArea": "AdminPage-textArea-5",
-            "titleText": "AdminPage-titleText-2",
+      <Connect(WithStyles(AdminPage))>
+        <WithStyles(AdminPage)
+          maintenance={
+            Object {
+              "message": "",
+              "show": false,
+            }
           }
-        }
-        maintenance={
-          Object {
-            "message": "",
-            "show": false,
+          scheduledMaintenance={
+            Object {
+              "message": "",
+              "show": false,
+            }
           }
-        }
-        scheduledMaintenance={
-          Object {
-            "message": "",
-            "show": false,
-          }
-        }
-        setMaintenanceState={[Function]}
-        setScheduledMaintenanceState={[Function]}
-      >
-        <div
-          className="AdminPage-root-1"
+          setMaintenanceState={[Function]}
+          setScheduledMaintenanceState={[Function]}
         >
-          <WithStyles(ForwardRef(Typography))
-            className="AdminPage-titleText-2"
-            variant="h3"
-          >
-            <ForwardRef(Typography)
-              className="AdminPage-titleText-2"
-              classes={
-                Object {
-                  "alignCenter": "MuiTypography-alignCenter",
-                  "alignJustify": "MuiTypography-alignJustify",
-                  "alignLeft": "MuiTypography-alignLeft",
-                  "alignRight": "MuiTypography-alignRight",
-                  "body1": "MuiTypography-body1",
-                  "body2": "MuiTypography-body2",
-                  "button": "MuiTypography-button",
-                  "caption": "MuiTypography-caption",
-                  "colorError": "MuiTypography-colorError",
-                  "colorInherit": "MuiTypography-colorInherit",
-                  "colorPrimary": "MuiTypography-colorPrimary",
-                  "colorSecondary": "MuiTypography-colorSecondary",
-                  "colorTextPrimary": "MuiTypography-colorTextPrimary",
-                  "colorTextSecondary": "MuiTypography-colorTextSecondary",
-                  "displayBlock": "MuiTypography-displayBlock",
-                  "displayInline": "MuiTypography-displayInline",
-                  "gutterBottom": "MuiTypography-gutterBottom",
-                  "h1": "MuiTypography-h1",
-                  "h2": "MuiTypography-h2",
-                  "h3": "MuiTypography-h3",
-                  "h4": "MuiTypography-h4",
-                  "h5": "MuiTypography-h5",
-                  "h6": "MuiTypography-h6",
-                  "noWrap": "MuiTypography-noWrap",
-                  "overline": "MuiTypography-overline",
-                  "paragraph": "MuiTypography-paragraph",
-                  "root": "MuiTypography-root",
-                  "srOnly": "MuiTypography-srOnly",
-                  "subtitle1": "MuiTypography-subtitle1",
-                  "subtitle2": "MuiTypography-subtitle2",
-                }
+          <AdminPage
+            classes={
+              Object {
+                "form": "AdminPage-form-4",
+                "paper": "AdminPage-paper-3",
+                "root": "AdminPage-root-1",
+                "textArea": "AdminPage-textArea-5",
+                "titleText": "AdminPage-titleText-2",
               }
-              variant="h3"
-            >
-              <h3
-                className="MuiTypography-root AdminPage-titleText-2 MuiTypography-h3"
-              >
-                title
-              </h3>
-            </ForwardRef(Typography)>
-          </WithStyles(ForwardRef(Typography))>
-          <WithStyles(ForwardRef(Paper))
-            className="AdminPage-paper-3"
-          >
-            <ForwardRef(Paper)
-              className="AdminPage-paper-3"
-              classes={
-                Object {
-                  "elevation0": "MuiPaper-elevation0",
-                  "elevation1": "MuiPaper-elevation1",
-                  "elevation10": "MuiPaper-elevation10",
-                  "elevation11": "MuiPaper-elevation11",
-                  "elevation12": "MuiPaper-elevation12",
-                  "elevation13": "MuiPaper-elevation13",
-                  "elevation14": "MuiPaper-elevation14",
-                  "elevation15": "MuiPaper-elevation15",
-                  "elevation16": "MuiPaper-elevation16",
-                  "elevation17": "MuiPaper-elevation17",
-                  "elevation18": "MuiPaper-elevation18",
-                  "elevation19": "MuiPaper-elevation19",
-                  "elevation2": "MuiPaper-elevation2",
-                  "elevation20": "MuiPaper-elevation20",
-                  "elevation21": "MuiPaper-elevation21",
-                  "elevation22": "MuiPaper-elevation22",
-                  "elevation23": "MuiPaper-elevation23",
-                  "elevation24": "MuiPaper-elevation24",
-                  "elevation3": "MuiPaper-elevation3",
-                  "elevation4": "MuiPaper-elevation4",
-                  "elevation5": "MuiPaper-elevation5",
-                  "elevation6": "MuiPaper-elevation6",
-                  "elevation7": "MuiPaper-elevation7",
-                  "elevation8": "MuiPaper-elevation8",
-                  "elevation9": "MuiPaper-elevation9",
-                  "outlined": "MuiPaper-outlined",
-                  "root": "MuiPaper-root",
-                  "rounded": "MuiPaper-rounded",
-                }
+            }
+            maintenance={
+              Object {
+                "message": "",
+                "show": false,
               }
+            }
+            scheduledMaintenance={
+              Object {
+                "message": "",
+                "show": false,
+              }
+            }
+            setMaintenanceState={[Function]}
+            setScheduledMaintenanceState={[Function]}
+          >
+            <div
+              className="AdminPage-root-1"
             >
-              <div
-                className="MuiPaper-root AdminPage-paper-3 MuiPaper-elevation1 MuiPaper-rounded"
+              <WithStyles(ForwardRef(Typography))
+                className="AdminPage-titleText-2"
+                variant="h3"
               >
-                <WithStyles(ForwardRef(Typography))
-                  variant="h4"
-                >
-                  <ForwardRef(Typography)
-                    classes={
-                      Object {
-                        "alignCenter": "MuiTypography-alignCenter",
-                        "alignJustify": "MuiTypography-alignJustify",
-                        "alignLeft": "MuiTypography-alignLeft",
-                        "alignRight": "MuiTypography-alignRight",
-                        "body1": "MuiTypography-body1",
-                        "body2": "MuiTypography-body2",
-                        "button": "MuiTypography-button",
-                        "caption": "MuiTypography-caption",
-                        "colorError": "MuiTypography-colorError",
-                        "colorInherit": "MuiTypography-colorInherit",
-                        "colorPrimary": "MuiTypography-colorPrimary",
-                        "colorSecondary": "MuiTypography-colorSecondary",
-                        "colorTextPrimary": "MuiTypography-colorTextPrimary",
-                        "colorTextSecondary": "MuiTypography-colorTextSecondary",
-                        "displayBlock": "MuiTypography-displayBlock",
-                        "displayInline": "MuiTypography-displayInline",
-                        "gutterBottom": "MuiTypography-gutterBottom",
-                        "h1": "MuiTypography-h1",
-                        "h2": "MuiTypography-h2",
-                        "h3": "MuiTypography-h3",
-                        "h4": "MuiTypography-h4",
-                        "h5": "MuiTypography-h5",
-                        "h6": "MuiTypography-h6",
-                        "noWrap": "MuiTypography-noWrap",
-                        "overline": "MuiTypography-overline",
-                        "paragraph": "MuiTypography-paragraph",
-                        "root": "MuiTypography-root",
-                        "srOnly": "MuiTypography-srOnly",
-                        "subtitle1": "MuiTypography-subtitle1",
-                        "subtitle2": "MuiTypography-subtitle2",
-                      }
-                    }
-                    variant="h4"
-                  >
-                    <h4
-                      className="MuiTypography-root MuiTypography-h4"
-                    >
-                      scheduled-maintenance-title
-                    </h4>
-                  </ForwardRef(Typography)>
-                </WithStyles(ForwardRef(Typography))>
-                <ForwardRef(TextareaAutosize)
-                  aria-label="shceduled-maintenance-message-arialabel"
-                  className="AdminPage-textArea-5"
-                  onChange={[Function]}
-                  placeholder="message-placeholder"
-                  rows={7}
-                  value=""
-                >
-                  <textarea
-                    aria-label="shceduled-maintenance-message-arialabel"
-                    className="AdminPage-textArea-5"
-                    onChange={[Function]}
-                    placeholder="message-placeholder"
-                    rows={7}
-                    style={
-                      Object {
-                        "height": -4,
-                        "overflow": "hidden",
-                      }
-                    }
-                    value=""
-                  />
-                  <textarea
-                    aria-hidden={true}
-                    className="AdminPage-textArea-5"
-                    readOnly={true}
-                    style={
-                      Object {
-                        "height": 0,
-                        "left": 0,
-                        "overflow": "hidden",
-                        "position": "absolute",
-                        "top": 0,
-                        "transform": "translateZ(0)",
-                        "visibility": "hidden",
-                      }
-                    }
-                    tabIndex={-1}
-                  />
-                </ForwardRef(TextareaAutosize)>
-                <div
-                  style={
+                <ForwardRef(Typography)
+                  className="AdminPage-titleText-2"
+                  classes={
                     Object {
-                      "display": "row",
+                      "alignCenter": "MuiTypography-alignCenter",
+                      "alignJustify": "MuiTypography-alignJustify",
+                      "alignLeft": "MuiTypography-alignLeft",
+                      "alignRight": "MuiTypography-alignRight",
+                      "body1": "MuiTypography-body1",
+                      "body2": "MuiTypography-body2",
+                      "button": "MuiTypography-button",
+                      "caption": "MuiTypography-caption",
+                      "colorError": "MuiTypography-colorError",
+                      "colorInherit": "MuiTypography-colorInherit",
+                      "colorPrimary": "MuiTypography-colorPrimary",
+                      "colorSecondary": "MuiTypography-colorSecondary",
+                      "colorTextPrimary": "MuiTypography-colorTextPrimary",
+                      "colorTextSecondary": "MuiTypography-colorTextSecondary",
+                      "displayBlock": "MuiTypography-displayBlock",
+                      "displayInline": "MuiTypography-displayInline",
+                      "gutterBottom": "MuiTypography-gutterBottom",
+                      "h1": "MuiTypography-h1",
+                      "h2": "MuiTypography-h2",
+                      "h3": "MuiTypography-h3",
+                      "h4": "MuiTypography-h4",
+                      "h5": "MuiTypography-h5",
+                      "h6": "MuiTypography-h6",
+                      "noWrap": "MuiTypography-noWrap",
+                      "overline": "MuiTypography-overline",
+                      "paragraph": "MuiTypography-paragraph",
+                      "root": "MuiTypography-root",
+                      "srOnly": "MuiTypography-srOnly",
+                      "subtitle1": "MuiTypography-subtitle1",
+                      "subtitle2": "MuiTypography-subtitle2",
                     }
                   }
+                  variant="h3"
                 >
-                  <WithStyles(ForwardRef(FormControlLabel))
-                    control={
-                      <WithStyles(ForwardRef(Checkbox))
-                        checked={false}
-                        color="secondary"
-                        inputProps={
-                          Object {
-                            "aria-label": "scheduled-maintenance-checkbox-arialabel",
-                          }
-                        }
-                        onChange={[Function]}
-                      />
-                    }
-                    label="display-checkbox"
-                    labelPlacement="end"
-                    style={
-                      Object {
-                        "float": "left",
-                      }
-                    }
-                    value={false}
+                  <h3
+                    className="MuiTypography-root AdminPage-titleText-2 MuiTypography-h3"
                   >
-                    <ForwardRef(FormControlLabel)
-                      classes={
-                        Object {
-                          "disabled": "Mui-disabled",
-                          "label": "MuiFormControlLabel-label",
-                          "labelPlacementBottom": "MuiFormControlLabel-labelPlacementBottom",
-                          "labelPlacementStart": "MuiFormControlLabel-labelPlacementStart",
-                          "labelPlacementTop": "MuiFormControlLabel-labelPlacementTop",
-                          "root": "MuiFormControlLabel-root",
-                        }
-                      }
-                      control={
-                        <WithStyles(ForwardRef(Checkbox))
-                          checked={false}
-                          color="secondary"
-                          inputProps={
-                            Object {
-                              "aria-label": "scheduled-maintenance-checkbox-arialabel",
-                            }
-                          }
-                          onChange={[Function]}
-                        />
-                      }
-                      label="display-checkbox"
-                      labelPlacement="end"
+                    title
+                  </h3>
+                </ForwardRef(Typography)>
+              </WithStyles(ForwardRef(Typography))>
+              <WithStyles(ForwardRef(Tabs))
+                onChange={[Function]}
+                value="maintenance"
+              >
+                <ForwardRef(Tabs)
+                  classes={
+                    Object {
+                      "centered": "MuiTabs-centered",
+                      "fixed": "MuiTabs-fixed",
+                      "flexContainer": "MuiTabs-flexContainer",
+                      "flexContainerVertical": "MuiTabs-flexContainerVertical",
+                      "indicator": "MuiTabs-indicator",
+                      "root": "MuiTabs-root",
+                      "scrollButtons": "MuiTabs-scrollButtons",
+                      "scrollButtonsDesktop": "MuiTabs-scrollButtonsDesktop",
+                      "scrollable": "MuiTabs-scrollable",
+                      "scroller": "MuiTabs-scroller",
+                      "vertical": "MuiTabs-vertical",
+                    }
+                  }
+                  onChange={[Function]}
+                  value="maintenance"
+                >
+                  <div
+                    className="MuiTabs-root"
+                  >
+                    <div
+                      className="MuiTabs-scroller MuiTabs-fixed"
+                      onScroll={[Function]}
                       style={
                         Object {
-                          "float": "left",
+                          "marginBottom": null,
+                          "overflow": "hidden",
                         }
                       }
-                      value={false}
                     >
-                      <label
-                        className="MuiFormControlLabel-root"
+                      <div
+                        className="MuiTabs-flexContainer"
+                        onKeyDown={[Function]}
+                        role="tablist"
+                      >
+                        <WithStyles(ForwardRef(Tab))
+                          aria-controls="maintenance-panel"
+                          fullWidth={false}
+                          id="maintenance-tab"
+                          indicator={false}
+                          key=".0"
+                          label="Maintenance"
+                          onChange={[Function]}
+                          selected={true}
+                          textColor="inherit"
+                          value="maintenance"
+                        >
+                          <ForwardRef(Tab)
+                            aria-controls="maintenance-panel"
+                            classes={
+                              Object {
+                                "disabled": "Mui-disabled",
+                                "fullWidth": "MuiTab-fullWidth",
+                                "labelIcon": "MuiTab-labelIcon",
+                                "root": "MuiTab-root",
+                                "selected": "Mui-selected",
+                                "textColorInherit": "MuiTab-textColorInherit",
+                                "textColorPrimary": "MuiTab-textColorPrimary",
+                                "textColorSecondary": "MuiTab-textColorSecondary",
+                                "wrapped": "MuiTab-wrapped",
+                                "wrapper": "MuiTab-wrapper",
+                              }
+                            }
+                            fullWidth={false}
+                            id="maintenance-tab"
+                            indicator={false}
+                            label="Maintenance"
+                            onChange={[Function]}
+                            selected={true}
+                            textColor="inherit"
+                            value="maintenance"
+                          >
+                            <WithStyles(ForwardRef(ButtonBase))
+                              aria-controls="maintenance-panel"
+                              aria-selected={true}
+                              className="MuiTab-root MuiTab-textColorInherit Mui-selected"
+                              disabled={false}
+                              focusRipple={true}
+                              id="maintenance-tab"
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              role="tab"
+                              tabIndex={0}
+                            >
+                              <ForwardRef(ButtonBase)
+                                aria-controls="maintenance-panel"
+                                aria-selected={true}
+                                className="MuiTab-root MuiTab-textColorInherit Mui-selected"
+                                classes={
+                                  Object {
+                                    "disabled": "Mui-disabled",
+                                    "focusVisible": "Mui-focusVisible",
+                                    "root": "MuiButtonBase-root",
+                                  }
+                                }
+                                disabled={false}
+                                focusRipple={true}
+                                id="maintenance-tab"
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                role="tab"
+                                tabIndex={0}
+                              >
+                                <button
+                                  aria-controls="maintenance-panel"
+                                  aria-selected={true}
+                                  className="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit Mui-selected"
+                                  disabled={false}
+                                  id="maintenance-tab"
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onDragLeave={[Function]}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onKeyUp={[Function]}
+                                  onMouseDown={[Function]}
+                                  onMouseLeave={[Function]}
+                                  onMouseUp={[Function]}
+                                  onTouchEnd={[Function]}
+                                  onTouchMove={[Function]}
+                                  onTouchStart={[Function]}
+                                  role="tab"
+                                  tabIndex={0}
+                                  type="button"
+                                >
+                                  <span
+                                    className="MuiTab-wrapper"
+                                  >
+                                    Maintenance
+                                  </span>
+                                  <WithStyles(memo)
+                                    center={false}
+                                  >
+                                    <ForwardRef(TouchRipple)
+                                      center={false}
+                                      classes={
+                                        Object {
+                                          "child": "MuiTouchRipple-child",
+                                          "childLeaving": "MuiTouchRipple-childLeaving",
+                                          "childPulsate": "MuiTouchRipple-childPulsate",
+                                          "ripple": "MuiTouchRipple-ripple",
+                                          "ripplePulsate": "MuiTouchRipple-ripplePulsate",
+                                          "rippleVisible": "MuiTouchRipple-rippleVisible",
+                                          "root": "MuiTouchRipple-root",
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        className="MuiTouchRipple-root"
+                                      >
+                                        <TransitionGroup
+                                          childFactory={[Function]}
+                                          component={null}
+                                          exit={true}
+                                        />
+                                      </span>
+                                    </ForwardRef(TouchRipple)>
+                                  </WithStyles(memo)>
+                                </button>
+                              </ForwardRef(ButtonBase)>
+                            </WithStyles(ForwardRef(ButtonBase))>
+                          </ForwardRef(Tab)>
+                        </WithStyles(ForwardRef(Tab))>
+                        <WithStyles(ForwardRef(Tab))
+                          component={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "displayName": "Link",
+                              "propTypes": Object {
+                                "innerRef": [Function],
+                                "onClick": [Function],
+                                "replace": [Function],
+                                "target": [Function],
+                                "to": [Function],
+                              },
+                              "render": [Function],
+                            }
+                          }
+                          fullWidth={false}
+                          id="download-tab"
+                          indicator={false}
+                          key=".1"
+                          label="Admin Download"
+                          onChange={[Function]}
+                          selected={false}
+                          textColor="inherit"
+                          to="/admin-download"
+                          value="download"
+                        >
+                          <ForwardRef(Tab)
+                            classes={
+                              Object {
+                                "disabled": "Mui-disabled",
+                                "fullWidth": "MuiTab-fullWidth",
+                                "labelIcon": "MuiTab-labelIcon",
+                                "root": "MuiTab-root",
+                                "selected": "Mui-selected",
+                                "textColorInherit": "MuiTab-textColorInherit",
+                                "textColorPrimary": "MuiTab-textColorPrimary",
+                                "textColorSecondary": "MuiTab-textColorSecondary",
+                                "wrapped": "MuiTab-wrapped",
+                                "wrapper": "MuiTab-wrapper",
+                              }
+                            }
+                            component={
+                              Object {
+                                "$$typeof": Symbol(react.forward_ref),
+                                "displayName": "Link",
+                                "propTypes": Object {
+                                  "innerRef": [Function],
+                                  "onClick": [Function],
+                                  "replace": [Function],
+                                  "target": [Function],
+                                  "to": [Function],
+                                },
+                                "render": [Function],
+                              }
+                            }
+                            fullWidth={false}
+                            id="download-tab"
+                            indicator={false}
+                            label="Admin Download"
+                            onChange={[Function]}
+                            selected={false}
+                            textColor="inherit"
+                            to="/admin-download"
+                            value="download"
+                          >
+                            <WithStyles(ForwardRef(ButtonBase))
+                              aria-selected={false}
+                              className="MuiTab-root MuiTab-textColorInherit"
+                              component={
+                                Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "displayName": "Link",
+                                  "propTypes": Object {
+                                    "innerRef": [Function],
+                                    "onClick": [Function],
+                                    "replace": [Function],
+                                    "target": [Function],
+                                    "to": [Function],
+                                  },
+                                  "render": [Function],
+                                }
+                              }
+                              disabled={false}
+                              focusRipple={true}
+                              id="download-tab"
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              role="tab"
+                              tabIndex={-1}
+                              to="/admin-download"
+                            >
+                              <ForwardRef(ButtonBase)
+                                aria-selected={false}
+                                className="MuiTab-root MuiTab-textColorInherit"
+                                classes={
+                                  Object {
+                                    "disabled": "Mui-disabled",
+                                    "focusVisible": "Mui-focusVisible",
+                                    "root": "MuiButtonBase-root",
+                                  }
+                                }
+                                component={
+                                  Object {
+                                    "$$typeof": Symbol(react.forward_ref),
+                                    "displayName": "Link",
+                                    "propTypes": Object {
+                                      "innerRef": [Function],
+                                      "onClick": [Function],
+                                      "replace": [Function],
+                                      "target": [Function],
+                                      "to": [Function],
+                                    },
+                                    "render": [Function],
+                                  }
+                                }
+                                disabled={false}
+                                focusRipple={true}
+                                id="download-tab"
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                role="tab"
+                                tabIndex={-1}
+                                to="/admin-download"
+                              >
+                                <Link
+                                  aria-disabled={false}
+                                  aria-selected={false}
+                                  className="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit"
+                                  id="download-tab"
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onDragLeave={[Function]}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onKeyUp={[Function]}
+                                  onMouseDown={[Function]}
+                                  onMouseLeave={[Function]}
+                                  onMouseUp={[Function]}
+                                  onTouchEnd={[Function]}
+                                  onTouchMove={[Function]}
+                                  onTouchStart={[Function]}
+                                  role="tab"
+                                  tabIndex={-1}
+                                  to="/admin-download"
+                                >
+                                  <LinkAnchor
+                                    aria-disabled={false}
+                                    aria-selected={false}
+                                    className="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit"
+                                    href="/admin-download"
+                                    id="download-tab"
+                                    navigate={[Function]}
+                                    onBlur={[Function]}
+                                    onClick={[Function]}
+                                    onDragLeave={[Function]}
+                                    onFocus={[Function]}
+                                    onKeyDown={[Function]}
+                                    onKeyUp={[Function]}
+                                    onMouseDown={[Function]}
+                                    onMouseLeave={[Function]}
+                                    onMouseUp={[Function]}
+                                    onTouchEnd={[Function]}
+                                    onTouchMove={[Function]}
+                                    onTouchStart={[Function]}
+                                    role="tab"
+                                    tabIndex={-1}
+                                  >
+                                    <a
+                                      aria-disabled={false}
+                                      aria-selected={false}
+                                      className="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit"
+                                      href="/admin-download"
+                                      id="download-tab"
+                                      onBlur={[Function]}
+                                      onClick={[Function]}
+                                      onDragLeave={[Function]}
+                                      onFocus={[Function]}
+                                      onKeyDown={[Function]}
+                                      onKeyUp={[Function]}
+                                      onMouseDown={[Function]}
+                                      onMouseLeave={[Function]}
+                                      onMouseUp={[Function]}
+                                      onTouchEnd={[Function]}
+                                      onTouchMove={[Function]}
+                                      onTouchStart={[Function]}
+                                      role="tab"
+                                      tabIndex={-1}
+                                    >
+                                      <span
+                                        className="MuiTab-wrapper"
+                                      >
+                                        Admin Download
+                                      </span>
+                                      <WithStyles(memo)
+                                        center={false}
+                                      >
+                                        <ForwardRef(TouchRipple)
+                                          center={false}
+                                          classes={
+                                            Object {
+                                              "child": "MuiTouchRipple-child",
+                                              "childLeaving": "MuiTouchRipple-childLeaving",
+                                              "childPulsate": "MuiTouchRipple-childPulsate",
+                                              "ripple": "MuiTouchRipple-ripple",
+                                              "ripplePulsate": "MuiTouchRipple-ripplePulsate",
+                                              "rippleVisible": "MuiTouchRipple-rippleVisible",
+                                              "root": "MuiTouchRipple-root",
+                                            }
+                                          }
+                                        >
+                                          <span
+                                            className="MuiTouchRipple-root"
+                                          >
+                                            <TransitionGroup
+                                              childFactory={[Function]}
+                                              component={null}
+                                              exit={true}
+                                            />
+                                          </span>
+                                        </ForwardRef(TouchRipple)>
+                                      </WithStyles(memo)>
+                                    </a>
+                                  </LinkAnchor>
+                                </Link>
+                              </ForwardRef(ButtonBase)>
+                            </WithStyles(ForwardRef(ButtonBase))>
+                          </ForwardRef(Tab)>
+                        </WithStyles(ForwardRef(Tab))>
+                      </div>
+                      <WithStyles(ForwardRef(TabIndicator))
+                        className="MuiTabs-indicator"
+                        color="secondary"
+                        orientation="horizontal"
                         style={
                           Object {
-                            "float": "left",
+                            "left": 0,
+                            "width": 0,
                           }
                         }
                       >
-                        <WithStyles(ForwardRef(Checkbox))
-                          checked={false}
-                          color="secondary"
-                          inputProps={
+                        <ForwardRef(TabIndicator)
+                          className="MuiTabs-indicator"
+                          classes={
                             Object {
-                              "aria-label": "scheduled-maintenance-checkbox-arialabel",
+                              "colorPrimary": "PrivateTabIndicator-colorPrimary-7",
+                              "colorSecondary": "PrivateTabIndicator-colorSecondary-8",
+                              "root": "PrivateTabIndicator-root-6",
+                              "vertical": "PrivateTabIndicator-vertical-9",
                             }
                           }
-                          onChange={[Function]}
-                          value={false}
+                          color="secondary"
+                          orientation="horizontal"
+                          style={
+                            Object {
+                              "left": 0,
+                              "width": 0,
+                            }
+                          }
                         >
-                          <ForwardRef(Checkbox)
-                            checked={false}
-                            classes={
+                          <span
+                            className="PrivateTabIndicator-root-6 PrivateTabIndicator-colorSecondary-8 MuiTabs-indicator"
+                            style={
                               Object {
-                                "checked": "Mui-checked",
-                                "colorPrimary": "MuiCheckbox-colorPrimary",
-                                "colorSecondary": "MuiCheckbox-colorSecondary",
-                                "disabled": "Mui-disabled",
-                                "indeterminate": "MuiCheckbox-indeterminate",
-                                "root": "MuiCheckbox-root",
+                                "left": 0,
+                                "width": 0,
                               }
                             }
-                            color="secondary"
-                            inputProps={
-                              Object {
-                                "aria-label": "scheduled-maintenance-checkbox-arialabel",
-                              }
+                          />
+                        </ForwardRef(TabIndicator)>
+                      </WithStyles(ForwardRef(TabIndicator))>
+                    </div>
+                  </div>
+                </ForwardRef(Tabs)>
+              </WithStyles(ForwardRef(Tabs))>
+              <div
+                aria-labelledby="maintenance-tab"
+                hidden={false}
+                id="maintenance-panel"
+                role="tabpanel"
+              >
+                <WithStyles(ForwardRef(Paper))
+                  className="AdminPage-paper-3"
+                >
+                  <ForwardRef(Paper)
+                    className="AdminPage-paper-3"
+                    classes={
+                      Object {
+                        "elevation0": "MuiPaper-elevation0",
+                        "elevation1": "MuiPaper-elevation1",
+                        "elevation10": "MuiPaper-elevation10",
+                        "elevation11": "MuiPaper-elevation11",
+                        "elevation12": "MuiPaper-elevation12",
+                        "elevation13": "MuiPaper-elevation13",
+                        "elevation14": "MuiPaper-elevation14",
+                        "elevation15": "MuiPaper-elevation15",
+                        "elevation16": "MuiPaper-elevation16",
+                        "elevation17": "MuiPaper-elevation17",
+                        "elevation18": "MuiPaper-elevation18",
+                        "elevation19": "MuiPaper-elevation19",
+                        "elevation2": "MuiPaper-elevation2",
+                        "elevation20": "MuiPaper-elevation20",
+                        "elevation21": "MuiPaper-elevation21",
+                        "elevation22": "MuiPaper-elevation22",
+                        "elevation23": "MuiPaper-elevation23",
+                        "elevation24": "MuiPaper-elevation24",
+                        "elevation3": "MuiPaper-elevation3",
+                        "elevation4": "MuiPaper-elevation4",
+                        "elevation5": "MuiPaper-elevation5",
+                        "elevation6": "MuiPaper-elevation6",
+                        "elevation7": "MuiPaper-elevation7",
+                        "elevation8": "MuiPaper-elevation8",
+                        "elevation9": "MuiPaper-elevation9",
+                        "outlined": "MuiPaper-outlined",
+                        "root": "MuiPaper-root",
+                        "rounded": "MuiPaper-rounded",
+                      }
+                    }
+                  >
+                    <div
+                      className="MuiPaper-root AdminPage-paper-3 MuiPaper-elevation1 MuiPaper-rounded"
+                    >
+                      <WithStyles(ForwardRef(Typography))
+                        variant="h4"
+                      >
+                        <ForwardRef(Typography)
+                          classes={
+                            Object {
+                              "alignCenter": "MuiTypography-alignCenter",
+                              "alignJustify": "MuiTypography-alignJustify",
+                              "alignLeft": "MuiTypography-alignLeft",
+                              "alignRight": "MuiTypography-alignRight",
+                              "body1": "MuiTypography-body1",
+                              "body2": "MuiTypography-body2",
+                              "button": "MuiTypography-button",
+                              "caption": "MuiTypography-caption",
+                              "colorError": "MuiTypography-colorError",
+                              "colorInherit": "MuiTypography-colorInherit",
+                              "colorPrimary": "MuiTypography-colorPrimary",
+                              "colorSecondary": "MuiTypography-colorSecondary",
+                              "colorTextPrimary": "MuiTypography-colorTextPrimary",
+                              "colorTextSecondary": "MuiTypography-colorTextSecondary",
+                              "displayBlock": "MuiTypography-displayBlock",
+                              "displayInline": "MuiTypography-displayInline",
+                              "gutterBottom": "MuiTypography-gutterBottom",
+                              "h1": "MuiTypography-h1",
+                              "h2": "MuiTypography-h2",
+                              "h3": "MuiTypography-h3",
+                              "h4": "MuiTypography-h4",
+                              "h5": "MuiTypography-h5",
+                              "h6": "MuiTypography-h6",
+                              "noWrap": "MuiTypography-noWrap",
+                              "overline": "MuiTypography-overline",
+                              "paragraph": "MuiTypography-paragraph",
+                              "root": "MuiTypography-root",
+                              "srOnly": "MuiTypography-srOnly",
+                              "subtitle1": "MuiTypography-subtitle1",
+                              "subtitle2": "MuiTypography-subtitle2",
                             }
-                            onChange={[Function]}
-                            value={false}
+                          }
+                          variant="h4"
+                        >
+                          <h4
+                            className="MuiTypography-root MuiTypography-h4"
                           >
-                            <WithStyles(ForwardRef(SwitchBase))
+                            scheduled-maintenance-title
+                          </h4>
+                        </ForwardRef(Typography)>
+                      </WithStyles(ForwardRef(Typography))>
+                      <ForwardRef(TextareaAutosize)
+                        aria-label="scheduled-maintenance-message-arialabel"
+                        className="AdminPage-textArea-5"
+                        onChange={[Function]}
+                        placeholder="message-placeholder"
+                        rows={7}
+                        value=""
+                      >
+                        <textarea
+                          aria-label="scheduled-maintenance-message-arialabel"
+                          className="AdminPage-textArea-5"
+                          onChange={[Function]}
+                          placeholder="message-placeholder"
+                          rows={7}
+                          style={
+                            Object {
+                              "height": -4,
+                              "overflow": "hidden",
+                            }
+                          }
+                          value=""
+                        />
+                        <textarea
+                          aria-hidden={true}
+                          className="AdminPage-textArea-5"
+                          readOnly={true}
+                          style={
+                            Object {
+                              "height": 0,
+                              "left": 0,
+                              "overflow": "hidden",
+                              "position": "absolute",
+                              "top": 0,
+                              "transform": "translateZ(0)",
+                              "visibility": "hidden",
+                            }
+                          }
+                          tabIndex={-1}
+                        />
+                      </ForwardRef(TextareaAutosize)>
+                      <div
+                        style={
+                          Object {
+                            "display": "row",
+                          }
+                        }
+                      >
+                        <WithStyles(ForwardRef(FormControlLabel))
+                          control={
+                            <WithStyles(ForwardRef(Checkbox))
                               checked={false}
-                              checkedIcon={<Memo />}
-                              classes={
-                                Object {
-                                  "checked": "Mui-checked",
-                                  "disabled": "Mui-disabled",
-                                  "root": "MuiCheckbox-root MuiCheckbox-colorSecondary",
-                                }
-                              }
                               color="secondary"
-                              icon={<Memo />}
                               inputProps={
                                 Object {
                                   "aria-label": "scheduled-maintenance-checkbox-arialabel",
-                                  "data-indeterminate": false,
                                 }
                               }
                               onChange={[Function]}
-                              type="checkbox"
-                              value={false}
-                            >
-                              <ForwardRef(SwitchBase)
+                            />
+                          }
+                          label="display-checkbox"
+                          labelPlacement="end"
+                          style={
+                            Object {
+                              "float": "left",
+                            }
+                          }
+                          value={false}
+                        >
+                          <ForwardRef(FormControlLabel)
+                            classes={
+                              Object {
+                                "disabled": "Mui-disabled",
+                                "label": "MuiFormControlLabel-label",
+                                "labelPlacementBottom": "MuiFormControlLabel-labelPlacementBottom",
+                                "labelPlacementStart": "MuiFormControlLabel-labelPlacementStart",
+                                "labelPlacementTop": "MuiFormControlLabel-labelPlacementTop",
+                                "root": "MuiFormControlLabel-root",
+                              }
+                            }
+                            control={
+                              <WithStyles(ForwardRef(Checkbox))
                                 checked={false}
-                                checkedIcon={<Memo />}
-                                classes={
-                                  Object {
-                                    "checked": "PrivateSwitchBase-checked-7 Mui-checked",
-                                    "disabled": "PrivateSwitchBase-disabled-8 Mui-disabled",
-                                    "input": "PrivateSwitchBase-input-9",
-                                    "root": "PrivateSwitchBase-root-6 MuiCheckbox-root MuiCheckbox-colorSecondary",
-                                  }
-                                }
                                 color="secondary"
-                                icon={<Memo />}
                                 inputProps={
                                   Object {
                                     "aria-label": "scheduled-maintenance-checkbox-arialabel",
-                                    "data-indeterminate": false,
                                   }
                                 }
                                 onChange={[Function]}
-                                type="checkbox"
+                              />
+                            }
+                            label="display-checkbox"
+                            labelPlacement="end"
+                            style={
+                              Object {
+                                "float": "left",
+                              }
+                            }
+                            value={false}
+                          >
+                            <label
+                              className="MuiFormControlLabel-root"
+                              style={
+                                Object {
+                                  "float": "left",
+                                }
+                              }
+                            >
+                              <WithStyles(ForwardRef(Checkbox))
+                                checked={false}
+                                color="secondary"
+                                inputProps={
+                                  Object {
+                                    "aria-label": "scheduled-maintenance-checkbox-arialabel",
+                                  }
+                                }
+                                onChange={[Function]}
                                 value={false}
                               >
-                                <WithStyles(ForwardRef(IconButton))
-                                  className="PrivateSwitchBase-root-6 MuiCheckbox-root MuiCheckbox-colorSecondary"
+                                <ForwardRef(Checkbox)
+                                  checked={false}
+                                  classes={
+                                    Object {
+                                      "checked": "Mui-checked",
+                                      "colorPrimary": "MuiCheckbox-colorPrimary",
+                                      "colorSecondary": "MuiCheckbox-colorSecondary",
+                                      "disabled": "Mui-disabled",
+                                      "indeterminate": "MuiCheckbox-indeterminate",
+                                      "root": "MuiCheckbox-root",
+                                    }
+                                  }
                                   color="secondary"
-                                  component="span"
-                                  onBlur={[Function]}
-                                  onFocus={[Function]}
-                                  tabIndex={null}
+                                  inputProps={
+                                    Object {
+                                      "aria-label": "scheduled-maintenance-checkbox-arialabel",
+                                    }
+                                  }
+                                  onChange={[Function]}
+                                  value={false}
                                 >
-                                  <ForwardRef(IconButton)
-                                    className="PrivateSwitchBase-root-6 MuiCheckbox-root MuiCheckbox-colorSecondary"
+                                  <WithStyles(ForwardRef(SwitchBase))
+                                    checked={false}
+                                    checkedIcon={<Memo />}
                                     classes={
                                       Object {
-                                        "colorInherit": "MuiIconButton-colorInherit",
-                                        "colorPrimary": "MuiIconButton-colorPrimary",
-                                        "colorSecondary": "MuiIconButton-colorSecondary",
+                                        "checked": "Mui-checked",
                                         "disabled": "Mui-disabled",
-                                        "edgeEnd": "MuiIconButton-edgeEnd",
-                                        "edgeStart": "MuiIconButton-edgeStart",
-                                        "label": "MuiIconButton-label",
-                                        "root": "MuiIconButton-root",
-                                        "sizeSmall": "MuiIconButton-sizeSmall",
+                                        "root": "MuiCheckbox-root MuiCheckbox-colorSecondary",
                                       }
                                     }
                                     color="secondary"
-                                    component="span"
-                                    onBlur={[Function]}
-                                    onFocus={[Function]}
-                                    tabIndex={null}
+                                    icon={<Memo />}
+                                    inputProps={
+                                      Object {
+                                        "aria-label": "scheduled-maintenance-checkbox-arialabel",
+                                        "data-indeterminate": false,
+                                      }
+                                    }
+                                    onChange={[Function]}
+                                    type="checkbox"
+                                    value={false}
                                   >
-                                    <WithStyles(ForwardRef(ButtonBase))
-                                      centerRipple={true}
-                                      className="MuiIconButton-root PrivateSwitchBase-root-6 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
-                                      component="span"
-                                      disabled={false}
-                                      focusRipple={true}
-                                      onBlur={[Function]}
-                                      onFocus={[Function]}
-                                      tabIndex={null}
-                                    >
-                                      <ForwardRef(ButtonBase)
-                                        centerRipple={true}
-                                        className="MuiIconButton-root PrivateSwitchBase-root-6 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
-                                        classes={
-                                          Object {
-                                            "disabled": "Mui-disabled",
-                                            "focusVisible": "Mui-focusVisible",
-                                            "root": "MuiButtonBase-root",
-                                          }
+                                    <ForwardRef(SwitchBase)
+                                      checked={false}
+                                      checkedIcon={<Memo />}
+                                      classes={
+                                        Object {
+                                          "checked": "PrivateSwitchBase-checked-11 Mui-checked",
+                                          "disabled": "PrivateSwitchBase-disabled-12 Mui-disabled",
+                                          "input": "PrivateSwitchBase-input-13",
+                                          "root": "PrivateSwitchBase-root-10 MuiCheckbox-root MuiCheckbox-colorSecondary",
                                         }
+                                      }
+                                      color="secondary"
+                                      icon={<Memo />}
+                                      inputProps={
+                                        Object {
+                                          "aria-label": "scheduled-maintenance-checkbox-arialabel",
+                                          "data-indeterminate": false,
+                                        }
+                                      }
+                                      onChange={[Function]}
+                                      type="checkbox"
+                                      value={false}
+                                    >
+                                      <WithStyles(ForwardRef(IconButton))
+                                        className="PrivateSwitchBase-root-10 MuiCheckbox-root MuiCheckbox-colorSecondary"
+                                        color="secondary"
                                         component="span"
-                                        disabled={false}
-                                        focusRipple={true}
                                         onBlur={[Function]}
                                         onFocus={[Function]}
                                         tabIndex={null}
                                       >
-                                        <span
-                                          aria-disabled={false}
-                                          className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-6 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
+                                        <ForwardRef(IconButton)
+                                          className="PrivateSwitchBase-root-10 MuiCheckbox-root MuiCheckbox-colorSecondary"
+                                          classes={
+                                            Object {
+                                              "colorInherit": "MuiIconButton-colorInherit",
+                                              "colorPrimary": "MuiIconButton-colorPrimary",
+                                              "colorSecondary": "MuiIconButton-colorSecondary",
+                                              "disabled": "Mui-disabled",
+                                              "edgeEnd": "MuiIconButton-edgeEnd",
+                                              "edgeStart": "MuiIconButton-edgeStart",
+                                              "label": "MuiIconButton-label",
+                                              "root": "MuiIconButton-root",
+                                              "sizeSmall": "MuiIconButton-sizeSmall",
+                                            }
+                                          }
+                                          color="secondary"
+                                          component="span"
                                           onBlur={[Function]}
-                                          onDragLeave={[Function]}
                                           onFocus={[Function]}
-                                          onKeyDown={[Function]}
-                                          onKeyUp={[Function]}
-                                          onMouseDown={[Function]}
-                                          onMouseLeave={[Function]}
-                                          onMouseUp={[Function]}
-                                          onTouchEnd={[Function]}
-                                          onTouchMove={[Function]}
-                                          onTouchStart={[Function]}
                                           tabIndex={null}
                                         >
-                                          <span
-                                            className="MuiIconButton-label"
+                                          <WithStyles(ForwardRef(ButtonBase))
+                                            centerRipple={true}
+                                            className="MuiIconButton-root PrivateSwitchBase-root-10 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
+                                            component="span"
+                                            disabled={false}
+                                            focusRipple={true}
+                                            onBlur={[Function]}
+                                            onFocus={[Function]}
+                                            tabIndex={null}
                                           >
-                                            <input
-                                              aria-label="scheduled-maintenance-checkbox-arialabel"
-                                              checked={false}
-                                              className="PrivateSwitchBase-input-9"
-                                              data-indeterminate={false}
-                                              onChange={[Function]}
-                                              type="checkbox"
-                                              value={false}
-                                            />
-                                            <ForwardRef(CheckBoxOutlineBlankIcon)>
-                                              <WithStyles(ForwardRef(SvgIcon))>
-                                                <ForwardRef(SvgIcon)
-                                                  classes={
-                                                    Object {
-                                                      "colorAction": "MuiSvgIcon-colorAction",
-                                                      "colorDisabled": "MuiSvgIcon-colorDisabled",
-                                                      "colorError": "MuiSvgIcon-colorError",
-                                                      "colorPrimary": "MuiSvgIcon-colorPrimary",
-                                                      "colorSecondary": "MuiSvgIcon-colorSecondary",
-                                                      "fontSizeInherit": "MuiSvgIcon-fontSizeInherit",
-                                                      "fontSizeLarge": "MuiSvgIcon-fontSizeLarge",
-                                                      "fontSizeSmall": "MuiSvgIcon-fontSizeSmall",
-                                                      "root": "MuiSvgIcon-root",
-                                                    }
-                                                  }
-                                                >
-                                                  <svg
-                                                    aria-hidden={true}
-                                                    className="MuiSvgIcon-root"
-                                                    focusable="false"
-                                                    viewBox="0 0 24 24"
-                                                  >
-                                                    <path
-                                                      d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
-                                                    />
-                                                  </svg>
-                                                </ForwardRef(SvgIcon)>
-                                              </WithStyles(ForwardRef(SvgIcon))>
-                                            </ForwardRef(CheckBoxOutlineBlankIcon)>
-                                          </span>
-                                          <WithStyles(memo)
-                                            center={true}
-                                          >
-                                            <ForwardRef(TouchRipple)
-                                              center={true}
+                                            <ForwardRef(ButtonBase)
+                                              centerRipple={true}
+                                              className="MuiIconButton-root PrivateSwitchBase-root-10 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
                                               classes={
                                                 Object {
-                                                  "child": "MuiTouchRipple-child",
-                                                  "childLeaving": "MuiTouchRipple-childLeaving",
-                                                  "childPulsate": "MuiTouchRipple-childPulsate",
-                                                  "ripple": "MuiTouchRipple-ripple",
-                                                  "ripplePulsate": "MuiTouchRipple-ripplePulsate",
-                                                  "rippleVisible": "MuiTouchRipple-rippleVisible",
-                                                  "root": "MuiTouchRipple-root",
+                                                  "disabled": "Mui-disabled",
+                                                  "focusVisible": "Mui-focusVisible",
+                                                  "root": "MuiButtonBase-root",
                                                 }
                                               }
+                                              component="span"
+                                              disabled={false}
+                                              focusRipple={true}
+                                              onBlur={[Function]}
+                                              onFocus={[Function]}
+                                              tabIndex={null}
                                             >
                                               <span
-                                                className="MuiTouchRipple-root"
+                                                aria-disabled={false}
+                                                className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-10 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
+                                                onBlur={[Function]}
+                                                onDragLeave={[Function]}
+                                                onFocus={[Function]}
+                                                onKeyDown={[Function]}
+                                                onKeyUp={[Function]}
+                                                onMouseDown={[Function]}
+                                                onMouseLeave={[Function]}
+                                                onMouseUp={[Function]}
+                                                onTouchEnd={[Function]}
+                                                onTouchMove={[Function]}
+                                                onTouchStart={[Function]}
+                                                tabIndex={null}
                                               >
-                                                <TransitionGroup
-                                                  childFactory={[Function]}
-                                                  component={null}
-                                                  exit={true}
-                                                />
+                                                <span
+                                                  className="MuiIconButton-label"
+                                                >
+                                                  <input
+                                                    aria-label="scheduled-maintenance-checkbox-arialabel"
+                                                    checked={false}
+                                                    className="PrivateSwitchBase-input-13"
+                                                    data-indeterminate={false}
+                                                    onChange={[Function]}
+                                                    type="checkbox"
+                                                    value={false}
+                                                  />
+                                                  <ForwardRef(CheckBoxOutlineBlankIcon)>
+                                                    <WithStyles(ForwardRef(SvgIcon))>
+                                                      <ForwardRef(SvgIcon)
+                                                        classes={
+                                                          Object {
+                                                            "colorAction": "MuiSvgIcon-colorAction",
+                                                            "colorDisabled": "MuiSvgIcon-colorDisabled",
+                                                            "colorError": "MuiSvgIcon-colorError",
+                                                            "colorPrimary": "MuiSvgIcon-colorPrimary",
+                                                            "colorSecondary": "MuiSvgIcon-colorSecondary",
+                                                            "fontSizeInherit": "MuiSvgIcon-fontSizeInherit",
+                                                            "fontSizeLarge": "MuiSvgIcon-fontSizeLarge",
+                                                            "fontSizeSmall": "MuiSvgIcon-fontSizeSmall",
+                                                            "root": "MuiSvgIcon-root",
+                                                          }
+                                                        }
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          className="MuiSvgIcon-root"
+                                                          focusable="false"
+                                                          viewBox="0 0 24 24"
+                                                        >
+                                                          <path
+                                                            d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                                                          />
+                                                        </svg>
+                                                      </ForwardRef(SvgIcon)>
+                                                    </WithStyles(ForwardRef(SvgIcon))>
+                                                  </ForwardRef(CheckBoxOutlineBlankIcon)>
+                                                </span>
+                                                <WithStyles(memo)
+                                                  center={true}
+                                                >
+                                                  <ForwardRef(TouchRipple)
+                                                    center={true}
+                                                    classes={
+                                                      Object {
+                                                        "child": "MuiTouchRipple-child",
+                                                        "childLeaving": "MuiTouchRipple-childLeaving",
+                                                        "childPulsate": "MuiTouchRipple-childPulsate",
+                                                        "ripple": "MuiTouchRipple-ripple",
+                                                        "ripplePulsate": "MuiTouchRipple-ripplePulsate",
+                                                        "rippleVisible": "MuiTouchRipple-rippleVisible",
+                                                        "root": "MuiTouchRipple-root",
+                                                      }
+                                                    }
+                                                  >
+                                                    <span
+                                                      className="MuiTouchRipple-root"
+                                                    >
+                                                      <TransitionGroup
+                                                        childFactory={[Function]}
+                                                        component={null}
+                                                        exit={true}
+                                                      />
+                                                    </span>
+                                                  </ForwardRef(TouchRipple)>
+                                                </WithStyles(memo)>
                                               </span>
-                                            </ForwardRef(TouchRipple)>
-                                          </WithStyles(memo)>
-                                        </span>
-                                      </ForwardRef(ButtonBase)>
-                                    </WithStyles(ForwardRef(ButtonBase))>
-                                  </ForwardRef(IconButton)>
-                                </WithStyles(ForwardRef(IconButton))>
-                              </ForwardRef(SwitchBase)>
-                            </WithStyles(ForwardRef(SwitchBase))>
-                          </ForwardRef(Checkbox)>
-                        </WithStyles(ForwardRef(Checkbox))>
-                        <WithStyles(ForwardRef(Typography))
-                          className="MuiFormControlLabel-label"
-                          component="span"
-                        >
-                          <ForwardRef(Typography)
-                            className="MuiFormControlLabel-label"
-                            classes={
-                              Object {
-                                "alignCenter": "MuiTypography-alignCenter",
-                                "alignJustify": "MuiTypography-alignJustify",
-                                "alignLeft": "MuiTypography-alignLeft",
-                                "alignRight": "MuiTypography-alignRight",
-                                "body1": "MuiTypography-body1",
-                                "body2": "MuiTypography-body2",
-                                "button": "MuiTypography-button",
-                                "caption": "MuiTypography-caption",
-                                "colorError": "MuiTypography-colorError",
-                                "colorInherit": "MuiTypography-colorInherit",
-                                "colorPrimary": "MuiTypography-colorPrimary",
-                                "colorSecondary": "MuiTypography-colorSecondary",
-                                "colorTextPrimary": "MuiTypography-colorTextPrimary",
-                                "colorTextSecondary": "MuiTypography-colorTextSecondary",
-                                "displayBlock": "MuiTypography-displayBlock",
-                                "displayInline": "MuiTypography-displayInline",
-                                "gutterBottom": "MuiTypography-gutterBottom",
-                                "h1": "MuiTypography-h1",
-                                "h2": "MuiTypography-h2",
-                                "h3": "MuiTypography-h3",
-                                "h4": "MuiTypography-h4",
-                                "h5": "MuiTypography-h5",
-                                "h6": "MuiTypography-h6",
-                                "noWrap": "MuiTypography-noWrap",
-                                "overline": "MuiTypography-overline",
-                                "paragraph": "MuiTypography-paragraph",
-                                "root": "MuiTypography-root",
-                                "srOnly": "MuiTypography-srOnly",
-                                "subtitle1": "MuiTypography-subtitle1",
-                                "subtitle2": "MuiTypography-subtitle2",
-                              }
-                            }
-                            component="span"
-                          >
-                            <span
-                              className="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
-                            >
-                              display-checkbox
-                            </span>
-                          </ForwardRef(Typography)>
-                        </WithStyles(ForwardRef(Typography))>
-                      </label>
-                    </ForwardRef(FormControlLabel)>
-                  </WithStyles(ForwardRef(FormControlLabel))>
-                  <WithStyles(ForwardRef(Button))
-                    color="primary"
-                    onClick={[Function]}
-                    style={
-                      Object {
-                        "float": "right",
-                      }
-                    }
-                    variant="contained"
-                  >
-                    <ForwardRef(Button)
-                      classes={
-                        Object {
-                          "colorInherit": "MuiButton-colorInherit",
-                          "contained": "MuiButton-contained",
-                          "containedPrimary": "MuiButton-containedPrimary",
-                          "containedSecondary": "MuiButton-containedSecondary",
-                          "containedSizeLarge": "MuiButton-containedSizeLarge",
-                          "containedSizeSmall": "MuiButton-containedSizeSmall",
-                          "disableElevation": "MuiButton-disableElevation",
-                          "disabled": "Mui-disabled",
-                          "endIcon": "MuiButton-endIcon",
-                          "focusVisible": "Mui-focusVisible",
-                          "fullWidth": "MuiButton-fullWidth",
-                          "iconSizeLarge": "MuiButton-iconSizeLarge",
-                          "iconSizeMedium": "MuiButton-iconSizeMedium",
-                          "iconSizeSmall": "MuiButton-iconSizeSmall",
-                          "label": "MuiButton-label",
-                          "outlined": "MuiButton-outlined",
-                          "outlinedPrimary": "MuiButton-outlinedPrimary",
-                          "outlinedSecondary": "MuiButton-outlinedSecondary",
-                          "outlinedSizeLarge": "MuiButton-outlinedSizeLarge",
-                          "outlinedSizeSmall": "MuiButton-outlinedSizeSmall",
-                          "root": "MuiButton-root",
-                          "sizeLarge": "MuiButton-sizeLarge",
-                          "sizeSmall": "MuiButton-sizeSmall",
-                          "startIcon": "MuiButton-startIcon",
-                          "text": "MuiButton-text",
-                          "textPrimary": "MuiButton-textPrimary",
-                          "textSecondary": "MuiButton-textSecondary",
-                          "textSizeLarge": "MuiButton-textSizeLarge",
-                          "textSizeSmall": "MuiButton-textSizeSmall",
-                        }
-                      }
-                      color="primary"
-                      onClick={[Function]}
-                      style={
-                        Object {
-                          "float": "right",
-                        }
-                      }
-                      variant="contained"
-                    >
-                      <WithStyles(ForwardRef(ButtonBase))
-                        className="MuiButton-root MuiButton-contained MuiButton-containedPrimary"
-                        component="button"
-                        disabled={false}
-                        focusRipple={true}
-                        focusVisibleClassName="Mui-focusVisible"
-                        onClick={[Function]}
-                        style={
-                          Object {
-                            "float": "right",
-                          }
-                        }
-                        type="button"
-                      >
-                        <ForwardRef(ButtonBase)
-                          className="MuiButton-root MuiButton-contained MuiButton-containedPrimary"
-                          classes={
-                            Object {
-                              "disabled": "Mui-disabled",
-                              "focusVisible": "Mui-focusVisible",
-                              "root": "MuiButtonBase-root",
-                            }
-                          }
-                          component="button"
-                          disabled={false}
-                          focusRipple={true}
-                          focusVisibleClassName="Mui-focusVisible"
-                          onClick={[Function]}
-                          style={
-                            Object {
-                              "float": "right",
-                            }
-                          }
-                          type="button"
-                        >
-                          <button
-                            className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"
-                            disabled={false}
-                            onBlur={[Function]}
-                            onClick={[Function]}
-                            onDragLeave={[Function]}
-                            onFocus={[Function]}
-                            onKeyDown={[Function]}
-                            onKeyUp={[Function]}
-                            onMouseDown={[Function]}
-                            onMouseLeave={[Function]}
-                            onMouseUp={[Function]}
-                            onTouchEnd={[Function]}
-                            onTouchMove={[Function]}
-                            onTouchStart={[Function]}
-                            style={
-                              Object {
-                                "float": "right",
-                              }
-                            }
-                            tabIndex={0}
-                            type="button"
-                          >
-                            <span
-                              className="MuiButton-label"
-                            >
+                                            </ForwardRef(ButtonBase)>
+                                          </WithStyles(ForwardRef(ButtonBase))>
+                                        </ForwardRef(IconButton)>
+                                      </WithStyles(ForwardRef(IconButton))>
+                                    </ForwardRef(SwitchBase)>
+                                  </WithStyles(ForwardRef(SwitchBase))>
+                                </ForwardRef(Checkbox)>
+                              </WithStyles(ForwardRef(Checkbox))>
                               <WithStyles(ForwardRef(Typography))
-                                color="inherit"
-                                noWrap={true}
-                                style={
-                                  Object {
-                                    "marginTop": 3,
-                                  }
-                                }
+                                className="MuiFormControlLabel-label"
+                                component="span"
                               >
                                 <ForwardRef(Typography)
+                                  className="MuiFormControlLabel-label"
                                   classes={
                                     Object {
                                       "alignCenter": "MuiTypography-alignCenter",
@@ -743,666 +1063,666 @@ exports[`Admin page component should render correctly 1`] = `
                                       "subtitle2": "MuiTypography-subtitle2",
                                     }
                                   }
-                                  color="inherit"
-                                  noWrap={true}
-                                  style={
-                                    Object {
-                                      "marginTop": 3,
-                                    }
-                                  }
+                                  component="span"
                                 >
-                                  <p
-                                    className="MuiTypography-root MuiTypography-body1 MuiTypography-colorInherit MuiTypography-noWrap"
-                                    style={
-                                      Object {
-                                        "marginTop": 3,
-                                      }
-                                    }
+                                  <span
+                                    className="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
                                   >
-                                    save-button
-                                  </p>
+                                    display-checkbox
+                                  </span>
                                 </ForwardRef(Typography)>
                               </WithStyles(ForwardRef(Typography))>
-                            </span>
-                            <WithStyles(memo)
-                              center={false}
-                            >
-                              <ForwardRef(TouchRipple)
-                                center={false}
-                                classes={
-                                  Object {
-                                    "child": "MuiTouchRipple-child",
-                                    "childLeaving": "MuiTouchRipple-childLeaving",
-                                    "childPulsate": "MuiTouchRipple-childPulsate",
-                                    "ripple": "MuiTouchRipple-ripple",
-                                    "ripplePulsate": "MuiTouchRipple-ripplePulsate",
-                                    "rippleVisible": "MuiTouchRipple-rippleVisible",
-                                    "root": "MuiTouchRipple-root",
-                                  }
-                                }
-                              >
-                                <span
-                                  className="MuiTouchRipple-root"
-                                >
-                                  <TransitionGroup
-                                    childFactory={[Function]}
-                                    component={null}
-                                    exit={true}
-                                  />
-                                </span>
-                              </ForwardRef(TouchRipple)>
-                            </WithStyles(memo)>
-                          </button>
-                        </ForwardRef(ButtonBase)>
-                      </WithStyles(ForwardRef(ButtonBase))>
-                    </ForwardRef(Button)>
-                  </WithStyles(ForwardRef(Button))>
-                </div>
-              </div>
-            </ForwardRef(Paper)>
-          </WithStyles(ForwardRef(Paper))>
-          <WithStyles(ForwardRef(Paper))
-            className="AdminPage-paper-3"
-          >
-            <ForwardRef(Paper)
-              className="AdminPage-paper-3"
-              classes={
-                Object {
-                  "elevation0": "MuiPaper-elevation0",
-                  "elevation1": "MuiPaper-elevation1",
-                  "elevation10": "MuiPaper-elevation10",
-                  "elevation11": "MuiPaper-elevation11",
-                  "elevation12": "MuiPaper-elevation12",
-                  "elevation13": "MuiPaper-elevation13",
-                  "elevation14": "MuiPaper-elevation14",
-                  "elevation15": "MuiPaper-elevation15",
-                  "elevation16": "MuiPaper-elevation16",
-                  "elevation17": "MuiPaper-elevation17",
-                  "elevation18": "MuiPaper-elevation18",
-                  "elevation19": "MuiPaper-elevation19",
-                  "elevation2": "MuiPaper-elevation2",
-                  "elevation20": "MuiPaper-elevation20",
-                  "elevation21": "MuiPaper-elevation21",
-                  "elevation22": "MuiPaper-elevation22",
-                  "elevation23": "MuiPaper-elevation23",
-                  "elevation24": "MuiPaper-elevation24",
-                  "elevation3": "MuiPaper-elevation3",
-                  "elevation4": "MuiPaper-elevation4",
-                  "elevation5": "MuiPaper-elevation5",
-                  "elevation6": "MuiPaper-elevation6",
-                  "elevation7": "MuiPaper-elevation7",
-                  "elevation8": "MuiPaper-elevation8",
-                  "elevation9": "MuiPaper-elevation9",
-                  "outlined": "MuiPaper-outlined",
-                  "root": "MuiPaper-root",
-                  "rounded": "MuiPaper-rounded",
-                }
-              }
-            >
-              <div
-                className="MuiPaper-root AdminPage-paper-3 MuiPaper-elevation1 MuiPaper-rounded"
-              >
-                <WithStyles(ForwardRef(Typography))
-                  variant="h4"
-                >
-                  <ForwardRef(Typography)
-                    classes={
-                      Object {
-                        "alignCenter": "MuiTypography-alignCenter",
-                        "alignJustify": "MuiTypography-alignJustify",
-                        "alignLeft": "MuiTypography-alignLeft",
-                        "alignRight": "MuiTypography-alignRight",
-                        "body1": "MuiTypography-body1",
-                        "body2": "MuiTypography-body2",
-                        "button": "MuiTypography-button",
-                        "caption": "MuiTypography-caption",
-                        "colorError": "MuiTypography-colorError",
-                        "colorInherit": "MuiTypography-colorInherit",
-                        "colorPrimary": "MuiTypography-colorPrimary",
-                        "colorSecondary": "MuiTypography-colorSecondary",
-                        "colorTextPrimary": "MuiTypography-colorTextPrimary",
-                        "colorTextSecondary": "MuiTypography-colorTextSecondary",
-                        "displayBlock": "MuiTypography-displayBlock",
-                        "displayInline": "MuiTypography-displayInline",
-                        "gutterBottom": "MuiTypography-gutterBottom",
-                        "h1": "MuiTypography-h1",
-                        "h2": "MuiTypography-h2",
-                        "h3": "MuiTypography-h3",
-                        "h4": "MuiTypography-h4",
-                        "h5": "MuiTypography-h5",
-                        "h6": "MuiTypography-h6",
-                        "noWrap": "MuiTypography-noWrap",
-                        "overline": "MuiTypography-overline",
-                        "paragraph": "MuiTypography-paragraph",
-                        "root": "MuiTypography-root",
-                        "srOnly": "MuiTypography-srOnly",
-                        "subtitle1": "MuiTypography-subtitle1",
-                        "subtitle2": "MuiTypography-subtitle2",
-                      }
-                    }
-                    variant="h4"
-                  >
-                    <h4
-                      className="MuiTypography-root MuiTypography-h4"
-                    >
-                      maintenance-title
-                    </h4>
-                  </ForwardRef(Typography)>
-                </WithStyles(ForwardRef(Typography))>
-                <ForwardRef(TextareaAutosize)
-                  aria-label="maintenance-message-arialabel"
-                  className="AdminPage-textArea-5"
-                  onChange={[Function]}
-                  placeholder="message-placeholder"
-                  rows={7}
-                  value=""
-                >
-                  <textarea
-                    aria-label="maintenance-message-arialabel"
-                    className="AdminPage-textArea-5"
-                    onChange={[Function]}
-                    placeholder="message-placeholder"
-                    rows={7}
-                    style={
-                      Object {
-                        "height": -4,
-                        "overflow": "hidden",
-                      }
-                    }
-                    value=""
-                  />
-                  <textarea
-                    aria-hidden={true}
-                    className="AdminPage-textArea-5"
-                    readOnly={true}
-                    style={
-                      Object {
-                        "height": 0,
-                        "left": 0,
-                        "overflow": "hidden",
-                        "position": "absolute",
-                        "top": 0,
-                        "transform": "translateZ(0)",
-                        "visibility": "hidden",
-                      }
-                    }
-                    tabIndex={-1}
-                  />
-                </ForwardRef(TextareaAutosize)>
-                <div
-                  style={
-                    Object {
-                      "display": "row",
-                    }
-                  }
-                >
-                  <WithStyles(ForwardRef(FormControlLabel))
-                    control={
-                      <WithStyles(ForwardRef(Checkbox))
-                        checked={false}
-                        color="secondary"
-                        inputProps={
-                          Object {
-                            "aria-label": "maintenance-checkbox-arialabel",
-                          }
-                        }
-                        onChange={[Function]}
-                      />
-                    }
-                    label="display-checkbox"
-                    labelPlacement="end"
-                    style={
-                      Object {
-                        "float": "left",
-                      }
-                    }
-                    value={false}
-                  >
-                    <ForwardRef(FormControlLabel)
-                      classes={
-                        Object {
-                          "disabled": "Mui-disabled",
-                          "label": "MuiFormControlLabel-label",
-                          "labelPlacementBottom": "MuiFormControlLabel-labelPlacementBottom",
-                          "labelPlacementStart": "MuiFormControlLabel-labelPlacementStart",
-                          "labelPlacementTop": "MuiFormControlLabel-labelPlacementTop",
-                          "root": "MuiFormControlLabel-root",
-                        }
-                      }
-                      control={
-                        <WithStyles(ForwardRef(Checkbox))
-                          checked={false}
-                          color="secondary"
-                          inputProps={
+                            </label>
+                          </ForwardRef(FormControlLabel)>
+                        </WithStyles(ForwardRef(FormControlLabel))>
+                        <WithStyles(ForwardRef(Button))
+                          color="primary"
+                          onClick={[Function]}
+                          style={
                             Object {
-                              "aria-label": "maintenance-checkbox-arialabel",
+                              "float": "right",
                             }
                           }
-                          onChange={[Function]}
-                        />
+                          variant="contained"
+                        >
+                          <ForwardRef(Button)
+                            classes={
+                              Object {
+                                "colorInherit": "MuiButton-colorInherit",
+                                "contained": "MuiButton-contained",
+                                "containedPrimary": "MuiButton-containedPrimary",
+                                "containedSecondary": "MuiButton-containedSecondary",
+                                "containedSizeLarge": "MuiButton-containedSizeLarge",
+                                "containedSizeSmall": "MuiButton-containedSizeSmall",
+                                "disableElevation": "MuiButton-disableElevation",
+                                "disabled": "Mui-disabled",
+                                "endIcon": "MuiButton-endIcon",
+                                "focusVisible": "Mui-focusVisible",
+                                "fullWidth": "MuiButton-fullWidth",
+                                "iconSizeLarge": "MuiButton-iconSizeLarge",
+                                "iconSizeMedium": "MuiButton-iconSizeMedium",
+                                "iconSizeSmall": "MuiButton-iconSizeSmall",
+                                "label": "MuiButton-label",
+                                "outlined": "MuiButton-outlined",
+                                "outlinedPrimary": "MuiButton-outlinedPrimary",
+                                "outlinedSecondary": "MuiButton-outlinedSecondary",
+                                "outlinedSizeLarge": "MuiButton-outlinedSizeLarge",
+                                "outlinedSizeSmall": "MuiButton-outlinedSizeSmall",
+                                "root": "MuiButton-root",
+                                "sizeLarge": "MuiButton-sizeLarge",
+                                "sizeSmall": "MuiButton-sizeSmall",
+                                "startIcon": "MuiButton-startIcon",
+                                "text": "MuiButton-text",
+                                "textPrimary": "MuiButton-textPrimary",
+                                "textSecondary": "MuiButton-textSecondary",
+                                "textSizeLarge": "MuiButton-textSizeLarge",
+                                "textSizeSmall": "MuiButton-textSizeSmall",
+                              }
+                            }
+                            color="primary"
+                            onClick={[Function]}
+                            style={
+                              Object {
+                                "float": "right",
+                              }
+                            }
+                            variant="contained"
+                          >
+                            <WithStyles(ForwardRef(ButtonBase))
+                              className="MuiButton-root MuiButton-contained MuiButton-containedPrimary"
+                              component="button"
+                              disabled={false}
+                              focusRipple={true}
+                              focusVisibleClassName="Mui-focusVisible"
+                              onClick={[Function]}
+                              style={
+                                Object {
+                                  "float": "right",
+                                }
+                              }
+                              type="button"
+                            >
+                              <ForwardRef(ButtonBase)
+                                className="MuiButton-root MuiButton-contained MuiButton-containedPrimary"
+                                classes={
+                                  Object {
+                                    "disabled": "Mui-disabled",
+                                    "focusVisible": "Mui-focusVisible",
+                                    "root": "MuiButtonBase-root",
+                                  }
+                                }
+                                component="button"
+                                disabled={false}
+                                focusRipple={true}
+                                focusVisibleClassName="Mui-focusVisible"
+                                onClick={[Function]}
+                                style={
+                                  Object {
+                                    "float": "right",
+                                  }
+                                }
+                                type="button"
+                              >
+                                <button
+                                  className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"
+                                  disabled={false}
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onDragLeave={[Function]}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onKeyUp={[Function]}
+                                  onMouseDown={[Function]}
+                                  onMouseLeave={[Function]}
+                                  onMouseUp={[Function]}
+                                  onTouchEnd={[Function]}
+                                  onTouchMove={[Function]}
+                                  onTouchStart={[Function]}
+                                  style={
+                                    Object {
+                                      "float": "right",
+                                    }
+                                  }
+                                  tabIndex={0}
+                                  type="button"
+                                >
+                                  <span
+                                    className="MuiButton-label"
+                                  >
+                                    <WithStyles(ForwardRef(Typography))
+                                      color="inherit"
+                                      noWrap={true}
+                                      style={
+                                        Object {
+                                          "marginTop": 3,
+                                        }
+                                      }
+                                    >
+                                      <ForwardRef(Typography)
+                                        classes={
+                                          Object {
+                                            "alignCenter": "MuiTypography-alignCenter",
+                                            "alignJustify": "MuiTypography-alignJustify",
+                                            "alignLeft": "MuiTypography-alignLeft",
+                                            "alignRight": "MuiTypography-alignRight",
+                                            "body1": "MuiTypography-body1",
+                                            "body2": "MuiTypography-body2",
+                                            "button": "MuiTypography-button",
+                                            "caption": "MuiTypography-caption",
+                                            "colorError": "MuiTypography-colorError",
+                                            "colorInherit": "MuiTypography-colorInherit",
+                                            "colorPrimary": "MuiTypography-colorPrimary",
+                                            "colorSecondary": "MuiTypography-colorSecondary",
+                                            "colorTextPrimary": "MuiTypography-colorTextPrimary",
+                                            "colorTextSecondary": "MuiTypography-colorTextSecondary",
+                                            "displayBlock": "MuiTypography-displayBlock",
+                                            "displayInline": "MuiTypography-displayInline",
+                                            "gutterBottom": "MuiTypography-gutterBottom",
+                                            "h1": "MuiTypography-h1",
+                                            "h2": "MuiTypography-h2",
+                                            "h3": "MuiTypography-h3",
+                                            "h4": "MuiTypography-h4",
+                                            "h5": "MuiTypography-h5",
+                                            "h6": "MuiTypography-h6",
+                                            "noWrap": "MuiTypography-noWrap",
+                                            "overline": "MuiTypography-overline",
+                                            "paragraph": "MuiTypography-paragraph",
+                                            "root": "MuiTypography-root",
+                                            "srOnly": "MuiTypography-srOnly",
+                                            "subtitle1": "MuiTypography-subtitle1",
+                                            "subtitle2": "MuiTypography-subtitle2",
+                                          }
+                                        }
+                                        color="inherit"
+                                        noWrap={true}
+                                        style={
+                                          Object {
+                                            "marginTop": 3,
+                                          }
+                                        }
+                                      >
+                                        <p
+                                          className="MuiTypography-root MuiTypography-body1 MuiTypography-colorInherit MuiTypography-noWrap"
+                                          style={
+                                            Object {
+                                              "marginTop": 3,
+                                            }
+                                          }
+                                        >
+                                          save-button
+                                        </p>
+                                      </ForwardRef(Typography)>
+                                    </WithStyles(ForwardRef(Typography))>
+                                  </span>
+                                  <WithStyles(memo)
+                                    center={false}
+                                  >
+                                    <ForwardRef(TouchRipple)
+                                      center={false}
+                                      classes={
+                                        Object {
+                                          "child": "MuiTouchRipple-child",
+                                          "childLeaving": "MuiTouchRipple-childLeaving",
+                                          "childPulsate": "MuiTouchRipple-childPulsate",
+                                          "ripple": "MuiTouchRipple-ripple",
+                                          "ripplePulsate": "MuiTouchRipple-ripplePulsate",
+                                          "rippleVisible": "MuiTouchRipple-rippleVisible",
+                                          "root": "MuiTouchRipple-root",
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        className="MuiTouchRipple-root"
+                                      >
+                                        <TransitionGroup
+                                          childFactory={[Function]}
+                                          component={null}
+                                          exit={true}
+                                        />
+                                      </span>
+                                    </ForwardRef(TouchRipple)>
+                                  </WithStyles(memo)>
+                                </button>
+                              </ForwardRef(ButtonBase)>
+                            </WithStyles(ForwardRef(ButtonBase))>
+                          </ForwardRef(Button)>
+                        </WithStyles(ForwardRef(Button))>
+                      </div>
+                    </div>
+                  </ForwardRef(Paper)>
+                </WithStyles(ForwardRef(Paper))>
+                <WithStyles(ForwardRef(Paper))
+                  className="AdminPage-paper-3"
+                >
+                  <ForwardRef(Paper)
+                    className="AdminPage-paper-3"
+                    classes={
+                      Object {
+                        "elevation0": "MuiPaper-elevation0",
+                        "elevation1": "MuiPaper-elevation1",
+                        "elevation10": "MuiPaper-elevation10",
+                        "elevation11": "MuiPaper-elevation11",
+                        "elevation12": "MuiPaper-elevation12",
+                        "elevation13": "MuiPaper-elevation13",
+                        "elevation14": "MuiPaper-elevation14",
+                        "elevation15": "MuiPaper-elevation15",
+                        "elevation16": "MuiPaper-elevation16",
+                        "elevation17": "MuiPaper-elevation17",
+                        "elevation18": "MuiPaper-elevation18",
+                        "elevation19": "MuiPaper-elevation19",
+                        "elevation2": "MuiPaper-elevation2",
+                        "elevation20": "MuiPaper-elevation20",
+                        "elevation21": "MuiPaper-elevation21",
+                        "elevation22": "MuiPaper-elevation22",
+                        "elevation23": "MuiPaper-elevation23",
+                        "elevation24": "MuiPaper-elevation24",
+                        "elevation3": "MuiPaper-elevation3",
+                        "elevation4": "MuiPaper-elevation4",
+                        "elevation5": "MuiPaper-elevation5",
+                        "elevation6": "MuiPaper-elevation6",
+                        "elevation7": "MuiPaper-elevation7",
+                        "elevation8": "MuiPaper-elevation8",
+                        "elevation9": "MuiPaper-elevation9",
+                        "outlined": "MuiPaper-outlined",
+                        "root": "MuiPaper-root",
+                        "rounded": "MuiPaper-rounded",
                       }
-                      label="display-checkbox"
-                      labelPlacement="end"
-                      style={
-                        Object {
-                          "float": "left",
-                        }
-                      }
-                      value={false}
+                    }
+                  >
+                    <div
+                      className="MuiPaper-root AdminPage-paper-3 MuiPaper-elevation1 MuiPaper-rounded"
                     >
-                      <label
-                        className="MuiFormControlLabel-root"
+                      <WithStyles(ForwardRef(Typography))
+                        variant="h4"
+                      >
+                        <ForwardRef(Typography)
+                          classes={
+                            Object {
+                              "alignCenter": "MuiTypography-alignCenter",
+                              "alignJustify": "MuiTypography-alignJustify",
+                              "alignLeft": "MuiTypography-alignLeft",
+                              "alignRight": "MuiTypography-alignRight",
+                              "body1": "MuiTypography-body1",
+                              "body2": "MuiTypography-body2",
+                              "button": "MuiTypography-button",
+                              "caption": "MuiTypography-caption",
+                              "colorError": "MuiTypography-colorError",
+                              "colorInherit": "MuiTypography-colorInherit",
+                              "colorPrimary": "MuiTypography-colorPrimary",
+                              "colorSecondary": "MuiTypography-colorSecondary",
+                              "colorTextPrimary": "MuiTypography-colorTextPrimary",
+                              "colorTextSecondary": "MuiTypography-colorTextSecondary",
+                              "displayBlock": "MuiTypography-displayBlock",
+                              "displayInline": "MuiTypography-displayInline",
+                              "gutterBottom": "MuiTypography-gutterBottom",
+                              "h1": "MuiTypography-h1",
+                              "h2": "MuiTypography-h2",
+                              "h3": "MuiTypography-h3",
+                              "h4": "MuiTypography-h4",
+                              "h5": "MuiTypography-h5",
+                              "h6": "MuiTypography-h6",
+                              "noWrap": "MuiTypography-noWrap",
+                              "overline": "MuiTypography-overline",
+                              "paragraph": "MuiTypography-paragraph",
+                              "root": "MuiTypography-root",
+                              "srOnly": "MuiTypography-srOnly",
+                              "subtitle1": "MuiTypography-subtitle1",
+                              "subtitle2": "MuiTypography-subtitle2",
+                            }
+                          }
+                          variant="h4"
+                        >
+                          <h4
+                            className="MuiTypography-root MuiTypography-h4"
+                          >
+                            maintenance-title
+                          </h4>
+                        </ForwardRef(Typography)>
+                      </WithStyles(ForwardRef(Typography))>
+                      <ForwardRef(TextareaAutosize)
+                        aria-label="maintenance-message-arialabel"
+                        className="AdminPage-textArea-5"
+                        onChange={[Function]}
+                        placeholder="message-placeholder"
+                        rows={7}
+                        value=""
+                      >
+                        <textarea
+                          aria-label="maintenance-message-arialabel"
+                          className="AdminPage-textArea-5"
+                          onChange={[Function]}
+                          placeholder="message-placeholder"
+                          rows={7}
+                          style={
+                            Object {
+                              "height": -4,
+                              "overflow": "hidden",
+                            }
+                          }
+                          value=""
+                        />
+                        <textarea
+                          aria-hidden={true}
+                          className="AdminPage-textArea-5"
+                          readOnly={true}
+                          style={
+                            Object {
+                              "height": 0,
+                              "left": 0,
+                              "overflow": "hidden",
+                              "position": "absolute",
+                              "top": 0,
+                              "transform": "translateZ(0)",
+                              "visibility": "hidden",
+                            }
+                          }
+                          tabIndex={-1}
+                        />
+                      </ForwardRef(TextareaAutosize)>
+                      <div
                         style={
                           Object {
-                            "float": "left",
+                            "display": "row",
                           }
                         }
                       >
-                        <WithStyles(ForwardRef(Checkbox))
-                          checked={false}
-                          color="secondary"
-                          inputProps={
-                            Object {
-                              "aria-label": "maintenance-checkbox-arialabel",
-                            }
-                          }
-                          onChange={[Function]}
-                          value={false}
-                        >
-                          <ForwardRef(Checkbox)
-                            checked={false}
-                            classes={
-                              Object {
-                                "checked": "Mui-checked",
-                                "colorPrimary": "MuiCheckbox-colorPrimary",
-                                "colorSecondary": "MuiCheckbox-colorSecondary",
-                                "disabled": "Mui-disabled",
-                                "indeterminate": "MuiCheckbox-indeterminate",
-                                "root": "MuiCheckbox-root",
-                              }
-                            }
-                            color="secondary"
-                            inputProps={
-                              Object {
-                                "aria-label": "maintenance-checkbox-arialabel",
-                              }
-                            }
-                            onChange={[Function]}
-                            value={false}
-                          >
-                            <WithStyles(ForwardRef(SwitchBase))
+                        <WithStyles(ForwardRef(FormControlLabel))
+                          control={
+                            <WithStyles(ForwardRef(Checkbox))
                               checked={false}
-                              checkedIcon={<Memo />}
-                              classes={
-                                Object {
-                                  "checked": "Mui-checked",
-                                  "disabled": "Mui-disabled",
-                                  "root": "MuiCheckbox-root MuiCheckbox-colorSecondary",
-                                }
-                              }
                               color="secondary"
-                              icon={<Memo />}
                               inputProps={
                                 Object {
                                   "aria-label": "maintenance-checkbox-arialabel",
-                                  "data-indeterminate": false,
                                 }
                               }
                               onChange={[Function]}
-                              type="checkbox"
-                              value={false}
-                            >
-                              <ForwardRef(SwitchBase)
+                            />
+                          }
+                          label="display-checkbox"
+                          labelPlacement="end"
+                          style={
+                            Object {
+                              "float": "left",
+                            }
+                          }
+                          value={false}
+                        >
+                          <ForwardRef(FormControlLabel)
+                            classes={
+                              Object {
+                                "disabled": "Mui-disabled",
+                                "label": "MuiFormControlLabel-label",
+                                "labelPlacementBottom": "MuiFormControlLabel-labelPlacementBottom",
+                                "labelPlacementStart": "MuiFormControlLabel-labelPlacementStart",
+                                "labelPlacementTop": "MuiFormControlLabel-labelPlacementTop",
+                                "root": "MuiFormControlLabel-root",
+                              }
+                            }
+                            control={
+                              <WithStyles(ForwardRef(Checkbox))
                                 checked={false}
-                                checkedIcon={<Memo />}
-                                classes={
-                                  Object {
-                                    "checked": "PrivateSwitchBase-checked-7 Mui-checked",
-                                    "disabled": "PrivateSwitchBase-disabled-8 Mui-disabled",
-                                    "input": "PrivateSwitchBase-input-9",
-                                    "root": "PrivateSwitchBase-root-6 MuiCheckbox-root MuiCheckbox-colorSecondary",
-                                  }
-                                }
                                 color="secondary"
-                                icon={<Memo />}
                                 inputProps={
                                   Object {
                                     "aria-label": "maintenance-checkbox-arialabel",
-                                    "data-indeterminate": false,
                                   }
                                 }
                                 onChange={[Function]}
-                                type="checkbox"
+                              />
+                            }
+                            label="display-checkbox"
+                            labelPlacement="end"
+                            style={
+                              Object {
+                                "float": "left",
+                              }
+                            }
+                            value={false}
+                          >
+                            <label
+                              className="MuiFormControlLabel-root"
+                              style={
+                                Object {
+                                  "float": "left",
+                                }
+                              }
+                            >
+                              <WithStyles(ForwardRef(Checkbox))
+                                checked={false}
+                                color="secondary"
+                                inputProps={
+                                  Object {
+                                    "aria-label": "maintenance-checkbox-arialabel",
+                                  }
+                                }
+                                onChange={[Function]}
                                 value={false}
                               >
-                                <WithStyles(ForwardRef(IconButton))
-                                  className="PrivateSwitchBase-root-6 MuiCheckbox-root MuiCheckbox-colorSecondary"
+                                <ForwardRef(Checkbox)
+                                  checked={false}
+                                  classes={
+                                    Object {
+                                      "checked": "Mui-checked",
+                                      "colorPrimary": "MuiCheckbox-colorPrimary",
+                                      "colorSecondary": "MuiCheckbox-colorSecondary",
+                                      "disabled": "Mui-disabled",
+                                      "indeterminate": "MuiCheckbox-indeterminate",
+                                      "root": "MuiCheckbox-root",
+                                    }
+                                  }
                                   color="secondary"
-                                  component="span"
-                                  onBlur={[Function]}
-                                  onFocus={[Function]}
-                                  tabIndex={null}
+                                  inputProps={
+                                    Object {
+                                      "aria-label": "maintenance-checkbox-arialabel",
+                                    }
+                                  }
+                                  onChange={[Function]}
+                                  value={false}
                                 >
-                                  <ForwardRef(IconButton)
-                                    className="PrivateSwitchBase-root-6 MuiCheckbox-root MuiCheckbox-colorSecondary"
+                                  <WithStyles(ForwardRef(SwitchBase))
+                                    checked={false}
+                                    checkedIcon={<Memo />}
                                     classes={
                                       Object {
-                                        "colorInherit": "MuiIconButton-colorInherit",
-                                        "colorPrimary": "MuiIconButton-colorPrimary",
-                                        "colorSecondary": "MuiIconButton-colorSecondary",
+                                        "checked": "Mui-checked",
                                         "disabled": "Mui-disabled",
-                                        "edgeEnd": "MuiIconButton-edgeEnd",
-                                        "edgeStart": "MuiIconButton-edgeStart",
-                                        "label": "MuiIconButton-label",
-                                        "root": "MuiIconButton-root",
-                                        "sizeSmall": "MuiIconButton-sizeSmall",
+                                        "root": "MuiCheckbox-root MuiCheckbox-colorSecondary",
                                       }
                                     }
                                     color="secondary"
-                                    component="span"
-                                    onBlur={[Function]}
-                                    onFocus={[Function]}
-                                    tabIndex={null}
+                                    icon={<Memo />}
+                                    inputProps={
+                                      Object {
+                                        "aria-label": "maintenance-checkbox-arialabel",
+                                        "data-indeterminate": false,
+                                      }
+                                    }
+                                    onChange={[Function]}
+                                    type="checkbox"
+                                    value={false}
                                   >
-                                    <WithStyles(ForwardRef(ButtonBase))
-                                      centerRipple={true}
-                                      className="MuiIconButton-root PrivateSwitchBase-root-6 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
-                                      component="span"
-                                      disabled={false}
-                                      focusRipple={true}
-                                      onBlur={[Function]}
-                                      onFocus={[Function]}
-                                      tabIndex={null}
-                                    >
-                                      <ForwardRef(ButtonBase)
-                                        centerRipple={true}
-                                        className="MuiIconButton-root PrivateSwitchBase-root-6 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
-                                        classes={
-                                          Object {
-                                            "disabled": "Mui-disabled",
-                                            "focusVisible": "Mui-focusVisible",
-                                            "root": "MuiButtonBase-root",
-                                          }
+                                    <ForwardRef(SwitchBase)
+                                      checked={false}
+                                      checkedIcon={<Memo />}
+                                      classes={
+                                        Object {
+                                          "checked": "PrivateSwitchBase-checked-11 Mui-checked",
+                                          "disabled": "PrivateSwitchBase-disabled-12 Mui-disabled",
+                                          "input": "PrivateSwitchBase-input-13",
+                                          "root": "PrivateSwitchBase-root-10 MuiCheckbox-root MuiCheckbox-colorSecondary",
                                         }
+                                      }
+                                      color="secondary"
+                                      icon={<Memo />}
+                                      inputProps={
+                                        Object {
+                                          "aria-label": "maintenance-checkbox-arialabel",
+                                          "data-indeterminate": false,
+                                        }
+                                      }
+                                      onChange={[Function]}
+                                      type="checkbox"
+                                      value={false}
+                                    >
+                                      <WithStyles(ForwardRef(IconButton))
+                                        className="PrivateSwitchBase-root-10 MuiCheckbox-root MuiCheckbox-colorSecondary"
+                                        color="secondary"
                                         component="span"
-                                        disabled={false}
-                                        focusRipple={true}
                                         onBlur={[Function]}
                                         onFocus={[Function]}
                                         tabIndex={null}
                                       >
-                                        <span
-                                          aria-disabled={false}
-                                          className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-6 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
+                                        <ForwardRef(IconButton)
+                                          className="PrivateSwitchBase-root-10 MuiCheckbox-root MuiCheckbox-colorSecondary"
+                                          classes={
+                                            Object {
+                                              "colorInherit": "MuiIconButton-colorInherit",
+                                              "colorPrimary": "MuiIconButton-colorPrimary",
+                                              "colorSecondary": "MuiIconButton-colorSecondary",
+                                              "disabled": "Mui-disabled",
+                                              "edgeEnd": "MuiIconButton-edgeEnd",
+                                              "edgeStart": "MuiIconButton-edgeStart",
+                                              "label": "MuiIconButton-label",
+                                              "root": "MuiIconButton-root",
+                                              "sizeSmall": "MuiIconButton-sizeSmall",
+                                            }
+                                          }
+                                          color="secondary"
+                                          component="span"
                                           onBlur={[Function]}
-                                          onDragLeave={[Function]}
                                           onFocus={[Function]}
-                                          onKeyDown={[Function]}
-                                          onKeyUp={[Function]}
-                                          onMouseDown={[Function]}
-                                          onMouseLeave={[Function]}
-                                          onMouseUp={[Function]}
-                                          onTouchEnd={[Function]}
-                                          onTouchMove={[Function]}
-                                          onTouchStart={[Function]}
                                           tabIndex={null}
                                         >
-                                          <span
-                                            className="MuiIconButton-label"
+                                          <WithStyles(ForwardRef(ButtonBase))
+                                            centerRipple={true}
+                                            className="MuiIconButton-root PrivateSwitchBase-root-10 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
+                                            component="span"
+                                            disabled={false}
+                                            focusRipple={true}
+                                            onBlur={[Function]}
+                                            onFocus={[Function]}
+                                            tabIndex={null}
                                           >
-                                            <input
-                                              aria-label="maintenance-checkbox-arialabel"
-                                              checked={false}
-                                              className="PrivateSwitchBase-input-9"
-                                              data-indeterminate={false}
-                                              onChange={[Function]}
-                                              type="checkbox"
-                                              value={false}
-                                            />
-                                            <ForwardRef(CheckBoxOutlineBlankIcon)>
-                                              <WithStyles(ForwardRef(SvgIcon))>
-                                                <ForwardRef(SvgIcon)
-                                                  classes={
-                                                    Object {
-                                                      "colorAction": "MuiSvgIcon-colorAction",
-                                                      "colorDisabled": "MuiSvgIcon-colorDisabled",
-                                                      "colorError": "MuiSvgIcon-colorError",
-                                                      "colorPrimary": "MuiSvgIcon-colorPrimary",
-                                                      "colorSecondary": "MuiSvgIcon-colorSecondary",
-                                                      "fontSizeInherit": "MuiSvgIcon-fontSizeInherit",
-                                                      "fontSizeLarge": "MuiSvgIcon-fontSizeLarge",
-                                                      "fontSizeSmall": "MuiSvgIcon-fontSizeSmall",
-                                                      "root": "MuiSvgIcon-root",
-                                                    }
-                                                  }
-                                                >
-                                                  <svg
-                                                    aria-hidden={true}
-                                                    className="MuiSvgIcon-root"
-                                                    focusable="false"
-                                                    viewBox="0 0 24 24"
-                                                  >
-                                                    <path
-                                                      d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
-                                                    />
-                                                  </svg>
-                                                </ForwardRef(SvgIcon)>
-                                              </WithStyles(ForwardRef(SvgIcon))>
-                                            </ForwardRef(CheckBoxOutlineBlankIcon)>
-                                          </span>
-                                          <WithStyles(memo)
-                                            center={true}
-                                          >
-                                            <ForwardRef(TouchRipple)
-                                              center={true}
+                                            <ForwardRef(ButtonBase)
+                                              centerRipple={true}
+                                              className="MuiIconButton-root PrivateSwitchBase-root-10 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
                                               classes={
                                                 Object {
-                                                  "child": "MuiTouchRipple-child",
-                                                  "childLeaving": "MuiTouchRipple-childLeaving",
-                                                  "childPulsate": "MuiTouchRipple-childPulsate",
-                                                  "ripple": "MuiTouchRipple-ripple",
-                                                  "ripplePulsate": "MuiTouchRipple-ripplePulsate",
-                                                  "rippleVisible": "MuiTouchRipple-rippleVisible",
-                                                  "root": "MuiTouchRipple-root",
+                                                  "disabled": "Mui-disabled",
+                                                  "focusVisible": "Mui-focusVisible",
+                                                  "root": "MuiButtonBase-root",
                                                 }
                                               }
+                                              component="span"
+                                              disabled={false}
+                                              focusRipple={true}
+                                              onBlur={[Function]}
+                                              onFocus={[Function]}
+                                              tabIndex={null}
                                             >
                                               <span
-                                                className="MuiTouchRipple-root"
+                                                aria-disabled={false}
+                                                className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-10 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
+                                                onBlur={[Function]}
+                                                onDragLeave={[Function]}
+                                                onFocus={[Function]}
+                                                onKeyDown={[Function]}
+                                                onKeyUp={[Function]}
+                                                onMouseDown={[Function]}
+                                                onMouseLeave={[Function]}
+                                                onMouseUp={[Function]}
+                                                onTouchEnd={[Function]}
+                                                onTouchMove={[Function]}
+                                                onTouchStart={[Function]}
+                                                tabIndex={null}
                                               >
-                                                <TransitionGroup
-                                                  childFactory={[Function]}
-                                                  component={null}
-                                                  exit={true}
-                                                />
+                                                <span
+                                                  className="MuiIconButton-label"
+                                                >
+                                                  <input
+                                                    aria-label="maintenance-checkbox-arialabel"
+                                                    checked={false}
+                                                    className="PrivateSwitchBase-input-13"
+                                                    data-indeterminate={false}
+                                                    onChange={[Function]}
+                                                    type="checkbox"
+                                                    value={false}
+                                                  />
+                                                  <ForwardRef(CheckBoxOutlineBlankIcon)>
+                                                    <WithStyles(ForwardRef(SvgIcon))>
+                                                      <ForwardRef(SvgIcon)
+                                                        classes={
+                                                          Object {
+                                                            "colorAction": "MuiSvgIcon-colorAction",
+                                                            "colorDisabled": "MuiSvgIcon-colorDisabled",
+                                                            "colorError": "MuiSvgIcon-colorError",
+                                                            "colorPrimary": "MuiSvgIcon-colorPrimary",
+                                                            "colorSecondary": "MuiSvgIcon-colorSecondary",
+                                                            "fontSizeInherit": "MuiSvgIcon-fontSizeInherit",
+                                                            "fontSizeLarge": "MuiSvgIcon-fontSizeLarge",
+                                                            "fontSizeSmall": "MuiSvgIcon-fontSizeSmall",
+                                                            "root": "MuiSvgIcon-root",
+                                                          }
+                                                        }
+                                                      >
+                                                        <svg
+                                                          aria-hidden={true}
+                                                          className="MuiSvgIcon-root"
+                                                          focusable="false"
+                                                          viewBox="0 0 24 24"
+                                                        >
+                                                          <path
+                                                            d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                                                          />
+                                                        </svg>
+                                                      </ForwardRef(SvgIcon)>
+                                                    </WithStyles(ForwardRef(SvgIcon))>
+                                                  </ForwardRef(CheckBoxOutlineBlankIcon)>
+                                                </span>
+                                                <WithStyles(memo)
+                                                  center={true}
+                                                >
+                                                  <ForwardRef(TouchRipple)
+                                                    center={true}
+                                                    classes={
+                                                      Object {
+                                                        "child": "MuiTouchRipple-child",
+                                                        "childLeaving": "MuiTouchRipple-childLeaving",
+                                                        "childPulsate": "MuiTouchRipple-childPulsate",
+                                                        "ripple": "MuiTouchRipple-ripple",
+                                                        "ripplePulsate": "MuiTouchRipple-ripplePulsate",
+                                                        "rippleVisible": "MuiTouchRipple-rippleVisible",
+                                                        "root": "MuiTouchRipple-root",
+                                                      }
+                                                    }
+                                                  >
+                                                    <span
+                                                      className="MuiTouchRipple-root"
+                                                    >
+                                                      <TransitionGroup
+                                                        childFactory={[Function]}
+                                                        component={null}
+                                                        exit={true}
+                                                      />
+                                                    </span>
+                                                  </ForwardRef(TouchRipple)>
+                                                </WithStyles(memo)>
                                               </span>
-                                            </ForwardRef(TouchRipple)>
-                                          </WithStyles(memo)>
-                                        </span>
-                                      </ForwardRef(ButtonBase)>
-                                    </WithStyles(ForwardRef(ButtonBase))>
-                                  </ForwardRef(IconButton)>
-                                </WithStyles(ForwardRef(IconButton))>
-                              </ForwardRef(SwitchBase)>
-                            </WithStyles(ForwardRef(SwitchBase))>
-                          </ForwardRef(Checkbox)>
-                        </WithStyles(ForwardRef(Checkbox))>
-                        <WithStyles(ForwardRef(Typography))
-                          className="MuiFormControlLabel-label"
-                          component="span"
-                        >
-                          <ForwardRef(Typography)
-                            className="MuiFormControlLabel-label"
-                            classes={
-                              Object {
-                                "alignCenter": "MuiTypography-alignCenter",
-                                "alignJustify": "MuiTypography-alignJustify",
-                                "alignLeft": "MuiTypography-alignLeft",
-                                "alignRight": "MuiTypography-alignRight",
-                                "body1": "MuiTypography-body1",
-                                "body2": "MuiTypography-body2",
-                                "button": "MuiTypography-button",
-                                "caption": "MuiTypography-caption",
-                                "colorError": "MuiTypography-colorError",
-                                "colorInherit": "MuiTypography-colorInherit",
-                                "colorPrimary": "MuiTypography-colorPrimary",
-                                "colorSecondary": "MuiTypography-colorSecondary",
-                                "colorTextPrimary": "MuiTypography-colorTextPrimary",
-                                "colorTextSecondary": "MuiTypography-colorTextSecondary",
-                                "displayBlock": "MuiTypography-displayBlock",
-                                "displayInline": "MuiTypography-displayInline",
-                                "gutterBottom": "MuiTypography-gutterBottom",
-                                "h1": "MuiTypography-h1",
-                                "h2": "MuiTypography-h2",
-                                "h3": "MuiTypography-h3",
-                                "h4": "MuiTypography-h4",
-                                "h5": "MuiTypography-h5",
-                                "h6": "MuiTypography-h6",
-                                "noWrap": "MuiTypography-noWrap",
-                                "overline": "MuiTypography-overline",
-                                "paragraph": "MuiTypography-paragraph",
-                                "root": "MuiTypography-root",
-                                "srOnly": "MuiTypography-srOnly",
-                                "subtitle1": "MuiTypography-subtitle1",
-                                "subtitle2": "MuiTypography-subtitle2",
-                              }
-                            }
-                            component="span"
-                          >
-                            <span
-                              className="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
-                            >
-                              display-checkbox
-                            </span>
-                          </ForwardRef(Typography)>
-                        </WithStyles(ForwardRef(Typography))>
-                      </label>
-                    </ForwardRef(FormControlLabel)>
-                  </WithStyles(ForwardRef(FormControlLabel))>
-                  <WithStyles(ForwardRef(Button))
-                    color="primary"
-                    onClick={[Function]}
-                    style={
-                      Object {
-                        "float": "right",
-                      }
-                    }
-                    variant="contained"
-                  >
-                    <ForwardRef(Button)
-                      classes={
-                        Object {
-                          "colorInherit": "MuiButton-colorInherit",
-                          "contained": "MuiButton-contained",
-                          "containedPrimary": "MuiButton-containedPrimary",
-                          "containedSecondary": "MuiButton-containedSecondary",
-                          "containedSizeLarge": "MuiButton-containedSizeLarge",
-                          "containedSizeSmall": "MuiButton-containedSizeSmall",
-                          "disableElevation": "MuiButton-disableElevation",
-                          "disabled": "Mui-disabled",
-                          "endIcon": "MuiButton-endIcon",
-                          "focusVisible": "Mui-focusVisible",
-                          "fullWidth": "MuiButton-fullWidth",
-                          "iconSizeLarge": "MuiButton-iconSizeLarge",
-                          "iconSizeMedium": "MuiButton-iconSizeMedium",
-                          "iconSizeSmall": "MuiButton-iconSizeSmall",
-                          "label": "MuiButton-label",
-                          "outlined": "MuiButton-outlined",
-                          "outlinedPrimary": "MuiButton-outlinedPrimary",
-                          "outlinedSecondary": "MuiButton-outlinedSecondary",
-                          "outlinedSizeLarge": "MuiButton-outlinedSizeLarge",
-                          "outlinedSizeSmall": "MuiButton-outlinedSizeSmall",
-                          "root": "MuiButton-root",
-                          "sizeLarge": "MuiButton-sizeLarge",
-                          "sizeSmall": "MuiButton-sizeSmall",
-                          "startIcon": "MuiButton-startIcon",
-                          "text": "MuiButton-text",
-                          "textPrimary": "MuiButton-textPrimary",
-                          "textSecondary": "MuiButton-textSecondary",
-                          "textSizeLarge": "MuiButton-textSizeLarge",
-                          "textSizeSmall": "MuiButton-textSizeSmall",
-                        }
-                      }
-                      color="primary"
-                      onClick={[Function]}
-                      style={
-                        Object {
-                          "float": "right",
-                        }
-                      }
-                      variant="contained"
-                    >
-                      <WithStyles(ForwardRef(ButtonBase))
-                        className="MuiButton-root MuiButton-contained MuiButton-containedPrimary"
-                        component="button"
-                        disabled={false}
-                        focusRipple={true}
-                        focusVisibleClassName="Mui-focusVisible"
-                        onClick={[Function]}
-                        style={
-                          Object {
-                            "float": "right",
-                          }
-                        }
-                        type="button"
-                      >
-                        <ForwardRef(ButtonBase)
-                          className="MuiButton-root MuiButton-contained MuiButton-containedPrimary"
-                          classes={
-                            Object {
-                              "disabled": "Mui-disabled",
-                              "focusVisible": "Mui-focusVisible",
-                              "root": "MuiButtonBase-root",
-                            }
-                          }
-                          component="button"
-                          disabled={false}
-                          focusRipple={true}
-                          focusVisibleClassName="Mui-focusVisible"
-                          onClick={[Function]}
-                          style={
-                            Object {
-                              "float": "right",
-                            }
-                          }
-                          type="button"
-                        >
-                          <button
-                            className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"
-                            disabled={false}
-                            onBlur={[Function]}
-                            onClick={[Function]}
-                            onDragLeave={[Function]}
-                            onFocus={[Function]}
-                            onKeyDown={[Function]}
-                            onKeyUp={[Function]}
-                            onMouseDown={[Function]}
-                            onMouseLeave={[Function]}
-                            onMouseUp={[Function]}
-                            onTouchEnd={[Function]}
-                            onTouchMove={[Function]}
-                            onTouchStart={[Function]}
-                            style={
-                              Object {
-                                "float": "right",
-                              }
-                            }
-                            tabIndex={0}
-                            type="button"
-                          >
-                            <span
-                              className="MuiButton-label"
-                            >
+                                            </ForwardRef(ButtonBase)>
+                                          </WithStyles(ForwardRef(ButtonBase))>
+                                        </ForwardRef(IconButton)>
+                                      </WithStyles(ForwardRef(IconButton))>
+                                    </ForwardRef(SwitchBase)>
+                                  </WithStyles(ForwardRef(SwitchBase))>
+                                </ForwardRef(Checkbox)>
+                              </WithStyles(ForwardRef(Checkbox))>
                               <WithStyles(ForwardRef(Typography))
-                                color="inherit"
-                                noWrap={true}
-                                style={
-                                  Object {
-                                    "marginTop": 3,
-                                  }
-                                }
+                                className="MuiFormControlLabel-label"
+                                component="span"
                               >
                                 <ForwardRef(Typography)
+                                  className="MuiFormControlLabel-label"
                                   classes={
                                     Object {
                                       "alignCenter": "MuiTypography-alignCenter",
@@ -1437,67 +1757,240 @@ exports[`Admin page component should render correctly 1`] = `
                                       "subtitle2": "MuiTypography-subtitle2",
                                     }
                                   }
-                                  color="inherit"
-                                  noWrap={true}
-                                  style={
-                                    Object {
-                                      "marginTop": 3,
-                                    }
-                                  }
+                                  component="span"
                                 >
-                                  <p
-                                    className="MuiTypography-root MuiTypography-body1 MuiTypography-colorInherit MuiTypography-noWrap"
-                                    style={
-                                      Object {
-                                        "marginTop": 3,
-                                      }
-                                    }
+                                  <span
+                                    className="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
                                   >
-                                    save-button
-                                  </p>
+                                    display-checkbox
+                                  </span>
                                 </ForwardRef(Typography)>
                               </WithStyles(ForwardRef(Typography))>
-                            </span>
-                            <WithStyles(memo)
-                              center={false}
+                            </label>
+                          </ForwardRef(FormControlLabel)>
+                        </WithStyles(ForwardRef(FormControlLabel))>
+                        <WithStyles(ForwardRef(Button))
+                          color="primary"
+                          onClick={[Function]}
+                          style={
+                            Object {
+                              "float": "right",
+                            }
+                          }
+                          variant="contained"
+                        >
+                          <ForwardRef(Button)
+                            classes={
+                              Object {
+                                "colorInherit": "MuiButton-colorInherit",
+                                "contained": "MuiButton-contained",
+                                "containedPrimary": "MuiButton-containedPrimary",
+                                "containedSecondary": "MuiButton-containedSecondary",
+                                "containedSizeLarge": "MuiButton-containedSizeLarge",
+                                "containedSizeSmall": "MuiButton-containedSizeSmall",
+                                "disableElevation": "MuiButton-disableElevation",
+                                "disabled": "Mui-disabled",
+                                "endIcon": "MuiButton-endIcon",
+                                "focusVisible": "Mui-focusVisible",
+                                "fullWidth": "MuiButton-fullWidth",
+                                "iconSizeLarge": "MuiButton-iconSizeLarge",
+                                "iconSizeMedium": "MuiButton-iconSizeMedium",
+                                "iconSizeSmall": "MuiButton-iconSizeSmall",
+                                "label": "MuiButton-label",
+                                "outlined": "MuiButton-outlined",
+                                "outlinedPrimary": "MuiButton-outlinedPrimary",
+                                "outlinedSecondary": "MuiButton-outlinedSecondary",
+                                "outlinedSizeLarge": "MuiButton-outlinedSizeLarge",
+                                "outlinedSizeSmall": "MuiButton-outlinedSizeSmall",
+                                "root": "MuiButton-root",
+                                "sizeLarge": "MuiButton-sizeLarge",
+                                "sizeSmall": "MuiButton-sizeSmall",
+                                "startIcon": "MuiButton-startIcon",
+                                "text": "MuiButton-text",
+                                "textPrimary": "MuiButton-textPrimary",
+                                "textSecondary": "MuiButton-textSecondary",
+                                "textSizeLarge": "MuiButton-textSizeLarge",
+                                "textSizeSmall": "MuiButton-textSizeSmall",
+                              }
+                            }
+                            color="primary"
+                            onClick={[Function]}
+                            style={
+                              Object {
+                                "float": "right",
+                              }
+                            }
+                            variant="contained"
+                          >
+                            <WithStyles(ForwardRef(ButtonBase))
+                              className="MuiButton-root MuiButton-contained MuiButton-containedPrimary"
+                              component="button"
+                              disabled={false}
+                              focusRipple={true}
+                              focusVisibleClassName="Mui-focusVisible"
+                              onClick={[Function]}
+                              style={
+                                Object {
+                                  "float": "right",
+                                }
+                              }
+                              type="button"
                             >
-                              <ForwardRef(TouchRipple)
-                                center={false}
+                              <ForwardRef(ButtonBase)
+                                className="MuiButton-root MuiButton-contained MuiButton-containedPrimary"
                                 classes={
                                   Object {
-                                    "child": "MuiTouchRipple-child",
-                                    "childLeaving": "MuiTouchRipple-childLeaving",
-                                    "childPulsate": "MuiTouchRipple-childPulsate",
-                                    "ripple": "MuiTouchRipple-ripple",
-                                    "ripplePulsate": "MuiTouchRipple-ripplePulsate",
-                                    "rippleVisible": "MuiTouchRipple-rippleVisible",
-                                    "root": "MuiTouchRipple-root",
+                                    "disabled": "Mui-disabled",
+                                    "focusVisible": "Mui-focusVisible",
+                                    "root": "MuiButtonBase-root",
                                   }
                                 }
+                                component="button"
+                                disabled={false}
+                                focusRipple={true}
+                                focusVisibleClassName="Mui-focusVisible"
+                                onClick={[Function]}
+                                style={
+                                  Object {
+                                    "float": "right",
+                                  }
+                                }
+                                type="button"
                               >
-                                <span
-                                  className="MuiTouchRipple-root"
+                                <button
+                                  className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"
+                                  disabled={false}
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onDragLeave={[Function]}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onKeyUp={[Function]}
+                                  onMouseDown={[Function]}
+                                  onMouseLeave={[Function]}
+                                  onMouseUp={[Function]}
+                                  onTouchEnd={[Function]}
+                                  onTouchMove={[Function]}
+                                  onTouchStart={[Function]}
+                                  style={
+                                    Object {
+                                      "float": "right",
+                                    }
+                                  }
+                                  tabIndex={0}
+                                  type="button"
                                 >
-                                  <TransitionGroup
-                                    childFactory={[Function]}
-                                    component={null}
-                                    exit={true}
-                                  />
-                                </span>
-                              </ForwardRef(TouchRipple)>
-                            </WithStyles(memo)>
-                          </button>
-                        </ForwardRef(ButtonBase)>
-                      </WithStyles(ForwardRef(ButtonBase))>
-                    </ForwardRef(Button)>
-                  </WithStyles(ForwardRef(Button))>
-                </div>
+                                  <span
+                                    className="MuiButton-label"
+                                  >
+                                    <WithStyles(ForwardRef(Typography))
+                                      color="inherit"
+                                      noWrap={true}
+                                      style={
+                                        Object {
+                                          "marginTop": 3,
+                                        }
+                                      }
+                                    >
+                                      <ForwardRef(Typography)
+                                        classes={
+                                          Object {
+                                            "alignCenter": "MuiTypography-alignCenter",
+                                            "alignJustify": "MuiTypography-alignJustify",
+                                            "alignLeft": "MuiTypography-alignLeft",
+                                            "alignRight": "MuiTypography-alignRight",
+                                            "body1": "MuiTypography-body1",
+                                            "body2": "MuiTypography-body2",
+                                            "button": "MuiTypography-button",
+                                            "caption": "MuiTypography-caption",
+                                            "colorError": "MuiTypography-colorError",
+                                            "colorInherit": "MuiTypography-colorInherit",
+                                            "colorPrimary": "MuiTypography-colorPrimary",
+                                            "colorSecondary": "MuiTypography-colorSecondary",
+                                            "colorTextPrimary": "MuiTypography-colorTextPrimary",
+                                            "colorTextSecondary": "MuiTypography-colorTextSecondary",
+                                            "displayBlock": "MuiTypography-displayBlock",
+                                            "displayInline": "MuiTypography-displayInline",
+                                            "gutterBottom": "MuiTypography-gutterBottom",
+                                            "h1": "MuiTypography-h1",
+                                            "h2": "MuiTypography-h2",
+                                            "h3": "MuiTypography-h3",
+                                            "h4": "MuiTypography-h4",
+                                            "h5": "MuiTypography-h5",
+                                            "h6": "MuiTypography-h6",
+                                            "noWrap": "MuiTypography-noWrap",
+                                            "overline": "MuiTypography-overline",
+                                            "paragraph": "MuiTypography-paragraph",
+                                            "root": "MuiTypography-root",
+                                            "srOnly": "MuiTypography-srOnly",
+                                            "subtitle1": "MuiTypography-subtitle1",
+                                            "subtitle2": "MuiTypography-subtitle2",
+                                          }
+                                        }
+                                        color="inherit"
+                                        noWrap={true}
+                                        style={
+                                          Object {
+                                            "marginTop": 3,
+                                          }
+                                        }
+                                      >
+                                        <p
+                                          className="MuiTypography-root MuiTypography-body1 MuiTypography-colorInherit MuiTypography-noWrap"
+                                          style={
+                                            Object {
+                                              "marginTop": 3,
+                                            }
+                                          }
+                                        >
+                                          save-button
+                                        </p>
+                                      </ForwardRef(Typography)>
+                                    </WithStyles(ForwardRef(Typography))>
+                                  </span>
+                                  <WithStyles(memo)
+                                    center={false}
+                                  >
+                                    <ForwardRef(TouchRipple)
+                                      center={false}
+                                      classes={
+                                        Object {
+                                          "child": "MuiTouchRipple-child",
+                                          "childLeaving": "MuiTouchRipple-childLeaving",
+                                          "childPulsate": "MuiTouchRipple-childPulsate",
+                                          "ripple": "MuiTouchRipple-ripple",
+                                          "ripplePulsate": "MuiTouchRipple-ripplePulsate",
+                                          "rippleVisible": "MuiTouchRipple-rippleVisible",
+                                          "root": "MuiTouchRipple-root",
+                                        }
+                                      }
+                                    >
+                                      <span
+                                        className="MuiTouchRipple-root"
+                                      >
+                                        <TransitionGroup
+                                          childFactory={[Function]}
+                                          component={null}
+                                          exit={true}
+                                        />
+                                      </span>
+                                    </ForwardRef(TouchRipple)>
+                                  </WithStyles(memo)>
+                                </button>
+                              </ForwardRef(ButtonBase)>
+                            </WithStyles(ForwardRef(ButtonBase))>
+                          </ForwardRef(Button)>
+                        </WithStyles(ForwardRef(Button))>
+                      </div>
+                    </div>
+                  </ForwardRef(Paper)>
+                </WithStyles(ForwardRef(Paper))>
               </div>
-            </ForwardRef(Paper)>
-          </WithStyles(ForwardRef(Paper))>
-        </div>
-      </AdminPage>
-    </WithStyles(AdminPage)>
-  </Connect(WithStyles(AdminPage))>
+            </div>
+          </AdminPage>
+        </WithStyles(AdminPage)>
+      </Connect(WithStyles(AdminPage))>
+    </Router>
+  </MemoryRouter>
 </Provider>
 `;

--- a/src/adminPage/__snapshots__/adminPage.component.test.tsx.snap
+++ b/src/adminPage/__snapshots__/adminPage.component.test.tsx.snap
@@ -96,400 +96,211 @@ exports[`Admin page component should render correctly 1`] = `
             setMaintenanceState={[Function]}
             setScheduledMaintenanceState={[Function]}
           >
-            <div
+            <WithStyles(ForwardRef(Paper))
               className="AdminPage-root-1"
             >
-              <WithStyles(ForwardRef(Typography))
-                className="AdminPage-titleText-2"
-                variant="h3"
-              >
-                <ForwardRef(Typography)
-                  className="AdminPage-titleText-2"
-                  classes={
-                    Object {
-                      "alignCenter": "MuiTypography-alignCenter",
-                      "alignJustify": "MuiTypography-alignJustify",
-                      "alignLeft": "MuiTypography-alignLeft",
-                      "alignRight": "MuiTypography-alignRight",
-                      "body1": "MuiTypography-body1",
-                      "body2": "MuiTypography-body2",
-                      "button": "MuiTypography-button",
-                      "caption": "MuiTypography-caption",
-                      "colorError": "MuiTypography-colorError",
-                      "colorInherit": "MuiTypography-colorInherit",
-                      "colorPrimary": "MuiTypography-colorPrimary",
-                      "colorSecondary": "MuiTypography-colorSecondary",
-                      "colorTextPrimary": "MuiTypography-colorTextPrimary",
-                      "colorTextSecondary": "MuiTypography-colorTextSecondary",
-                      "displayBlock": "MuiTypography-displayBlock",
-                      "displayInline": "MuiTypography-displayInline",
-                      "gutterBottom": "MuiTypography-gutterBottom",
-                      "h1": "MuiTypography-h1",
-                      "h2": "MuiTypography-h2",
-                      "h3": "MuiTypography-h3",
-                      "h4": "MuiTypography-h4",
-                      "h5": "MuiTypography-h5",
-                      "h6": "MuiTypography-h6",
-                      "noWrap": "MuiTypography-noWrap",
-                      "overline": "MuiTypography-overline",
-                      "paragraph": "MuiTypography-paragraph",
-                      "root": "MuiTypography-root",
-                      "srOnly": "MuiTypography-srOnly",
-                      "subtitle1": "MuiTypography-subtitle1",
-                      "subtitle2": "MuiTypography-subtitle2",
-                    }
+              <ForwardRef(Paper)
+                className="AdminPage-root-1"
+                classes={
+                  Object {
+                    "elevation0": "MuiPaper-elevation0",
+                    "elevation1": "MuiPaper-elevation1",
+                    "elevation10": "MuiPaper-elevation10",
+                    "elevation11": "MuiPaper-elevation11",
+                    "elevation12": "MuiPaper-elevation12",
+                    "elevation13": "MuiPaper-elevation13",
+                    "elevation14": "MuiPaper-elevation14",
+                    "elevation15": "MuiPaper-elevation15",
+                    "elevation16": "MuiPaper-elevation16",
+                    "elevation17": "MuiPaper-elevation17",
+                    "elevation18": "MuiPaper-elevation18",
+                    "elevation19": "MuiPaper-elevation19",
+                    "elevation2": "MuiPaper-elevation2",
+                    "elevation20": "MuiPaper-elevation20",
+                    "elevation21": "MuiPaper-elevation21",
+                    "elevation22": "MuiPaper-elevation22",
+                    "elevation23": "MuiPaper-elevation23",
+                    "elevation24": "MuiPaper-elevation24",
+                    "elevation3": "MuiPaper-elevation3",
+                    "elevation4": "MuiPaper-elevation4",
+                    "elevation5": "MuiPaper-elevation5",
+                    "elevation6": "MuiPaper-elevation6",
+                    "elevation7": "MuiPaper-elevation7",
+                    "elevation8": "MuiPaper-elevation8",
+                    "elevation9": "MuiPaper-elevation9",
+                    "outlined": "MuiPaper-outlined",
+                    "root": "MuiPaper-root",
+                    "rounded": "MuiPaper-rounded",
                   }
-                  variant="h3"
-                >
-                  <h3
-                    className="MuiTypography-root AdminPage-titleText-2 MuiTypography-h3"
-                  >
-                    title
-                  </h3>
-                </ForwardRef(Typography)>
-              </WithStyles(ForwardRef(Typography))>
-              <WithStyles(ForwardRef(Tabs))
-                onChange={[Function]}
-                value="maintenance"
+                }
               >
-                <ForwardRef(Tabs)
-                  classes={
-                    Object {
-                      "centered": "MuiTabs-centered",
-                      "fixed": "MuiTabs-fixed",
-                      "flexContainer": "MuiTabs-flexContainer",
-                      "flexContainerVertical": "MuiTabs-flexContainerVertical",
-                      "indicator": "MuiTabs-indicator",
-                      "root": "MuiTabs-root",
-                      "scrollButtons": "MuiTabs-scrollButtons",
-                      "scrollButtonsDesktop": "MuiTabs-scrollButtonsDesktop",
-                      "scrollable": "MuiTabs-scrollable",
-                      "scroller": "MuiTabs-scroller",
-                      "vertical": "MuiTabs-vertical",
-                    }
-                  }
-                  onChange={[Function]}
-                  value="maintenance"
+                <div
+                  className="MuiPaper-root AdminPage-root-1 MuiPaper-elevation1 MuiPaper-rounded"
                 >
-                  <div
-                    className="MuiTabs-root"
+                  <WithStyles(ForwardRef(Typography))
+                    className="AdminPage-titleText-2"
+                    variant="h3"
                   >
-                    <div
-                      className="MuiTabs-scroller MuiTabs-fixed"
-                      onScroll={[Function]}
-                      style={
+                    <ForwardRef(Typography)
+                      className="AdminPage-titleText-2"
+                      classes={
                         Object {
-                          "marginBottom": null,
-                          "overflow": "hidden",
+                          "alignCenter": "MuiTypography-alignCenter",
+                          "alignJustify": "MuiTypography-alignJustify",
+                          "alignLeft": "MuiTypography-alignLeft",
+                          "alignRight": "MuiTypography-alignRight",
+                          "body1": "MuiTypography-body1",
+                          "body2": "MuiTypography-body2",
+                          "button": "MuiTypography-button",
+                          "caption": "MuiTypography-caption",
+                          "colorError": "MuiTypography-colorError",
+                          "colorInherit": "MuiTypography-colorInherit",
+                          "colorPrimary": "MuiTypography-colorPrimary",
+                          "colorSecondary": "MuiTypography-colorSecondary",
+                          "colorTextPrimary": "MuiTypography-colorTextPrimary",
+                          "colorTextSecondary": "MuiTypography-colorTextSecondary",
+                          "displayBlock": "MuiTypography-displayBlock",
+                          "displayInline": "MuiTypography-displayInline",
+                          "gutterBottom": "MuiTypography-gutterBottom",
+                          "h1": "MuiTypography-h1",
+                          "h2": "MuiTypography-h2",
+                          "h3": "MuiTypography-h3",
+                          "h4": "MuiTypography-h4",
+                          "h5": "MuiTypography-h5",
+                          "h6": "MuiTypography-h6",
+                          "noWrap": "MuiTypography-noWrap",
+                          "overline": "MuiTypography-overline",
+                          "paragraph": "MuiTypography-paragraph",
+                          "root": "MuiTypography-root",
+                          "srOnly": "MuiTypography-srOnly",
+                          "subtitle1": "MuiTypography-subtitle1",
+                          "subtitle2": "MuiTypography-subtitle2",
                         }
                       }
+                      variant="h3"
+                    >
+                      <h3
+                        className="MuiTypography-root AdminPage-titleText-2 MuiTypography-h3"
+                      >
+                        title
+                      </h3>
+                    </ForwardRef(Typography)>
+                  </WithStyles(ForwardRef(Typography))>
+                  <WithStyles(ForwardRef(Tabs))
+                    onChange={[Function]}
+                    value="maintenance"
+                  >
+                    <ForwardRef(Tabs)
+                      classes={
+                        Object {
+                          "centered": "MuiTabs-centered",
+                          "fixed": "MuiTabs-fixed",
+                          "flexContainer": "MuiTabs-flexContainer",
+                          "flexContainerVertical": "MuiTabs-flexContainerVertical",
+                          "indicator": "MuiTabs-indicator",
+                          "root": "MuiTabs-root",
+                          "scrollButtons": "MuiTabs-scrollButtons",
+                          "scrollButtonsDesktop": "MuiTabs-scrollButtonsDesktop",
+                          "scrollable": "MuiTabs-scrollable",
+                          "scroller": "MuiTabs-scroller",
+                          "vertical": "MuiTabs-vertical",
+                        }
+                      }
+                      onChange={[Function]}
+                      value="maintenance"
                     >
                       <div
-                        className="MuiTabs-flexContainer"
-                        onKeyDown={[Function]}
-                        role="tablist"
+                        className="MuiTabs-root"
                       >
-                        <WithStyles(ForwardRef(Tab))
-                          aria-controls="maintenance-panel"
-                          fullWidth={false}
-                          id="maintenance-tab"
-                          indicator={false}
-                          key=".0"
-                          label="Maintenance"
-                          onChange={[Function]}
-                          selected={true}
-                          textColor="inherit"
-                          value="maintenance"
-                        >
-                          <ForwardRef(Tab)
-                            aria-controls="maintenance-panel"
-                            classes={
-                              Object {
-                                "disabled": "Mui-disabled",
-                                "fullWidth": "MuiTab-fullWidth",
-                                "labelIcon": "MuiTab-labelIcon",
-                                "root": "MuiTab-root",
-                                "selected": "Mui-selected",
-                                "textColorInherit": "MuiTab-textColorInherit",
-                                "textColorPrimary": "MuiTab-textColorPrimary",
-                                "textColorSecondary": "MuiTab-textColorSecondary",
-                                "wrapped": "MuiTab-wrapped",
-                                "wrapper": "MuiTab-wrapper",
-                              }
-                            }
-                            fullWidth={false}
-                            id="maintenance-tab"
-                            indicator={false}
-                            label="Maintenance"
-                            onChange={[Function]}
-                            selected={true}
-                            textColor="inherit"
-                            value="maintenance"
-                          >
-                            <WithStyles(ForwardRef(ButtonBase))
-                              aria-controls="maintenance-panel"
-                              aria-selected={true}
-                              className="MuiTab-root MuiTab-textColorInherit Mui-selected"
-                              disabled={false}
-                              focusRipple={true}
-                              id="maintenance-tab"
-                              onClick={[Function]}
-                              onFocus={[Function]}
-                              role="tab"
-                              tabIndex={0}
-                            >
-                              <ForwardRef(ButtonBase)
-                                aria-controls="maintenance-panel"
-                                aria-selected={true}
-                                className="MuiTab-root MuiTab-textColorInherit Mui-selected"
-                                classes={
-                                  Object {
-                                    "disabled": "Mui-disabled",
-                                    "focusVisible": "Mui-focusVisible",
-                                    "root": "MuiButtonBase-root",
-                                  }
-                                }
-                                disabled={false}
-                                focusRipple={true}
-                                id="maintenance-tab"
-                                onClick={[Function]}
-                                onFocus={[Function]}
-                                role="tab"
-                                tabIndex={0}
-                              >
-                                <button
-                                  aria-controls="maintenance-panel"
-                                  aria-selected={true}
-                                  className="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit Mui-selected"
-                                  disabled={false}
-                                  id="maintenance-tab"
-                                  onBlur={[Function]}
-                                  onClick={[Function]}
-                                  onDragLeave={[Function]}
-                                  onFocus={[Function]}
-                                  onKeyDown={[Function]}
-                                  onKeyUp={[Function]}
-                                  onMouseDown={[Function]}
-                                  onMouseLeave={[Function]}
-                                  onMouseUp={[Function]}
-                                  onTouchEnd={[Function]}
-                                  onTouchMove={[Function]}
-                                  onTouchStart={[Function]}
-                                  role="tab"
-                                  tabIndex={0}
-                                  type="button"
-                                >
-                                  <span
-                                    className="MuiTab-wrapper"
-                                  >
-                                    Maintenance
-                                  </span>
-                                  <WithStyles(memo)
-                                    center={false}
-                                  >
-                                    <ForwardRef(TouchRipple)
-                                      center={false}
-                                      classes={
-                                        Object {
-                                          "child": "MuiTouchRipple-child",
-                                          "childLeaving": "MuiTouchRipple-childLeaving",
-                                          "childPulsate": "MuiTouchRipple-childPulsate",
-                                          "ripple": "MuiTouchRipple-ripple",
-                                          "ripplePulsate": "MuiTouchRipple-ripplePulsate",
-                                          "rippleVisible": "MuiTouchRipple-rippleVisible",
-                                          "root": "MuiTouchRipple-root",
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        className="MuiTouchRipple-root"
-                                      >
-                                        <TransitionGroup
-                                          childFactory={[Function]}
-                                          component={null}
-                                          exit={true}
-                                        />
-                                      </span>
-                                    </ForwardRef(TouchRipple)>
-                                  </WithStyles(memo)>
-                                </button>
-                              </ForwardRef(ButtonBase)>
-                            </WithStyles(ForwardRef(ButtonBase))>
-                          </ForwardRef(Tab)>
-                        </WithStyles(ForwardRef(Tab))>
-                        <WithStyles(ForwardRef(Tab))
-                          component={
+                        <div
+                          className="MuiTabs-scroller MuiTabs-fixed"
+                          onScroll={[Function]}
+                          style={
                             Object {
-                              "$$typeof": Symbol(react.forward_ref),
-                              "displayName": "Link",
-                              "propTypes": Object {
-                                "innerRef": [Function],
-                                "onClick": [Function],
-                                "replace": [Function],
-                                "target": [Function],
-                                "to": [Function],
-                              },
-                              "render": [Function],
+                              "marginBottom": null,
+                              "overflow": "hidden",
                             }
                           }
-                          fullWidth={false}
-                          id="download-tab"
-                          indicator={false}
-                          key=".1"
-                          label="Admin Download"
-                          onChange={[Function]}
-                          selected={false}
-                          textColor="inherit"
-                          to="/admin-download"
-                          value="download"
                         >
-                          <ForwardRef(Tab)
-                            classes={
-                              Object {
-                                "disabled": "Mui-disabled",
-                                "fullWidth": "MuiTab-fullWidth",
-                                "labelIcon": "MuiTab-labelIcon",
-                                "root": "MuiTab-root",
-                                "selected": "Mui-selected",
-                                "textColorInherit": "MuiTab-textColorInherit",
-                                "textColorPrimary": "MuiTab-textColorPrimary",
-                                "textColorSecondary": "MuiTab-textColorSecondary",
-                                "wrapped": "MuiTab-wrapped",
-                                "wrapper": "MuiTab-wrapper",
-                              }
-                            }
-                            component={
-                              Object {
-                                "$$typeof": Symbol(react.forward_ref),
-                                "displayName": "Link",
-                                "propTypes": Object {
-                                  "innerRef": [Function],
-                                  "onClick": [Function],
-                                  "replace": [Function],
-                                  "target": [Function],
-                                  "to": [Function],
-                                },
-                                "render": [Function],
-                              }
-                            }
-                            fullWidth={false}
-                            id="download-tab"
-                            indicator={false}
-                            label="Admin Download"
-                            onChange={[Function]}
-                            selected={false}
-                            textColor="inherit"
-                            to="/admin-download"
-                            value="download"
+                          <div
+                            className="MuiTabs-flexContainer"
+                            onKeyDown={[Function]}
+                            role="tablist"
                           >
-                            <WithStyles(ForwardRef(ButtonBase))
-                              aria-selected={false}
-                              className="MuiTab-root MuiTab-textColorInherit"
-                              component={
-                                Object {
-                                  "$$typeof": Symbol(react.forward_ref),
-                                  "displayName": "Link",
-                                  "propTypes": Object {
-                                    "innerRef": [Function],
-                                    "onClick": [Function],
-                                    "replace": [Function],
-                                    "target": [Function],
-                                    "to": [Function],
-                                  },
-                                  "render": [Function],
-                                }
-                              }
-                              disabled={false}
-                              focusRipple={true}
-                              id="download-tab"
-                              onClick={[Function]}
-                              onFocus={[Function]}
-                              role="tab"
-                              tabIndex={-1}
-                              to="/admin-download"
+                            <WithStyles(ForwardRef(Tab))
+                              aria-controls="maintenance-panel"
+                              fullWidth={false}
+                              id="maintenance-tab"
+                              indicator={false}
+                              key=".0"
+                              label="Maintenance"
+                              onChange={[Function]}
+                              selected={true}
+                              textColor="inherit"
+                              value="maintenance"
                             >
-                              <ForwardRef(ButtonBase)
-                                aria-selected={false}
-                                className="MuiTab-root MuiTab-textColorInherit"
+                              <ForwardRef(Tab)
+                                aria-controls="maintenance-panel"
                                 classes={
                                   Object {
                                     "disabled": "Mui-disabled",
-                                    "focusVisible": "Mui-focusVisible",
-                                    "root": "MuiButtonBase-root",
+                                    "fullWidth": "MuiTab-fullWidth",
+                                    "labelIcon": "MuiTab-labelIcon",
+                                    "root": "MuiTab-root",
+                                    "selected": "Mui-selected",
+                                    "textColorInherit": "MuiTab-textColorInherit",
+                                    "textColorPrimary": "MuiTab-textColorPrimary",
+                                    "textColorSecondary": "MuiTab-textColorSecondary",
+                                    "wrapped": "MuiTab-wrapped",
+                                    "wrapper": "MuiTab-wrapper",
                                   }
                                 }
-                                component={
-                                  Object {
-                                    "$$typeof": Symbol(react.forward_ref),
-                                    "displayName": "Link",
-                                    "propTypes": Object {
-                                      "innerRef": [Function],
-                                      "onClick": [Function],
-                                      "replace": [Function],
-                                      "target": [Function],
-                                      "to": [Function],
-                                    },
-                                    "render": [Function],
-                                  }
-                                }
-                                disabled={false}
-                                focusRipple={true}
-                                id="download-tab"
-                                onClick={[Function]}
-                                onFocus={[Function]}
-                                role="tab"
-                                tabIndex={-1}
-                                to="/admin-download"
+                                fullWidth={false}
+                                id="maintenance-tab"
+                                indicator={false}
+                                label="Maintenance"
+                                onChange={[Function]}
+                                selected={true}
+                                textColor="inherit"
+                                value="maintenance"
                               >
-                                <Link
-                                  aria-disabled={false}
-                                  aria-selected={false}
-                                  className="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit"
-                                  id="download-tab"
-                                  onBlur={[Function]}
+                                <WithStyles(ForwardRef(ButtonBase))
+                                  aria-controls="maintenance-panel"
+                                  aria-selected={true}
+                                  className="MuiTab-root MuiTab-textColorInherit Mui-selected"
+                                  disabled={false}
+                                  focusRipple={true}
+                                  id="maintenance-tab"
                                   onClick={[Function]}
-                                  onDragLeave={[Function]}
                                   onFocus={[Function]}
-                                  onKeyDown={[Function]}
-                                  onKeyUp={[Function]}
-                                  onMouseDown={[Function]}
-                                  onMouseLeave={[Function]}
-                                  onMouseUp={[Function]}
-                                  onTouchEnd={[Function]}
-                                  onTouchMove={[Function]}
-                                  onTouchStart={[Function]}
                                   role="tab"
-                                  tabIndex={-1}
-                                  to="/admin-download"
+                                  tabIndex={0}
                                 >
-                                  <LinkAnchor
-                                    aria-disabled={false}
-                                    aria-selected={false}
-                                    className="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit"
-                                    href="/admin-download"
-                                    id="download-tab"
-                                    navigate={[Function]}
-                                    onBlur={[Function]}
+                                  <ForwardRef(ButtonBase)
+                                    aria-controls="maintenance-panel"
+                                    aria-selected={true}
+                                    className="MuiTab-root MuiTab-textColorInherit Mui-selected"
+                                    classes={
+                                      Object {
+                                        "disabled": "Mui-disabled",
+                                        "focusVisible": "Mui-focusVisible",
+                                        "root": "MuiButtonBase-root",
+                                      }
+                                    }
+                                    disabled={false}
+                                    focusRipple={true}
+                                    id="maintenance-tab"
                                     onClick={[Function]}
-                                    onDragLeave={[Function]}
                                     onFocus={[Function]}
-                                    onKeyDown={[Function]}
-                                    onKeyUp={[Function]}
-                                    onMouseDown={[Function]}
-                                    onMouseLeave={[Function]}
-                                    onMouseUp={[Function]}
-                                    onTouchEnd={[Function]}
-                                    onTouchMove={[Function]}
-                                    onTouchStart={[Function]}
                                     role="tab"
-                                    tabIndex={-1}
+                                    tabIndex={0}
                                   >
-                                    <a
-                                      aria-disabled={false}
-                                      aria-selected={false}
-                                      className="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit"
-                                      href="/admin-download"
-                                      id="download-tab"
+                                    <button
+                                      aria-controls="maintenance-panel"
+                                      aria-selected={true}
+                                      className="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit Mui-selected"
+                                      disabled={false}
+                                      id="maintenance-tab"
                                       onBlur={[Function]}
                                       onClick={[Function]}
                                       onDragLeave={[Function]}
@@ -503,12 +314,13 @@ exports[`Admin page component should render correctly 1`] = `
                                       onTouchMove={[Function]}
                                       onTouchStart={[Function]}
                                       role="tab"
-                                      tabIndex={-1}
+                                      tabIndex={0}
+                                      type="button"
                                     >
                                       <span
                                         className="MuiTab-wrapper"
                                       >
-                                        Admin Download
+                                        Maintenance
                                       </span>
                                       <WithStyles(memo)
                                         center={false}
@@ -538,285 +350,430 @@ exports[`Admin page component should render correctly 1`] = `
                                           </span>
                                         </ForwardRef(TouchRipple)>
                                       </WithStyles(memo)>
-                                    </a>
-                                  </LinkAnchor>
-                                </Link>
-                              </ForwardRef(ButtonBase)>
-                            </WithStyles(ForwardRef(ButtonBase))>
-                          </ForwardRef(Tab)>
-                        </WithStyles(ForwardRef(Tab))>
-                      </div>
-                      <WithStyles(ForwardRef(TabIndicator))
-                        className="MuiTabs-indicator"
-                        color="secondary"
-                        orientation="horizontal"
-                        style={
-                          Object {
-                            "left": 0,
-                            "width": 0,
-                          }
-                        }
-                      >
-                        <ForwardRef(TabIndicator)
-                          className="MuiTabs-indicator"
-                          classes={
-                            Object {
-                              "colorPrimary": "PrivateTabIndicator-colorPrimary-7",
-                              "colorSecondary": "PrivateTabIndicator-colorSecondary-8",
-                              "root": "PrivateTabIndicator-root-6",
-                              "vertical": "PrivateTabIndicator-vertical-9",
-                            }
-                          }
-                          color="secondary"
-                          orientation="horizontal"
-                          style={
-                            Object {
-                              "left": 0,
-                              "width": 0,
-                            }
-                          }
-                        >
-                          <span
-                            className="PrivateTabIndicator-root-6 PrivateTabIndicator-colorSecondary-8 MuiTabs-indicator"
+                                    </button>
+                                  </ForwardRef(ButtonBase)>
+                                </WithStyles(ForwardRef(ButtonBase))>
+                              </ForwardRef(Tab)>
+                            </WithStyles(ForwardRef(Tab))>
+                            <WithStyles(ForwardRef(Tab))
+                              component={
+                                Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "displayName": "Link",
+                                  "propTypes": Object {
+                                    "innerRef": [Function],
+                                    "onClick": [Function],
+                                    "replace": [Function],
+                                    "target": [Function],
+                                    "to": [Function],
+                                  },
+                                  "render": [Function],
+                                }
+                              }
+                              fullWidth={false}
+                              id="download-tab"
+                              indicator={false}
+                              key=".1"
+                              label="Admin Download"
+                              onChange={[Function]}
+                              selected={false}
+                              textColor="inherit"
+                              to="/admin-download"
+                              value="download"
+                            >
+                              <ForwardRef(Tab)
+                                classes={
+                                  Object {
+                                    "disabled": "Mui-disabled",
+                                    "fullWidth": "MuiTab-fullWidth",
+                                    "labelIcon": "MuiTab-labelIcon",
+                                    "root": "MuiTab-root",
+                                    "selected": "Mui-selected",
+                                    "textColorInherit": "MuiTab-textColorInherit",
+                                    "textColorPrimary": "MuiTab-textColorPrimary",
+                                    "textColorSecondary": "MuiTab-textColorSecondary",
+                                    "wrapped": "MuiTab-wrapped",
+                                    "wrapper": "MuiTab-wrapper",
+                                  }
+                                }
+                                component={
+                                  Object {
+                                    "$$typeof": Symbol(react.forward_ref),
+                                    "displayName": "Link",
+                                    "propTypes": Object {
+                                      "innerRef": [Function],
+                                      "onClick": [Function],
+                                      "replace": [Function],
+                                      "target": [Function],
+                                      "to": [Function],
+                                    },
+                                    "render": [Function],
+                                  }
+                                }
+                                fullWidth={false}
+                                id="download-tab"
+                                indicator={false}
+                                label="Admin Download"
+                                onChange={[Function]}
+                                selected={false}
+                                textColor="inherit"
+                                to="/admin-download"
+                                value="download"
+                              >
+                                <WithStyles(ForwardRef(ButtonBase))
+                                  aria-selected={false}
+                                  className="MuiTab-root MuiTab-textColorInherit"
+                                  component={
+                                    Object {
+                                      "$$typeof": Symbol(react.forward_ref),
+                                      "displayName": "Link",
+                                      "propTypes": Object {
+                                        "innerRef": [Function],
+                                        "onClick": [Function],
+                                        "replace": [Function],
+                                        "target": [Function],
+                                        "to": [Function],
+                                      },
+                                      "render": [Function],
+                                    }
+                                  }
+                                  disabled={false}
+                                  focusRipple={true}
+                                  id="download-tab"
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  role="tab"
+                                  tabIndex={-1}
+                                  to="/admin-download"
+                                >
+                                  <ForwardRef(ButtonBase)
+                                    aria-selected={false}
+                                    className="MuiTab-root MuiTab-textColorInherit"
+                                    classes={
+                                      Object {
+                                        "disabled": "Mui-disabled",
+                                        "focusVisible": "Mui-focusVisible",
+                                        "root": "MuiButtonBase-root",
+                                      }
+                                    }
+                                    component={
+                                      Object {
+                                        "$$typeof": Symbol(react.forward_ref),
+                                        "displayName": "Link",
+                                        "propTypes": Object {
+                                          "innerRef": [Function],
+                                          "onClick": [Function],
+                                          "replace": [Function],
+                                          "target": [Function],
+                                          "to": [Function],
+                                        },
+                                        "render": [Function],
+                                      }
+                                    }
+                                    disabled={false}
+                                    focusRipple={true}
+                                    id="download-tab"
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                    role="tab"
+                                    tabIndex={-1}
+                                    to="/admin-download"
+                                  >
+                                    <Link
+                                      aria-disabled={false}
+                                      aria-selected={false}
+                                      className="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit"
+                                      id="download-tab"
+                                      onBlur={[Function]}
+                                      onClick={[Function]}
+                                      onDragLeave={[Function]}
+                                      onFocus={[Function]}
+                                      onKeyDown={[Function]}
+                                      onKeyUp={[Function]}
+                                      onMouseDown={[Function]}
+                                      onMouseLeave={[Function]}
+                                      onMouseUp={[Function]}
+                                      onTouchEnd={[Function]}
+                                      onTouchMove={[Function]}
+                                      onTouchStart={[Function]}
+                                      role="tab"
+                                      tabIndex={-1}
+                                      to="/admin-download"
+                                    >
+                                      <LinkAnchor
+                                        aria-disabled={false}
+                                        aria-selected={false}
+                                        className="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit"
+                                        href="/admin-download"
+                                        id="download-tab"
+                                        navigate={[Function]}
+                                        onBlur={[Function]}
+                                        onClick={[Function]}
+                                        onDragLeave={[Function]}
+                                        onFocus={[Function]}
+                                        onKeyDown={[Function]}
+                                        onKeyUp={[Function]}
+                                        onMouseDown={[Function]}
+                                        onMouseLeave={[Function]}
+                                        onMouseUp={[Function]}
+                                        onTouchEnd={[Function]}
+                                        onTouchMove={[Function]}
+                                        onTouchStart={[Function]}
+                                        role="tab"
+                                        tabIndex={-1}
+                                      >
+                                        <a
+                                          aria-disabled={false}
+                                          aria-selected={false}
+                                          className="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit"
+                                          href="/admin-download"
+                                          id="download-tab"
+                                          onBlur={[Function]}
+                                          onClick={[Function]}
+                                          onDragLeave={[Function]}
+                                          onFocus={[Function]}
+                                          onKeyDown={[Function]}
+                                          onKeyUp={[Function]}
+                                          onMouseDown={[Function]}
+                                          onMouseLeave={[Function]}
+                                          onMouseUp={[Function]}
+                                          onTouchEnd={[Function]}
+                                          onTouchMove={[Function]}
+                                          onTouchStart={[Function]}
+                                          role="tab"
+                                          tabIndex={-1}
+                                        >
+                                          <span
+                                            className="MuiTab-wrapper"
+                                          >
+                                            Admin Download
+                                          </span>
+                                          <WithStyles(memo)
+                                            center={false}
+                                          >
+                                            <ForwardRef(TouchRipple)
+                                              center={false}
+                                              classes={
+                                                Object {
+                                                  "child": "MuiTouchRipple-child",
+                                                  "childLeaving": "MuiTouchRipple-childLeaving",
+                                                  "childPulsate": "MuiTouchRipple-childPulsate",
+                                                  "ripple": "MuiTouchRipple-ripple",
+                                                  "ripplePulsate": "MuiTouchRipple-ripplePulsate",
+                                                  "rippleVisible": "MuiTouchRipple-rippleVisible",
+                                                  "root": "MuiTouchRipple-root",
+                                                }
+                                              }
+                                            >
+                                              <span
+                                                className="MuiTouchRipple-root"
+                                              >
+                                                <TransitionGroup
+                                                  childFactory={[Function]}
+                                                  component={null}
+                                                  exit={true}
+                                                />
+                                              </span>
+                                            </ForwardRef(TouchRipple)>
+                                          </WithStyles(memo)>
+                                        </a>
+                                      </LinkAnchor>
+                                    </Link>
+                                  </ForwardRef(ButtonBase)>
+                                </WithStyles(ForwardRef(ButtonBase))>
+                              </ForwardRef(Tab)>
+                            </WithStyles(ForwardRef(Tab))>
+                          </div>
+                          <WithStyles(ForwardRef(TabIndicator))
+                            className="MuiTabs-indicator"
+                            color="secondary"
+                            orientation="horizontal"
                             style={
                               Object {
                                 "left": 0,
                                 "width": 0,
                               }
                             }
-                          />
-                        </ForwardRef(TabIndicator)>
-                      </WithStyles(ForwardRef(TabIndicator))>
-                    </div>
-                  </div>
-                </ForwardRef(Tabs)>
-              </WithStyles(ForwardRef(Tabs))>
-              <div
-                aria-labelledby="maintenance-tab"
-                hidden={false}
-                id="maintenance-panel"
-                role="tabpanel"
-              >
-                <WithStyles(ForwardRef(Paper))
-                  className="AdminPage-paper-3"
-                >
-                  <ForwardRef(Paper)
-                    className="AdminPage-paper-3"
-                    classes={
-                      Object {
-                        "elevation0": "MuiPaper-elevation0",
-                        "elevation1": "MuiPaper-elevation1",
-                        "elevation10": "MuiPaper-elevation10",
-                        "elevation11": "MuiPaper-elevation11",
-                        "elevation12": "MuiPaper-elevation12",
-                        "elevation13": "MuiPaper-elevation13",
-                        "elevation14": "MuiPaper-elevation14",
-                        "elevation15": "MuiPaper-elevation15",
-                        "elevation16": "MuiPaper-elevation16",
-                        "elevation17": "MuiPaper-elevation17",
-                        "elevation18": "MuiPaper-elevation18",
-                        "elevation19": "MuiPaper-elevation19",
-                        "elevation2": "MuiPaper-elevation2",
-                        "elevation20": "MuiPaper-elevation20",
-                        "elevation21": "MuiPaper-elevation21",
-                        "elevation22": "MuiPaper-elevation22",
-                        "elevation23": "MuiPaper-elevation23",
-                        "elevation24": "MuiPaper-elevation24",
-                        "elevation3": "MuiPaper-elevation3",
-                        "elevation4": "MuiPaper-elevation4",
-                        "elevation5": "MuiPaper-elevation5",
-                        "elevation6": "MuiPaper-elevation6",
-                        "elevation7": "MuiPaper-elevation7",
-                        "elevation8": "MuiPaper-elevation8",
-                        "elevation9": "MuiPaper-elevation9",
-                        "outlined": "MuiPaper-outlined",
-                        "root": "MuiPaper-root",
-                        "rounded": "MuiPaper-rounded",
-                      }
-                    }
-                  >
-                    <div
-                      className="MuiPaper-root AdminPage-paper-3 MuiPaper-elevation1 MuiPaper-rounded"
-                    >
-                      <WithStyles(ForwardRef(Typography))
-                        variant="h4"
-                      >
-                        <ForwardRef(Typography)
-                          classes={
-                            Object {
-                              "alignCenter": "MuiTypography-alignCenter",
-                              "alignJustify": "MuiTypography-alignJustify",
-                              "alignLeft": "MuiTypography-alignLeft",
-                              "alignRight": "MuiTypography-alignRight",
-                              "body1": "MuiTypography-body1",
-                              "body2": "MuiTypography-body2",
-                              "button": "MuiTypography-button",
-                              "caption": "MuiTypography-caption",
-                              "colorError": "MuiTypography-colorError",
-                              "colorInherit": "MuiTypography-colorInherit",
-                              "colorPrimary": "MuiTypography-colorPrimary",
-                              "colorSecondary": "MuiTypography-colorSecondary",
-                              "colorTextPrimary": "MuiTypography-colorTextPrimary",
-                              "colorTextSecondary": "MuiTypography-colorTextSecondary",
-                              "displayBlock": "MuiTypography-displayBlock",
-                              "displayInline": "MuiTypography-displayInline",
-                              "gutterBottom": "MuiTypography-gutterBottom",
-                              "h1": "MuiTypography-h1",
-                              "h2": "MuiTypography-h2",
-                              "h3": "MuiTypography-h3",
-                              "h4": "MuiTypography-h4",
-                              "h5": "MuiTypography-h5",
-                              "h6": "MuiTypography-h6",
-                              "noWrap": "MuiTypography-noWrap",
-                              "overline": "MuiTypography-overline",
-                              "paragraph": "MuiTypography-paragraph",
-                              "root": "MuiTypography-root",
-                              "srOnly": "MuiTypography-srOnly",
-                              "subtitle1": "MuiTypography-subtitle1",
-                              "subtitle2": "MuiTypography-subtitle2",
-                            }
-                          }
-                          variant="h4"
-                        >
-                          <h4
-                            className="MuiTypography-root MuiTypography-h4"
                           >
-                            scheduled-maintenance-title
-                          </h4>
-                        </ForwardRef(Typography)>
-                      </WithStyles(ForwardRef(Typography))>
-                      <ForwardRef(TextareaAutosize)
-                        aria-label="scheduled-maintenance-message-arialabel"
-                        className="AdminPage-textArea-5"
-                        onChange={[Function]}
-                        placeholder="message-placeholder"
-                        rows={7}
-                        value=""
-                      >
-                        <textarea
-                          aria-label="scheduled-maintenance-message-arialabel"
-                          className="AdminPage-textArea-5"
-                          onChange={[Function]}
-                          placeholder="message-placeholder"
-                          rows={7}
-                          style={
-                            Object {
-                              "height": -4,
-                              "overflow": "hidden",
-                            }
-                          }
-                          value=""
-                        />
-                        <textarea
-                          aria-hidden={true}
-                          className="AdminPage-textArea-5"
-                          readOnly={true}
-                          style={
-                            Object {
-                              "height": 0,
-                              "left": 0,
-                              "overflow": "hidden",
-                              "position": "absolute",
-                              "top": 0,
-                              "transform": "translateZ(0)",
-                              "visibility": "hidden",
-                            }
-                          }
-                          tabIndex={-1}
-                        />
-                      </ForwardRef(TextareaAutosize)>
-                      <div
-                        style={
-                          Object {
-                            "display": "row",
-                          }
-                        }
-                      >
-                        <WithStyles(ForwardRef(FormControlLabel))
-                          control={
-                            <WithStyles(ForwardRef(Checkbox))
-                              checked={false}
-                              color="secondary"
-                              inputProps={
+                            <ForwardRef(TabIndicator)
+                              className="MuiTabs-indicator"
+                              classes={
                                 Object {
-                                  "aria-label": "scheduled-maintenance-checkbox-arialabel",
+                                  "colorPrimary": "PrivateTabIndicator-colorPrimary-7",
+                                  "colorSecondary": "PrivateTabIndicator-colorSecondary-8",
+                                  "root": "PrivateTabIndicator-root-6",
+                                  "vertical": "PrivateTabIndicator-vertical-9",
                                 }
                               }
-                              onChange={[Function]}
-                            />
-                          }
-                          label="display-checkbox"
-                          labelPlacement="end"
-                          style={
-                            Object {
-                              "float": "left",
-                            }
-                          }
-                          value={false}
-                        >
-                          <ForwardRef(FormControlLabel)
-                            classes={
-                              Object {
-                                "disabled": "Mui-disabled",
-                                "label": "MuiFormControlLabel-label",
-                                "labelPlacementBottom": "MuiFormControlLabel-labelPlacementBottom",
-                                "labelPlacementStart": "MuiFormControlLabel-labelPlacementStart",
-                                "labelPlacementTop": "MuiFormControlLabel-labelPlacementTop",
-                                "root": "MuiFormControlLabel-root",
-                              }
-                            }
-                            control={
-                              <WithStyles(ForwardRef(Checkbox))
-                                checked={false}
-                                color="secondary"
-                                inputProps={
-                                  Object {
-                                    "aria-label": "scheduled-maintenance-checkbox-arialabel",
-                                  }
-                                }
-                                onChange={[Function]}
-                              />
-                            }
-                            label="display-checkbox"
-                            labelPlacement="end"
-                            style={
-                              Object {
-                                "float": "left",
-                              }
-                            }
-                            value={false}
-                          >
-                            <label
-                              className="MuiFormControlLabel-root"
+                              color="secondary"
+                              orientation="horizontal"
                               style={
                                 Object {
-                                  "float": "left",
+                                  "left": 0,
+                                  "width": 0,
                                 }
                               }
                             >
-                              <WithStyles(ForwardRef(Checkbox))
-                                checked={false}
-                                color="secondary"
-                                inputProps={
+                              <span
+                                className="PrivateTabIndicator-root-6 PrivateTabIndicator-colorSecondary-8 MuiTabs-indicator"
+                                style={
                                   Object {
-                                    "aria-label": "scheduled-maintenance-checkbox-arialabel",
+                                    "left": 0,
+                                    "width": 0,
                                   }
                                 }
-                                onChange={[Function]}
-                                value={false}
+                              />
+                            </ForwardRef(TabIndicator)>
+                          </WithStyles(ForwardRef(TabIndicator))>
+                        </div>
+                      </div>
+                    </ForwardRef(Tabs)>
+                  </WithStyles(ForwardRef(Tabs))>
+                  <div
+                    aria-labelledby="maintenance-tab"
+                    hidden={false}
+                    id="maintenance-panel"
+                    role="tabpanel"
+                  >
+                    <WithStyles(ForwardRef(Paper))
+                      className="AdminPage-paper-3"
+                    >
+                      <ForwardRef(Paper)
+                        className="AdminPage-paper-3"
+                        classes={
+                          Object {
+                            "elevation0": "MuiPaper-elevation0",
+                            "elevation1": "MuiPaper-elevation1",
+                            "elevation10": "MuiPaper-elevation10",
+                            "elevation11": "MuiPaper-elevation11",
+                            "elevation12": "MuiPaper-elevation12",
+                            "elevation13": "MuiPaper-elevation13",
+                            "elevation14": "MuiPaper-elevation14",
+                            "elevation15": "MuiPaper-elevation15",
+                            "elevation16": "MuiPaper-elevation16",
+                            "elevation17": "MuiPaper-elevation17",
+                            "elevation18": "MuiPaper-elevation18",
+                            "elevation19": "MuiPaper-elevation19",
+                            "elevation2": "MuiPaper-elevation2",
+                            "elevation20": "MuiPaper-elevation20",
+                            "elevation21": "MuiPaper-elevation21",
+                            "elevation22": "MuiPaper-elevation22",
+                            "elevation23": "MuiPaper-elevation23",
+                            "elevation24": "MuiPaper-elevation24",
+                            "elevation3": "MuiPaper-elevation3",
+                            "elevation4": "MuiPaper-elevation4",
+                            "elevation5": "MuiPaper-elevation5",
+                            "elevation6": "MuiPaper-elevation6",
+                            "elevation7": "MuiPaper-elevation7",
+                            "elevation8": "MuiPaper-elevation8",
+                            "elevation9": "MuiPaper-elevation9",
+                            "outlined": "MuiPaper-outlined",
+                            "root": "MuiPaper-root",
+                            "rounded": "MuiPaper-rounded",
+                          }
+                        }
+                      >
+                        <div
+                          className="MuiPaper-root AdminPage-paper-3 MuiPaper-elevation1 MuiPaper-rounded"
+                        >
+                          <WithStyles(ForwardRef(Typography))
+                            variant="h4"
+                          >
+                            <ForwardRef(Typography)
+                              classes={
+                                Object {
+                                  "alignCenter": "MuiTypography-alignCenter",
+                                  "alignJustify": "MuiTypography-alignJustify",
+                                  "alignLeft": "MuiTypography-alignLeft",
+                                  "alignRight": "MuiTypography-alignRight",
+                                  "body1": "MuiTypography-body1",
+                                  "body2": "MuiTypography-body2",
+                                  "button": "MuiTypography-button",
+                                  "caption": "MuiTypography-caption",
+                                  "colorError": "MuiTypography-colorError",
+                                  "colorInherit": "MuiTypography-colorInherit",
+                                  "colorPrimary": "MuiTypography-colorPrimary",
+                                  "colorSecondary": "MuiTypography-colorSecondary",
+                                  "colorTextPrimary": "MuiTypography-colorTextPrimary",
+                                  "colorTextSecondary": "MuiTypography-colorTextSecondary",
+                                  "displayBlock": "MuiTypography-displayBlock",
+                                  "displayInline": "MuiTypography-displayInline",
+                                  "gutterBottom": "MuiTypography-gutterBottom",
+                                  "h1": "MuiTypography-h1",
+                                  "h2": "MuiTypography-h2",
+                                  "h3": "MuiTypography-h3",
+                                  "h4": "MuiTypography-h4",
+                                  "h5": "MuiTypography-h5",
+                                  "h6": "MuiTypography-h6",
+                                  "noWrap": "MuiTypography-noWrap",
+                                  "overline": "MuiTypography-overline",
+                                  "paragraph": "MuiTypography-paragraph",
+                                  "root": "MuiTypography-root",
+                                  "srOnly": "MuiTypography-srOnly",
+                                  "subtitle1": "MuiTypography-subtitle1",
+                                  "subtitle2": "MuiTypography-subtitle2",
+                                }
+                              }
+                              variant="h4"
+                            >
+                              <h4
+                                className="MuiTypography-root MuiTypography-h4"
                               >
-                                <ForwardRef(Checkbox)
+                                scheduled-maintenance-title
+                              </h4>
+                            </ForwardRef(Typography)>
+                          </WithStyles(ForwardRef(Typography))>
+                          <ForwardRef(TextareaAutosize)
+                            aria-label="scheduled-maintenance-message-arialabel"
+                            className="AdminPage-textArea-5"
+                            onChange={[Function]}
+                            placeholder="message-placeholder"
+                            rows={7}
+                            value=""
+                          >
+                            <textarea
+                              aria-label="scheduled-maintenance-message-arialabel"
+                              className="AdminPage-textArea-5"
+                              onChange={[Function]}
+                              placeholder="message-placeholder"
+                              rows={7}
+                              style={
+                                Object {
+                                  "height": -4,
+                                  "overflow": "hidden",
+                                }
+                              }
+                              value=""
+                            />
+                            <textarea
+                              aria-hidden={true}
+                              className="AdminPage-textArea-5"
+                              readOnly={true}
+                              style={
+                                Object {
+                                  "height": 0,
+                                  "left": 0,
+                                  "overflow": "hidden",
+                                  "position": "absolute",
+                                  "top": 0,
+                                  "transform": "translateZ(0)",
+                                  "visibility": "hidden",
+                                }
+                              }
+                              tabIndex={-1}
+                            />
+                          </ForwardRef(TextareaAutosize)>
+                          <div
+                            style={
+                              Object {
+                                "display": "row",
+                              }
+                            }
+                          >
+                            <WithStyles(ForwardRef(FormControlLabel))
+                              control={
+                                <WithStyles(ForwardRef(Checkbox))
                                   checked={false}
-                                  classes={
-                                    Object {
-                                      "checked": "Mui-checked",
-                                      "colorPrimary": "MuiCheckbox-colorPrimary",
-                                      "colorSecondary": "MuiCheckbox-colorSecondary",
-                                      "disabled": "Mui-disabled",
-                                      "indeterminate": "MuiCheckbox-indeterminate",
-                                      "root": "MuiCheckbox-root",
-                                    }
-                                  }
                                   color="secondary"
                                   inputProps={
                                     Object {
@@ -824,693 +781,693 @@ exports[`Admin page component should render correctly 1`] = `
                                     }
                                   }
                                   onChange={[Function]}
-                                  value={false}
-                                >
-                                  <WithStyles(ForwardRef(SwitchBase))
+                                />
+                              }
+                              label="display-checkbox"
+                              labelPlacement="end"
+                              style={
+                                Object {
+                                  "float": "left",
+                                }
+                              }
+                              value={false}
+                            >
+                              <ForwardRef(FormControlLabel)
+                                classes={
+                                  Object {
+                                    "disabled": "Mui-disabled",
+                                    "label": "MuiFormControlLabel-label",
+                                    "labelPlacementBottom": "MuiFormControlLabel-labelPlacementBottom",
+                                    "labelPlacementStart": "MuiFormControlLabel-labelPlacementStart",
+                                    "labelPlacementTop": "MuiFormControlLabel-labelPlacementTop",
+                                    "root": "MuiFormControlLabel-root",
+                                  }
+                                }
+                                control={
+                                  <WithStyles(ForwardRef(Checkbox))
                                     checked={false}
-                                    checkedIcon={<Memo />}
-                                    classes={
-                                      Object {
-                                        "checked": "Mui-checked",
-                                        "disabled": "Mui-disabled",
-                                        "root": "MuiCheckbox-root MuiCheckbox-colorSecondary",
-                                      }
-                                    }
                                     color="secondary"
-                                    icon={<Memo />}
                                     inputProps={
                                       Object {
                                         "aria-label": "scheduled-maintenance-checkbox-arialabel",
-                                        "data-indeterminate": false,
                                       }
                                     }
                                     onChange={[Function]}
-                                    type="checkbox"
+                                  />
+                                }
+                                label="display-checkbox"
+                                labelPlacement="end"
+                                style={
+                                  Object {
+                                    "float": "left",
+                                  }
+                                }
+                                value={false}
+                              >
+                                <label
+                                  className="MuiFormControlLabel-root"
+                                  style={
+                                    Object {
+                                      "float": "left",
+                                    }
+                                  }
+                                >
+                                  <WithStyles(ForwardRef(Checkbox))
+                                    checked={false}
+                                    color="secondary"
+                                    inputProps={
+                                      Object {
+                                        "aria-label": "scheduled-maintenance-checkbox-arialabel",
+                                      }
+                                    }
+                                    onChange={[Function]}
                                     value={false}
                                   >
-                                    <ForwardRef(SwitchBase)
+                                    <ForwardRef(Checkbox)
                                       checked={false}
-                                      checkedIcon={<Memo />}
                                       classes={
                                         Object {
-                                          "checked": "PrivateSwitchBase-checked-11 Mui-checked",
-                                          "disabled": "PrivateSwitchBase-disabled-12 Mui-disabled",
-                                          "input": "PrivateSwitchBase-input-13",
-                                          "root": "PrivateSwitchBase-root-10 MuiCheckbox-root MuiCheckbox-colorSecondary",
+                                          "checked": "Mui-checked",
+                                          "colorPrimary": "MuiCheckbox-colorPrimary",
+                                          "colorSecondary": "MuiCheckbox-colorSecondary",
+                                          "disabled": "Mui-disabled",
+                                          "indeterminate": "MuiCheckbox-indeterminate",
+                                          "root": "MuiCheckbox-root",
                                         }
                                       }
                                       color="secondary"
-                                      icon={<Memo />}
                                       inputProps={
                                         Object {
                                           "aria-label": "scheduled-maintenance-checkbox-arialabel",
-                                          "data-indeterminate": false,
                                         }
                                       }
                                       onChange={[Function]}
-                                      type="checkbox"
                                       value={false}
                                     >
-                                      <WithStyles(ForwardRef(IconButton))
-                                        className="PrivateSwitchBase-root-10 MuiCheckbox-root MuiCheckbox-colorSecondary"
+                                      <WithStyles(ForwardRef(SwitchBase))
+                                        checked={false}
+                                        checkedIcon={<Memo />}
+                                        classes={
+                                          Object {
+                                            "checked": "Mui-checked",
+                                            "disabled": "Mui-disabled",
+                                            "root": "MuiCheckbox-root MuiCheckbox-colorSecondary",
+                                          }
+                                        }
                                         color="secondary"
-                                        component="span"
-                                        onBlur={[Function]}
-                                        onFocus={[Function]}
-                                        tabIndex={null}
+                                        icon={<Memo />}
+                                        inputProps={
+                                          Object {
+                                            "aria-label": "scheduled-maintenance-checkbox-arialabel",
+                                            "data-indeterminate": false,
+                                          }
+                                        }
+                                        onChange={[Function]}
+                                        type="checkbox"
+                                        value={false}
                                       >
-                                        <ForwardRef(IconButton)
-                                          className="PrivateSwitchBase-root-10 MuiCheckbox-root MuiCheckbox-colorSecondary"
+                                        <ForwardRef(SwitchBase)
+                                          checked={false}
+                                          checkedIcon={<Memo />}
                                           classes={
                                             Object {
-                                              "colorInherit": "MuiIconButton-colorInherit",
-                                              "colorPrimary": "MuiIconButton-colorPrimary",
-                                              "colorSecondary": "MuiIconButton-colorSecondary",
-                                              "disabled": "Mui-disabled",
-                                              "edgeEnd": "MuiIconButton-edgeEnd",
-                                              "edgeStart": "MuiIconButton-edgeStart",
-                                              "label": "MuiIconButton-label",
-                                              "root": "MuiIconButton-root",
-                                              "sizeSmall": "MuiIconButton-sizeSmall",
+                                              "checked": "PrivateSwitchBase-checked-11 Mui-checked",
+                                              "disabled": "PrivateSwitchBase-disabled-12 Mui-disabled",
+                                              "input": "PrivateSwitchBase-input-13",
+                                              "root": "PrivateSwitchBase-root-10 MuiCheckbox-root MuiCheckbox-colorSecondary",
                                             }
                                           }
                                           color="secondary"
-                                          component="span"
-                                          onBlur={[Function]}
-                                          onFocus={[Function]}
-                                          tabIndex={null}
+                                          icon={<Memo />}
+                                          inputProps={
+                                            Object {
+                                              "aria-label": "scheduled-maintenance-checkbox-arialabel",
+                                              "data-indeterminate": false,
+                                            }
+                                          }
+                                          onChange={[Function]}
+                                          type="checkbox"
+                                          value={false}
                                         >
-                                          <WithStyles(ForwardRef(ButtonBase))
-                                            centerRipple={true}
-                                            className="MuiIconButton-root PrivateSwitchBase-root-10 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
+                                          <WithStyles(ForwardRef(IconButton))
+                                            className="PrivateSwitchBase-root-10 MuiCheckbox-root MuiCheckbox-colorSecondary"
+                                            color="secondary"
                                             component="span"
-                                            disabled={false}
-                                            focusRipple={true}
                                             onBlur={[Function]}
                                             onFocus={[Function]}
                                             tabIndex={null}
                                           >
-                                            <ForwardRef(ButtonBase)
-                                              centerRipple={true}
-                                              className="MuiIconButton-root PrivateSwitchBase-root-10 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
+                                            <ForwardRef(IconButton)
+                                              className="PrivateSwitchBase-root-10 MuiCheckbox-root MuiCheckbox-colorSecondary"
                                               classes={
                                                 Object {
+                                                  "colorInherit": "MuiIconButton-colorInherit",
+                                                  "colorPrimary": "MuiIconButton-colorPrimary",
+                                                  "colorSecondary": "MuiIconButton-colorSecondary",
                                                   "disabled": "Mui-disabled",
-                                                  "focusVisible": "Mui-focusVisible",
-                                                  "root": "MuiButtonBase-root",
+                                                  "edgeEnd": "MuiIconButton-edgeEnd",
+                                                  "edgeStart": "MuiIconButton-edgeStart",
+                                                  "label": "MuiIconButton-label",
+                                                  "root": "MuiIconButton-root",
+                                                  "sizeSmall": "MuiIconButton-sizeSmall",
                                                 }
                                               }
+                                              color="secondary"
                                               component="span"
-                                              disabled={false}
-                                              focusRipple={true}
                                               onBlur={[Function]}
                                               onFocus={[Function]}
                                               tabIndex={null}
                                             >
-                                              <span
-                                                aria-disabled={false}
-                                                className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-10 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
+                                              <WithStyles(ForwardRef(ButtonBase))
+                                                centerRipple={true}
+                                                className="MuiIconButton-root PrivateSwitchBase-root-10 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
+                                                component="span"
+                                                disabled={false}
+                                                focusRipple={true}
                                                 onBlur={[Function]}
-                                                onDragLeave={[Function]}
                                                 onFocus={[Function]}
-                                                onKeyDown={[Function]}
-                                                onKeyUp={[Function]}
-                                                onMouseDown={[Function]}
-                                                onMouseLeave={[Function]}
-                                                onMouseUp={[Function]}
-                                                onTouchEnd={[Function]}
-                                                onTouchMove={[Function]}
-                                                onTouchStart={[Function]}
                                                 tabIndex={null}
                                               >
-                                                <span
-                                                  className="MuiIconButton-label"
+                                                <ForwardRef(ButtonBase)
+                                                  centerRipple={true}
+                                                  className="MuiIconButton-root PrivateSwitchBase-root-10 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
+                                                  classes={
+                                                    Object {
+                                                      "disabled": "Mui-disabled",
+                                                      "focusVisible": "Mui-focusVisible",
+                                                      "root": "MuiButtonBase-root",
+                                                    }
+                                                  }
+                                                  component="span"
+                                                  disabled={false}
+                                                  focusRipple={true}
+                                                  onBlur={[Function]}
+                                                  onFocus={[Function]}
+                                                  tabIndex={null}
                                                 >
-                                                  <input
-                                                    aria-label="scheduled-maintenance-checkbox-arialabel"
-                                                    checked={false}
-                                                    className="PrivateSwitchBase-input-13"
-                                                    data-indeterminate={false}
-                                                    onChange={[Function]}
-                                                    type="checkbox"
-                                                    value={false}
-                                                  />
-                                                  <ForwardRef(CheckBoxOutlineBlankIcon)>
-                                                    <WithStyles(ForwardRef(SvgIcon))>
-                                                      <ForwardRef(SvgIcon)
+                                                  <span
+                                                    aria-disabled={false}
+                                                    className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-10 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
+                                                    onBlur={[Function]}
+                                                    onDragLeave={[Function]}
+                                                    onFocus={[Function]}
+                                                    onKeyDown={[Function]}
+                                                    onKeyUp={[Function]}
+                                                    onMouseDown={[Function]}
+                                                    onMouseLeave={[Function]}
+                                                    onMouseUp={[Function]}
+                                                    onTouchEnd={[Function]}
+                                                    onTouchMove={[Function]}
+                                                    onTouchStart={[Function]}
+                                                    tabIndex={null}
+                                                  >
+                                                    <span
+                                                      className="MuiIconButton-label"
+                                                    >
+                                                      <input
+                                                        aria-label="scheduled-maintenance-checkbox-arialabel"
+                                                        checked={false}
+                                                        className="PrivateSwitchBase-input-13"
+                                                        data-indeterminate={false}
+                                                        onChange={[Function]}
+                                                        type="checkbox"
+                                                        value={false}
+                                                      />
+                                                      <ForwardRef(CheckBoxOutlineBlankIcon)>
+                                                        <WithStyles(ForwardRef(SvgIcon))>
+                                                          <ForwardRef(SvgIcon)
+                                                            classes={
+                                                              Object {
+                                                                "colorAction": "MuiSvgIcon-colorAction",
+                                                                "colorDisabled": "MuiSvgIcon-colorDisabled",
+                                                                "colorError": "MuiSvgIcon-colorError",
+                                                                "colorPrimary": "MuiSvgIcon-colorPrimary",
+                                                                "colorSecondary": "MuiSvgIcon-colorSecondary",
+                                                                "fontSizeInherit": "MuiSvgIcon-fontSizeInherit",
+                                                                "fontSizeLarge": "MuiSvgIcon-fontSizeLarge",
+                                                                "fontSizeSmall": "MuiSvgIcon-fontSizeSmall",
+                                                                "root": "MuiSvgIcon-root",
+                                                              }
+                                                            }
+                                                          >
+                                                            <svg
+                                                              aria-hidden={true}
+                                                              className="MuiSvgIcon-root"
+                                                              focusable="false"
+                                                              viewBox="0 0 24 24"
+                                                            >
+                                                              <path
+                                                                d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                                                              />
+                                                            </svg>
+                                                          </ForwardRef(SvgIcon)>
+                                                        </WithStyles(ForwardRef(SvgIcon))>
+                                                      </ForwardRef(CheckBoxOutlineBlankIcon)>
+                                                    </span>
+                                                    <WithStyles(memo)
+                                                      center={true}
+                                                    >
+                                                      <ForwardRef(TouchRipple)
+                                                        center={true}
                                                         classes={
                                                           Object {
-                                                            "colorAction": "MuiSvgIcon-colorAction",
-                                                            "colorDisabled": "MuiSvgIcon-colorDisabled",
-                                                            "colorError": "MuiSvgIcon-colorError",
-                                                            "colorPrimary": "MuiSvgIcon-colorPrimary",
-                                                            "colorSecondary": "MuiSvgIcon-colorSecondary",
-                                                            "fontSizeInherit": "MuiSvgIcon-fontSizeInherit",
-                                                            "fontSizeLarge": "MuiSvgIcon-fontSizeLarge",
-                                                            "fontSizeSmall": "MuiSvgIcon-fontSizeSmall",
-                                                            "root": "MuiSvgIcon-root",
+                                                            "child": "MuiTouchRipple-child",
+                                                            "childLeaving": "MuiTouchRipple-childLeaving",
+                                                            "childPulsate": "MuiTouchRipple-childPulsate",
+                                                            "ripple": "MuiTouchRipple-ripple",
+                                                            "ripplePulsate": "MuiTouchRipple-ripplePulsate",
+                                                            "rippleVisible": "MuiTouchRipple-rippleVisible",
+                                                            "root": "MuiTouchRipple-root",
                                                           }
                                                         }
                                                       >
-                                                        <svg
-                                                          aria-hidden={true}
-                                                          className="MuiSvgIcon-root"
-                                                          focusable="false"
-                                                          viewBox="0 0 24 24"
+                                                        <span
+                                                          className="MuiTouchRipple-root"
                                                         >
-                                                          <path
-                                                            d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                                                          <TransitionGroup
+                                                            childFactory={[Function]}
+                                                            component={null}
+                                                            exit={true}
                                                           />
-                                                        </svg>
-                                                      </ForwardRef(SvgIcon)>
-                                                    </WithStyles(ForwardRef(SvgIcon))>
-                                                  </ForwardRef(CheckBoxOutlineBlankIcon)>
-                                                </span>
-                                                <WithStyles(memo)
-                                                  center={true}
-                                                >
-                                                  <ForwardRef(TouchRipple)
-                                                    center={true}
-                                                    classes={
-                                                      Object {
-                                                        "child": "MuiTouchRipple-child",
-                                                        "childLeaving": "MuiTouchRipple-childLeaving",
-                                                        "childPulsate": "MuiTouchRipple-childPulsate",
-                                                        "ripple": "MuiTouchRipple-ripple",
-                                                        "ripplePulsate": "MuiTouchRipple-ripplePulsate",
-                                                        "rippleVisible": "MuiTouchRipple-rippleVisible",
-                                                        "root": "MuiTouchRipple-root",
-                                                      }
-                                                    }
-                                                  >
-                                                    <span
-                                                      className="MuiTouchRipple-root"
-                                                    >
-                                                      <TransitionGroup
-                                                        childFactory={[Function]}
-                                                        component={null}
-                                                        exit={true}
-                                                      />
-                                                    </span>
-                                                  </ForwardRef(TouchRipple)>
-                                                </WithStyles(memo)>
-                                              </span>
-                                            </ForwardRef(ButtonBase)>
-                                          </WithStyles(ForwardRef(ButtonBase))>
-                                        </ForwardRef(IconButton)>
-                                      </WithStyles(ForwardRef(IconButton))>
-                                    </ForwardRef(SwitchBase)>
-                                  </WithStyles(ForwardRef(SwitchBase))>
-                                </ForwardRef(Checkbox)>
-                              </WithStyles(ForwardRef(Checkbox))>
-                              <WithStyles(ForwardRef(Typography))
-                                className="MuiFormControlLabel-label"
-                                component="span"
-                              >
-                                <ForwardRef(Typography)
-                                  className="MuiFormControlLabel-label"
-                                  classes={
-                                    Object {
-                                      "alignCenter": "MuiTypography-alignCenter",
-                                      "alignJustify": "MuiTypography-alignJustify",
-                                      "alignLeft": "MuiTypography-alignLeft",
-                                      "alignRight": "MuiTypography-alignRight",
-                                      "body1": "MuiTypography-body1",
-                                      "body2": "MuiTypography-body2",
-                                      "button": "MuiTypography-button",
-                                      "caption": "MuiTypography-caption",
-                                      "colorError": "MuiTypography-colorError",
-                                      "colorInherit": "MuiTypography-colorInherit",
-                                      "colorPrimary": "MuiTypography-colorPrimary",
-                                      "colorSecondary": "MuiTypography-colorSecondary",
-                                      "colorTextPrimary": "MuiTypography-colorTextPrimary",
-                                      "colorTextSecondary": "MuiTypography-colorTextSecondary",
-                                      "displayBlock": "MuiTypography-displayBlock",
-                                      "displayInline": "MuiTypography-displayInline",
-                                      "gutterBottom": "MuiTypography-gutterBottom",
-                                      "h1": "MuiTypography-h1",
-                                      "h2": "MuiTypography-h2",
-                                      "h3": "MuiTypography-h3",
-                                      "h4": "MuiTypography-h4",
-                                      "h5": "MuiTypography-h5",
-                                      "h6": "MuiTypography-h6",
-                                      "noWrap": "MuiTypography-noWrap",
-                                      "overline": "MuiTypography-overline",
-                                      "paragraph": "MuiTypography-paragraph",
-                                      "root": "MuiTypography-root",
-                                      "srOnly": "MuiTypography-srOnly",
-                                      "subtitle1": "MuiTypography-subtitle1",
-                                      "subtitle2": "MuiTypography-subtitle2",
-                                    }
-                                  }
-                                  component="span"
-                                >
-                                  <span
-                                    className="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+                                                        </span>
+                                                      </ForwardRef(TouchRipple)>
+                                                    </WithStyles(memo)>
+                                                  </span>
+                                                </ForwardRef(ButtonBase)>
+                                              </WithStyles(ForwardRef(ButtonBase))>
+                                            </ForwardRef(IconButton)>
+                                          </WithStyles(ForwardRef(IconButton))>
+                                        </ForwardRef(SwitchBase)>
+                                      </WithStyles(ForwardRef(SwitchBase))>
+                                    </ForwardRef(Checkbox)>
+                                  </WithStyles(ForwardRef(Checkbox))>
+                                  <WithStyles(ForwardRef(Typography))
+                                    className="MuiFormControlLabel-label"
+                                    component="span"
                                   >
-                                    display-checkbox
-                                  </span>
-                                </ForwardRef(Typography)>
-                              </WithStyles(ForwardRef(Typography))>
-                            </label>
-                          </ForwardRef(FormControlLabel)>
-                        </WithStyles(ForwardRef(FormControlLabel))>
-                        <WithStyles(ForwardRef(Button))
-                          color="primary"
-                          onClick={[Function]}
-                          style={
-                            Object {
-                              "float": "right",
-                            }
-                          }
-                          variant="contained"
-                        >
-                          <ForwardRef(Button)
-                            classes={
-                              Object {
-                                "colorInherit": "MuiButton-colorInherit",
-                                "contained": "MuiButton-contained",
-                                "containedPrimary": "MuiButton-containedPrimary",
-                                "containedSecondary": "MuiButton-containedSecondary",
-                                "containedSizeLarge": "MuiButton-containedSizeLarge",
-                                "containedSizeSmall": "MuiButton-containedSizeSmall",
-                                "disableElevation": "MuiButton-disableElevation",
-                                "disabled": "Mui-disabled",
-                                "endIcon": "MuiButton-endIcon",
-                                "focusVisible": "Mui-focusVisible",
-                                "fullWidth": "MuiButton-fullWidth",
-                                "iconSizeLarge": "MuiButton-iconSizeLarge",
-                                "iconSizeMedium": "MuiButton-iconSizeMedium",
-                                "iconSizeSmall": "MuiButton-iconSizeSmall",
-                                "label": "MuiButton-label",
-                                "outlined": "MuiButton-outlined",
-                                "outlinedPrimary": "MuiButton-outlinedPrimary",
-                                "outlinedSecondary": "MuiButton-outlinedSecondary",
-                                "outlinedSizeLarge": "MuiButton-outlinedSizeLarge",
-                                "outlinedSizeSmall": "MuiButton-outlinedSizeSmall",
-                                "root": "MuiButton-root",
-                                "sizeLarge": "MuiButton-sizeLarge",
-                                "sizeSmall": "MuiButton-sizeSmall",
-                                "startIcon": "MuiButton-startIcon",
-                                "text": "MuiButton-text",
-                                "textPrimary": "MuiButton-textPrimary",
-                                "textSecondary": "MuiButton-textSecondary",
-                                "textSizeLarge": "MuiButton-textSizeLarge",
-                                "textSizeSmall": "MuiButton-textSizeSmall",
-                              }
-                            }
-                            color="primary"
-                            onClick={[Function]}
-                            style={
-                              Object {
-                                "float": "right",
-                              }
-                            }
-                            variant="contained"
-                          >
-                            <WithStyles(ForwardRef(ButtonBase))
-                              className="MuiButton-root MuiButton-contained MuiButton-containedPrimary"
-                              component="button"
-                              disabled={false}
-                              focusRipple={true}
-                              focusVisibleClassName="Mui-focusVisible"
+                                    <ForwardRef(Typography)
+                                      className="MuiFormControlLabel-label"
+                                      classes={
+                                        Object {
+                                          "alignCenter": "MuiTypography-alignCenter",
+                                          "alignJustify": "MuiTypography-alignJustify",
+                                          "alignLeft": "MuiTypography-alignLeft",
+                                          "alignRight": "MuiTypography-alignRight",
+                                          "body1": "MuiTypography-body1",
+                                          "body2": "MuiTypography-body2",
+                                          "button": "MuiTypography-button",
+                                          "caption": "MuiTypography-caption",
+                                          "colorError": "MuiTypography-colorError",
+                                          "colorInherit": "MuiTypography-colorInherit",
+                                          "colorPrimary": "MuiTypography-colorPrimary",
+                                          "colorSecondary": "MuiTypography-colorSecondary",
+                                          "colorTextPrimary": "MuiTypography-colorTextPrimary",
+                                          "colorTextSecondary": "MuiTypography-colorTextSecondary",
+                                          "displayBlock": "MuiTypography-displayBlock",
+                                          "displayInline": "MuiTypography-displayInline",
+                                          "gutterBottom": "MuiTypography-gutterBottom",
+                                          "h1": "MuiTypography-h1",
+                                          "h2": "MuiTypography-h2",
+                                          "h3": "MuiTypography-h3",
+                                          "h4": "MuiTypography-h4",
+                                          "h5": "MuiTypography-h5",
+                                          "h6": "MuiTypography-h6",
+                                          "noWrap": "MuiTypography-noWrap",
+                                          "overline": "MuiTypography-overline",
+                                          "paragraph": "MuiTypography-paragraph",
+                                          "root": "MuiTypography-root",
+                                          "srOnly": "MuiTypography-srOnly",
+                                          "subtitle1": "MuiTypography-subtitle1",
+                                          "subtitle2": "MuiTypography-subtitle2",
+                                        }
+                                      }
+                                      component="span"
+                                    >
+                                      <span
+                                        className="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+                                      >
+                                        display-checkbox
+                                      </span>
+                                    </ForwardRef(Typography)>
+                                  </WithStyles(ForwardRef(Typography))>
+                                </label>
+                              </ForwardRef(FormControlLabel)>
+                            </WithStyles(ForwardRef(FormControlLabel))>
+                            <WithStyles(ForwardRef(Button))
+                              color="primary"
                               onClick={[Function]}
                               style={
                                 Object {
                                   "float": "right",
                                 }
                               }
-                              type="button"
+                              variant="contained"
                             >
-                              <ForwardRef(ButtonBase)
-                                className="MuiButton-root MuiButton-contained MuiButton-containedPrimary"
+                              <ForwardRef(Button)
                                 classes={
                                   Object {
+                                    "colorInherit": "MuiButton-colorInherit",
+                                    "contained": "MuiButton-contained",
+                                    "containedPrimary": "MuiButton-containedPrimary",
+                                    "containedSecondary": "MuiButton-containedSecondary",
+                                    "containedSizeLarge": "MuiButton-containedSizeLarge",
+                                    "containedSizeSmall": "MuiButton-containedSizeSmall",
+                                    "disableElevation": "MuiButton-disableElevation",
                                     "disabled": "Mui-disabled",
+                                    "endIcon": "MuiButton-endIcon",
                                     "focusVisible": "Mui-focusVisible",
-                                    "root": "MuiButtonBase-root",
+                                    "fullWidth": "MuiButton-fullWidth",
+                                    "iconSizeLarge": "MuiButton-iconSizeLarge",
+                                    "iconSizeMedium": "MuiButton-iconSizeMedium",
+                                    "iconSizeSmall": "MuiButton-iconSizeSmall",
+                                    "label": "MuiButton-label",
+                                    "outlined": "MuiButton-outlined",
+                                    "outlinedPrimary": "MuiButton-outlinedPrimary",
+                                    "outlinedSecondary": "MuiButton-outlinedSecondary",
+                                    "outlinedSizeLarge": "MuiButton-outlinedSizeLarge",
+                                    "outlinedSizeSmall": "MuiButton-outlinedSizeSmall",
+                                    "root": "MuiButton-root",
+                                    "sizeLarge": "MuiButton-sizeLarge",
+                                    "sizeSmall": "MuiButton-sizeSmall",
+                                    "startIcon": "MuiButton-startIcon",
+                                    "text": "MuiButton-text",
+                                    "textPrimary": "MuiButton-textPrimary",
+                                    "textSecondary": "MuiButton-textSecondary",
+                                    "textSizeLarge": "MuiButton-textSizeLarge",
+                                    "textSizeSmall": "MuiButton-textSizeSmall",
                                   }
                                 }
-                                component="button"
-                                disabled={false}
-                                focusRipple={true}
-                                focusVisibleClassName="Mui-focusVisible"
+                                color="primary"
                                 onClick={[Function]}
                                 style={
                                   Object {
                                     "float": "right",
                                   }
                                 }
-                                type="button"
+                                variant="contained"
                               >
-                                <button
-                                  className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"
+                                <WithStyles(ForwardRef(ButtonBase))
+                                  className="MuiButton-root MuiButton-contained MuiButton-containedPrimary"
+                                  component="button"
                                   disabled={false}
-                                  onBlur={[Function]}
+                                  focusRipple={true}
+                                  focusVisibleClassName="Mui-focusVisible"
                                   onClick={[Function]}
-                                  onDragLeave={[Function]}
-                                  onFocus={[Function]}
-                                  onKeyDown={[Function]}
-                                  onKeyUp={[Function]}
-                                  onMouseDown={[Function]}
-                                  onMouseLeave={[Function]}
-                                  onMouseUp={[Function]}
-                                  onTouchEnd={[Function]}
-                                  onTouchMove={[Function]}
-                                  onTouchStart={[Function]}
                                   style={
                                     Object {
                                       "float": "right",
                                     }
                                   }
-                                  tabIndex={0}
                                   type="button"
                                 >
-                                  <span
-                                    className="MuiButton-label"
+                                  <ForwardRef(ButtonBase)
+                                    className="MuiButton-root MuiButton-contained MuiButton-containedPrimary"
+                                    classes={
+                                      Object {
+                                        "disabled": "Mui-disabled",
+                                        "focusVisible": "Mui-focusVisible",
+                                        "root": "MuiButtonBase-root",
+                                      }
+                                    }
+                                    component="button"
+                                    disabled={false}
+                                    focusRipple={true}
+                                    focusVisibleClassName="Mui-focusVisible"
+                                    onClick={[Function]}
+                                    style={
+                                      Object {
+                                        "float": "right",
+                                      }
+                                    }
+                                    type="button"
                                   >
-                                    <WithStyles(ForwardRef(Typography))
-                                      color="inherit"
-                                      noWrap={true}
+                                    <button
+                                      className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"
+                                      disabled={false}
+                                      onBlur={[Function]}
+                                      onClick={[Function]}
+                                      onDragLeave={[Function]}
+                                      onFocus={[Function]}
+                                      onKeyDown={[Function]}
+                                      onKeyUp={[Function]}
+                                      onMouseDown={[Function]}
+                                      onMouseLeave={[Function]}
+                                      onMouseUp={[Function]}
+                                      onTouchEnd={[Function]}
+                                      onTouchMove={[Function]}
+                                      onTouchStart={[Function]}
                                       style={
                                         Object {
-                                          "marginTop": 3,
+                                          "float": "right",
                                         }
                                       }
+                                      tabIndex={0}
+                                      type="button"
                                     >
-                                      <ForwardRef(Typography)
-                                        classes={
-                                          Object {
-                                            "alignCenter": "MuiTypography-alignCenter",
-                                            "alignJustify": "MuiTypography-alignJustify",
-                                            "alignLeft": "MuiTypography-alignLeft",
-                                            "alignRight": "MuiTypography-alignRight",
-                                            "body1": "MuiTypography-body1",
-                                            "body2": "MuiTypography-body2",
-                                            "button": "MuiTypography-button",
-                                            "caption": "MuiTypography-caption",
-                                            "colorError": "MuiTypography-colorError",
-                                            "colorInherit": "MuiTypography-colorInherit",
-                                            "colorPrimary": "MuiTypography-colorPrimary",
-                                            "colorSecondary": "MuiTypography-colorSecondary",
-                                            "colorTextPrimary": "MuiTypography-colorTextPrimary",
-                                            "colorTextSecondary": "MuiTypography-colorTextSecondary",
-                                            "displayBlock": "MuiTypography-displayBlock",
-                                            "displayInline": "MuiTypography-displayInline",
-                                            "gutterBottom": "MuiTypography-gutterBottom",
-                                            "h1": "MuiTypography-h1",
-                                            "h2": "MuiTypography-h2",
-                                            "h3": "MuiTypography-h3",
-                                            "h4": "MuiTypography-h4",
-                                            "h5": "MuiTypography-h5",
-                                            "h6": "MuiTypography-h6",
-                                            "noWrap": "MuiTypography-noWrap",
-                                            "overline": "MuiTypography-overline",
-                                            "paragraph": "MuiTypography-paragraph",
-                                            "root": "MuiTypography-root",
-                                            "srOnly": "MuiTypography-srOnly",
-                                            "subtitle1": "MuiTypography-subtitle1",
-                                            "subtitle2": "MuiTypography-subtitle2",
-                                          }
-                                        }
-                                        color="inherit"
-                                        noWrap={true}
-                                        style={
-                                          Object {
-                                            "marginTop": 3,
-                                          }
-                                        }
+                                      <span
+                                        className="MuiButton-label"
                                       >
-                                        <p
-                                          className="MuiTypography-root MuiTypography-body1 MuiTypography-colorInherit MuiTypography-noWrap"
+                                        <WithStyles(ForwardRef(Typography))
+                                          color="inherit"
+                                          noWrap={true}
                                           style={
                                             Object {
                                               "marginTop": 3,
                                             }
                                           }
                                         >
-                                          save-button
-                                        </p>
-                                      </ForwardRef(Typography)>
-                                    </WithStyles(ForwardRef(Typography))>
-                                  </span>
-                                  <WithStyles(memo)
-                                    center={false}
-                                  >
-                                    <ForwardRef(TouchRipple)
-                                      center={false}
-                                      classes={
-                                        Object {
-                                          "child": "MuiTouchRipple-child",
-                                          "childLeaving": "MuiTouchRipple-childLeaving",
-                                          "childPulsate": "MuiTouchRipple-childPulsate",
-                                          "ripple": "MuiTouchRipple-ripple",
-                                          "ripplePulsate": "MuiTouchRipple-ripplePulsate",
-                                          "rippleVisible": "MuiTouchRipple-rippleVisible",
-                                          "root": "MuiTouchRipple-root",
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        className="MuiTouchRipple-root"
-                                      >
-                                        <TransitionGroup
-                                          childFactory={[Function]}
-                                          component={null}
-                                          exit={true}
-                                        />
+                                          <ForwardRef(Typography)
+                                            classes={
+                                              Object {
+                                                "alignCenter": "MuiTypography-alignCenter",
+                                                "alignJustify": "MuiTypography-alignJustify",
+                                                "alignLeft": "MuiTypography-alignLeft",
+                                                "alignRight": "MuiTypography-alignRight",
+                                                "body1": "MuiTypography-body1",
+                                                "body2": "MuiTypography-body2",
+                                                "button": "MuiTypography-button",
+                                                "caption": "MuiTypography-caption",
+                                                "colorError": "MuiTypography-colorError",
+                                                "colorInherit": "MuiTypography-colorInherit",
+                                                "colorPrimary": "MuiTypography-colorPrimary",
+                                                "colorSecondary": "MuiTypography-colorSecondary",
+                                                "colorTextPrimary": "MuiTypography-colorTextPrimary",
+                                                "colorTextSecondary": "MuiTypography-colorTextSecondary",
+                                                "displayBlock": "MuiTypography-displayBlock",
+                                                "displayInline": "MuiTypography-displayInline",
+                                                "gutterBottom": "MuiTypography-gutterBottom",
+                                                "h1": "MuiTypography-h1",
+                                                "h2": "MuiTypography-h2",
+                                                "h3": "MuiTypography-h3",
+                                                "h4": "MuiTypography-h4",
+                                                "h5": "MuiTypography-h5",
+                                                "h6": "MuiTypography-h6",
+                                                "noWrap": "MuiTypography-noWrap",
+                                                "overline": "MuiTypography-overline",
+                                                "paragraph": "MuiTypography-paragraph",
+                                                "root": "MuiTypography-root",
+                                                "srOnly": "MuiTypography-srOnly",
+                                                "subtitle1": "MuiTypography-subtitle1",
+                                                "subtitle2": "MuiTypography-subtitle2",
+                                              }
+                                            }
+                                            color="inherit"
+                                            noWrap={true}
+                                            style={
+                                              Object {
+                                                "marginTop": 3,
+                                              }
+                                            }
+                                          >
+                                            <p
+                                              className="MuiTypography-root MuiTypography-body1 MuiTypography-colorInherit MuiTypography-noWrap"
+                                              style={
+                                                Object {
+                                                  "marginTop": 3,
+                                                }
+                                              }
+                                            >
+                                              save-button
+                                            </p>
+                                          </ForwardRef(Typography)>
+                                        </WithStyles(ForwardRef(Typography))>
                                       </span>
-                                    </ForwardRef(TouchRipple)>
-                                  </WithStyles(memo)>
-                                </button>
-                              </ForwardRef(ButtonBase)>
-                            </WithStyles(ForwardRef(ButtonBase))>
-                          </ForwardRef(Button)>
-                        </WithStyles(ForwardRef(Button))>
-                      </div>
-                    </div>
-                  </ForwardRef(Paper)>
-                </WithStyles(ForwardRef(Paper))>
-                <WithStyles(ForwardRef(Paper))
-                  className="AdminPage-paper-3"
-                >
-                  <ForwardRef(Paper)
-                    className="AdminPage-paper-3"
-                    classes={
-                      Object {
-                        "elevation0": "MuiPaper-elevation0",
-                        "elevation1": "MuiPaper-elevation1",
-                        "elevation10": "MuiPaper-elevation10",
-                        "elevation11": "MuiPaper-elevation11",
-                        "elevation12": "MuiPaper-elevation12",
-                        "elevation13": "MuiPaper-elevation13",
-                        "elevation14": "MuiPaper-elevation14",
-                        "elevation15": "MuiPaper-elevation15",
-                        "elevation16": "MuiPaper-elevation16",
-                        "elevation17": "MuiPaper-elevation17",
-                        "elevation18": "MuiPaper-elevation18",
-                        "elevation19": "MuiPaper-elevation19",
-                        "elevation2": "MuiPaper-elevation2",
-                        "elevation20": "MuiPaper-elevation20",
-                        "elevation21": "MuiPaper-elevation21",
-                        "elevation22": "MuiPaper-elevation22",
-                        "elevation23": "MuiPaper-elevation23",
-                        "elevation24": "MuiPaper-elevation24",
-                        "elevation3": "MuiPaper-elevation3",
-                        "elevation4": "MuiPaper-elevation4",
-                        "elevation5": "MuiPaper-elevation5",
-                        "elevation6": "MuiPaper-elevation6",
-                        "elevation7": "MuiPaper-elevation7",
-                        "elevation8": "MuiPaper-elevation8",
-                        "elevation9": "MuiPaper-elevation9",
-                        "outlined": "MuiPaper-outlined",
-                        "root": "MuiPaper-root",
-                        "rounded": "MuiPaper-rounded",
-                      }
-                    }
-                  >
-                    <div
-                      className="MuiPaper-root AdminPage-paper-3 MuiPaper-elevation1 MuiPaper-rounded"
+                                      <WithStyles(memo)
+                                        center={false}
+                                      >
+                                        <ForwardRef(TouchRipple)
+                                          center={false}
+                                          classes={
+                                            Object {
+                                              "child": "MuiTouchRipple-child",
+                                              "childLeaving": "MuiTouchRipple-childLeaving",
+                                              "childPulsate": "MuiTouchRipple-childPulsate",
+                                              "ripple": "MuiTouchRipple-ripple",
+                                              "ripplePulsate": "MuiTouchRipple-ripplePulsate",
+                                              "rippleVisible": "MuiTouchRipple-rippleVisible",
+                                              "root": "MuiTouchRipple-root",
+                                            }
+                                          }
+                                        >
+                                          <span
+                                            className="MuiTouchRipple-root"
+                                          >
+                                            <TransitionGroup
+                                              childFactory={[Function]}
+                                              component={null}
+                                              exit={true}
+                                            />
+                                          </span>
+                                        </ForwardRef(TouchRipple)>
+                                      </WithStyles(memo)>
+                                    </button>
+                                  </ForwardRef(ButtonBase)>
+                                </WithStyles(ForwardRef(ButtonBase))>
+                              </ForwardRef(Button)>
+                            </WithStyles(ForwardRef(Button))>
+                          </div>
+                        </div>
+                      </ForwardRef(Paper)>
+                    </WithStyles(ForwardRef(Paper))>
+                    <WithStyles(ForwardRef(Paper))
+                      className="AdminPage-paper-3"
                     >
-                      <WithStyles(ForwardRef(Typography))
-                        variant="h4"
-                      >
-                        <ForwardRef(Typography)
-                          classes={
-                            Object {
-                              "alignCenter": "MuiTypography-alignCenter",
-                              "alignJustify": "MuiTypography-alignJustify",
-                              "alignLeft": "MuiTypography-alignLeft",
-                              "alignRight": "MuiTypography-alignRight",
-                              "body1": "MuiTypography-body1",
-                              "body2": "MuiTypography-body2",
-                              "button": "MuiTypography-button",
-                              "caption": "MuiTypography-caption",
-                              "colorError": "MuiTypography-colorError",
-                              "colorInherit": "MuiTypography-colorInherit",
-                              "colorPrimary": "MuiTypography-colorPrimary",
-                              "colorSecondary": "MuiTypography-colorSecondary",
-                              "colorTextPrimary": "MuiTypography-colorTextPrimary",
-                              "colorTextSecondary": "MuiTypography-colorTextSecondary",
-                              "displayBlock": "MuiTypography-displayBlock",
-                              "displayInline": "MuiTypography-displayInline",
-                              "gutterBottom": "MuiTypography-gutterBottom",
-                              "h1": "MuiTypography-h1",
-                              "h2": "MuiTypography-h2",
-                              "h3": "MuiTypography-h3",
-                              "h4": "MuiTypography-h4",
-                              "h5": "MuiTypography-h5",
-                              "h6": "MuiTypography-h6",
-                              "noWrap": "MuiTypography-noWrap",
-                              "overline": "MuiTypography-overline",
-                              "paragraph": "MuiTypography-paragraph",
-                              "root": "MuiTypography-root",
-                              "srOnly": "MuiTypography-srOnly",
-                              "subtitle1": "MuiTypography-subtitle1",
-                              "subtitle2": "MuiTypography-subtitle2",
-                            }
-                          }
-                          variant="h4"
-                        >
-                          <h4
-                            className="MuiTypography-root MuiTypography-h4"
-                          >
-                            maintenance-title
-                          </h4>
-                        </ForwardRef(Typography)>
-                      </WithStyles(ForwardRef(Typography))>
-                      <ForwardRef(TextareaAutosize)
-                        aria-label="maintenance-message-arialabel"
-                        className="AdminPage-textArea-5"
-                        onChange={[Function]}
-                        placeholder="message-placeholder"
-                        rows={7}
-                        value=""
-                      >
-                        <textarea
-                          aria-label="maintenance-message-arialabel"
-                          className="AdminPage-textArea-5"
-                          onChange={[Function]}
-                          placeholder="message-placeholder"
-                          rows={7}
-                          style={
-                            Object {
-                              "height": -4,
-                              "overflow": "hidden",
-                            }
-                          }
-                          value=""
-                        />
-                        <textarea
-                          aria-hidden={true}
-                          className="AdminPage-textArea-5"
-                          readOnly={true}
-                          style={
-                            Object {
-                              "height": 0,
-                              "left": 0,
-                              "overflow": "hidden",
-                              "position": "absolute",
-                              "top": 0,
-                              "transform": "translateZ(0)",
-                              "visibility": "hidden",
-                            }
-                          }
-                          tabIndex={-1}
-                        />
-                      </ForwardRef(TextareaAutosize)>
-                      <div
-                        style={
+                      <ForwardRef(Paper)
+                        className="AdminPage-paper-3"
+                        classes={
                           Object {
-                            "display": "row",
+                            "elevation0": "MuiPaper-elevation0",
+                            "elevation1": "MuiPaper-elevation1",
+                            "elevation10": "MuiPaper-elevation10",
+                            "elevation11": "MuiPaper-elevation11",
+                            "elevation12": "MuiPaper-elevation12",
+                            "elevation13": "MuiPaper-elevation13",
+                            "elevation14": "MuiPaper-elevation14",
+                            "elevation15": "MuiPaper-elevation15",
+                            "elevation16": "MuiPaper-elevation16",
+                            "elevation17": "MuiPaper-elevation17",
+                            "elevation18": "MuiPaper-elevation18",
+                            "elevation19": "MuiPaper-elevation19",
+                            "elevation2": "MuiPaper-elevation2",
+                            "elevation20": "MuiPaper-elevation20",
+                            "elevation21": "MuiPaper-elevation21",
+                            "elevation22": "MuiPaper-elevation22",
+                            "elevation23": "MuiPaper-elevation23",
+                            "elevation24": "MuiPaper-elevation24",
+                            "elevation3": "MuiPaper-elevation3",
+                            "elevation4": "MuiPaper-elevation4",
+                            "elevation5": "MuiPaper-elevation5",
+                            "elevation6": "MuiPaper-elevation6",
+                            "elevation7": "MuiPaper-elevation7",
+                            "elevation8": "MuiPaper-elevation8",
+                            "elevation9": "MuiPaper-elevation9",
+                            "outlined": "MuiPaper-outlined",
+                            "root": "MuiPaper-root",
+                            "rounded": "MuiPaper-rounded",
                           }
                         }
                       >
-                        <WithStyles(ForwardRef(FormControlLabel))
-                          control={
-                            <WithStyles(ForwardRef(Checkbox))
-                              checked={false}
-                              color="secondary"
-                              inputProps={
-                                Object {
-                                  "aria-label": "maintenance-checkbox-arialabel",
-                                }
-                              }
-                              onChange={[Function]}
-                            />
-                          }
-                          label="display-checkbox"
-                          labelPlacement="end"
-                          style={
-                            Object {
-                              "float": "left",
-                            }
-                          }
-                          value={false}
+                        <div
+                          className="MuiPaper-root AdminPage-paper-3 MuiPaper-elevation1 MuiPaper-rounded"
                         >
-                          <ForwardRef(FormControlLabel)
-                            classes={
-                              Object {
-                                "disabled": "Mui-disabled",
-                                "label": "MuiFormControlLabel-label",
-                                "labelPlacementBottom": "MuiFormControlLabel-labelPlacementBottom",
-                                "labelPlacementStart": "MuiFormControlLabel-labelPlacementStart",
-                                "labelPlacementTop": "MuiFormControlLabel-labelPlacementTop",
-                                "root": "MuiFormControlLabel-root",
-                              }
-                            }
-                            control={
-                              <WithStyles(ForwardRef(Checkbox))
-                                checked={false}
-                                color="secondary"
-                                inputProps={
-                                  Object {
-                                    "aria-label": "maintenance-checkbox-arialabel",
-                                  }
-                                }
-                                onChange={[Function]}
-                              />
-                            }
-                            label="display-checkbox"
-                            labelPlacement="end"
-                            style={
-                              Object {
-                                "float": "left",
-                              }
-                            }
-                            value={false}
+                          <WithStyles(ForwardRef(Typography))
+                            variant="h4"
                           >
-                            <label
-                              className="MuiFormControlLabel-root"
+                            <ForwardRef(Typography)
+                              classes={
+                                Object {
+                                  "alignCenter": "MuiTypography-alignCenter",
+                                  "alignJustify": "MuiTypography-alignJustify",
+                                  "alignLeft": "MuiTypography-alignLeft",
+                                  "alignRight": "MuiTypography-alignRight",
+                                  "body1": "MuiTypography-body1",
+                                  "body2": "MuiTypography-body2",
+                                  "button": "MuiTypography-button",
+                                  "caption": "MuiTypography-caption",
+                                  "colorError": "MuiTypography-colorError",
+                                  "colorInherit": "MuiTypography-colorInherit",
+                                  "colorPrimary": "MuiTypography-colorPrimary",
+                                  "colorSecondary": "MuiTypography-colorSecondary",
+                                  "colorTextPrimary": "MuiTypography-colorTextPrimary",
+                                  "colorTextSecondary": "MuiTypography-colorTextSecondary",
+                                  "displayBlock": "MuiTypography-displayBlock",
+                                  "displayInline": "MuiTypography-displayInline",
+                                  "gutterBottom": "MuiTypography-gutterBottom",
+                                  "h1": "MuiTypography-h1",
+                                  "h2": "MuiTypography-h2",
+                                  "h3": "MuiTypography-h3",
+                                  "h4": "MuiTypography-h4",
+                                  "h5": "MuiTypography-h5",
+                                  "h6": "MuiTypography-h6",
+                                  "noWrap": "MuiTypography-noWrap",
+                                  "overline": "MuiTypography-overline",
+                                  "paragraph": "MuiTypography-paragraph",
+                                  "root": "MuiTypography-root",
+                                  "srOnly": "MuiTypography-srOnly",
+                                  "subtitle1": "MuiTypography-subtitle1",
+                                  "subtitle2": "MuiTypography-subtitle2",
+                                }
+                              }
+                              variant="h4"
+                            >
+                              <h4
+                                className="MuiTypography-root MuiTypography-h4"
+                              >
+                                maintenance-title
+                              </h4>
+                            </ForwardRef(Typography)>
+                          </WithStyles(ForwardRef(Typography))>
+                          <ForwardRef(TextareaAutosize)
+                            aria-label="maintenance-message-arialabel"
+                            className="AdminPage-textArea-5"
+                            onChange={[Function]}
+                            placeholder="message-placeholder"
+                            rows={7}
+                            value=""
+                          >
+                            <textarea
+                              aria-label="maintenance-message-arialabel"
+                              className="AdminPage-textArea-5"
+                              onChange={[Function]}
+                              placeholder="message-placeholder"
+                              rows={7}
                               style={
                                 Object {
-                                  "float": "left",
+                                  "height": -4,
+                                  "overflow": "hidden",
                                 }
                               }
-                            >
-                              <WithStyles(ForwardRef(Checkbox))
-                                checked={false}
-                                color="secondary"
-                                inputProps={
-                                  Object {
-                                    "aria-label": "maintenance-checkbox-arialabel",
-                                  }
+                              value=""
+                            />
+                            <textarea
+                              aria-hidden={true}
+                              className="AdminPage-textArea-5"
+                              readOnly={true}
+                              style={
+                                Object {
+                                  "height": 0,
+                                  "left": 0,
+                                  "overflow": "hidden",
+                                  "position": "absolute",
+                                  "top": 0,
+                                  "transform": "translateZ(0)",
+                                  "visibility": "hidden",
                                 }
-                                onChange={[Function]}
-                                value={false}
-                              >
-                                <ForwardRef(Checkbox)
+                              }
+                              tabIndex={-1}
+                            />
+                          </ForwardRef(TextareaAutosize)>
+                          <div
+                            style={
+                              Object {
+                                "display": "row",
+                              }
+                            }
+                          >
+                            <WithStyles(ForwardRef(FormControlLabel))
+                              control={
+                                <WithStyles(ForwardRef(Checkbox))
                                   checked={false}
-                                  classes={
-                                    Object {
-                                      "checked": "Mui-checked",
-                                      "colorPrimary": "MuiCheckbox-colorPrimary",
-                                      "colorSecondary": "MuiCheckbox-colorSecondary",
-                                      "disabled": "Mui-disabled",
-                                      "indeterminate": "MuiCheckbox-indeterminate",
-                                      "root": "MuiCheckbox-root",
-                                    }
-                                  }
                                   color="secondary"
                                   inputProps={
                                     Object {
@@ -1518,475 +1475,558 @@ exports[`Admin page component should render correctly 1`] = `
                                     }
                                   }
                                   onChange={[Function]}
-                                  value={false}
-                                >
-                                  <WithStyles(ForwardRef(SwitchBase))
+                                />
+                              }
+                              label="display-checkbox"
+                              labelPlacement="end"
+                              style={
+                                Object {
+                                  "float": "left",
+                                }
+                              }
+                              value={false}
+                            >
+                              <ForwardRef(FormControlLabel)
+                                classes={
+                                  Object {
+                                    "disabled": "Mui-disabled",
+                                    "label": "MuiFormControlLabel-label",
+                                    "labelPlacementBottom": "MuiFormControlLabel-labelPlacementBottom",
+                                    "labelPlacementStart": "MuiFormControlLabel-labelPlacementStart",
+                                    "labelPlacementTop": "MuiFormControlLabel-labelPlacementTop",
+                                    "root": "MuiFormControlLabel-root",
+                                  }
+                                }
+                                control={
+                                  <WithStyles(ForwardRef(Checkbox))
                                     checked={false}
-                                    checkedIcon={<Memo />}
-                                    classes={
-                                      Object {
-                                        "checked": "Mui-checked",
-                                        "disabled": "Mui-disabled",
-                                        "root": "MuiCheckbox-root MuiCheckbox-colorSecondary",
-                                      }
-                                    }
                                     color="secondary"
-                                    icon={<Memo />}
                                     inputProps={
                                       Object {
                                         "aria-label": "maintenance-checkbox-arialabel",
-                                        "data-indeterminate": false,
                                       }
                                     }
                                     onChange={[Function]}
-                                    type="checkbox"
+                                  />
+                                }
+                                label="display-checkbox"
+                                labelPlacement="end"
+                                style={
+                                  Object {
+                                    "float": "left",
+                                  }
+                                }
+                                value={false}
+                              >
+                                <label
+                                  className="MuiFormControlLabel-root"
+                                  style={
+                                    Object {
+                                      "float": "left",
+                                    }
+                                  }
+                                >
+                                  <WithStyles(ForwardRef(Checkbox))
+                                    checked={false}
+                                    color="secondary"
+                                    inputProps={
+                                      Object {
+                                        "aria-label": "maintenance-checkbox-arialabel",
+                                      }
+                                    }
+                                    onChange={[Function]}
                                     value={false}
                                   >
-                                    <ForwardRef(SwitchBase)
+                                    <ForwardRef(Checkbox)
                                       checked={false}
-                                      checkedIcon={<Memo />}
                                       classes={
                                         Object {
-                                          "checked": "PrivateSwitchBase-checked-11 Mui-checked",
-                                          "disabled": "PrivateSwitchBase-disabled-12 Mui-disabled",
-                                          "input": "PrivateSwitchBase-input-13",
-                                          "root": "PrivateSwitchBase-root-10 MuiCheckbox-root MuiCheckbox-colorSecondary",
+                                          "checked": "Mui-checked",
+                                          "colorPrimary": "MuiCheckbox-colorPrimary",
+                                          "colorSecondary": "MuiCheckbox-colorSecondary",
+                                          "disabled": "Mui-disabled",
+                                          "indeterminate": "MuiCheckbox-indeterminate",
+                                          "root": "MuiCheckbox-root",
                                         }
                                       }
                                       color="secondary"
-                                      icon={<Memo />}
                                       inputProps={
                                         Object {
                                           "aria-label": "maintenance-checkbox-arialabel",
-                                          "data-indeterminate": false,
                                         }
                                       }
                                       onChange={[Function]}
-                                      type="checkbox"
                                       value={false}
                                     >
-                                      <WithStyles(ForwardRef(IconButton))
-                                        className="PrivateSwitchBase-root-10 MuiCheckbox-root MuiCheckbox-colorSecondary"
+                                      <WithStyles(ForwardRef(SwitchBase))
+                                        checked={false}
+                                        checkedIcon={<Memo />}
+                                        classes={
+                                          Object {
+                                            "checked": "Mui-checked",
+                                            "disabled": "Mui-disabled",
+                                            "root": "MuiCheckbox-root MuiCheckbox-colorSecondary",
+                                          }
+                                        }
                                         color="secondary"
-                                        component="span"
-                                        onBlur={[Function]}
-                                        onFocus={[Function]}
-                                        tabIndex={null}
+                                        icon={<Memo />}
+                                        inputProps={
+                                          Object {
+                                            "aria-label": "maintenance-checkbox-arialabel",
+                                            "data-indeterminate": false,
+                                          }
+                                        }
+                                        onChange={[Function]}
+                                        type="checkbox"
+                                        value={false}
                                       >
-                                        <ForwardRef(IconButton)
-                                          className="PrivateSwitchBase-root-10 MuiCheckbox-root MuiCheckbox-colorSecondary"
+                                        <ForwardRef(SwitchBase)
+                                          checked={false}
+                                          checkedIcon={<Memo />}
                                           classes={
                                             Object {
-                                              "colorInherit": "MuiIconButton-colorInherit",
-                                              "colorPrimary": "MuiIconButton-colorPrimary",
-                                              "colorSecondary": "MuiIconButton-colorSecondary",
-                                              "disabled": "Mui-disabled",
-                                              "edgeEnd": "MuiIconButton-edgeEnd",
-                                              "edgeStart": "MuiIconButton-edgeStart",
-                                              "label": "MuiIconButton-label",
-                                              "root": "MuiIconButton-root",
-                                              "sizeSmall": "MuiIconButton-sizeSmall",
+                                              "checked": "PrivateSwitchBase-checked-11 Mui-checked",
+                                              "disabled": "PrivateSwitchBase-disabled-12 Mui-disabled",
+                                              "input": "PrivateSwitchBase-input-13",
+                                              "root": "PrivateSwitchBase-root-10 MuiCheckbox-root MuiCheckbox-colorSecondary",
                                             }
                                           }
                                           color="secondary"
-                                          component="span"
-                                          onBlur={[Function]}
-                                          onFocus={[Function]}
-                                          tabIndex={null}
+                                          icon={<Memo />}
+                                          inputProps={
+                                            Object {
+                                              "aria-label": "maintenance-checkbox-arialabel",
+                                              "data-indeterminate": false,
+                                            }
+                                          }
+                                          onChange={[Function]}
+                                          type="checkbox"
+                                          value={false}
                                         >
-                                          <WithStyles(ForwardRef(ButtonBase))
-                                            centerRipple={true}
-                                            className="MuiIconButton-root PrivateSwitchBase-root-10 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
+                                          <WithStyles(ForwardRef(IconButton))
+                                            className="PrivateSwitchBase-root-10 MuiCheckbox-root MuiCheckbox-colorSecondary"
+                                            color="secondary"
                                             component="span"
-                                            disabled={false}
-                                            focusRipple={true}
                                             onBlur={[Function]}
                                             onFocus={[Function]}
                                             tabIndex={null}
                                           >
-                                            <ForwardRef(ButtonBase)
-                                              centerRipple={true}
-                                              className="MuiIconButton-root PrivateSwitchBase-root-10 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
+                                            <ForwardRef(IconButton)
+                                              className="PrivateSwitchBase-root-10 MuiCheckbox-root MuiCheckbox-colorSecondary"
                                               classes={
                                                 Object {
+                                                  "colorInherit": "MuiIconButton-colorInherit",
+                                                  "colorPrimary": "MuiIconButton-colorPrimary",
+                                                  "colorSecondary": "MuiIconButton-colorSecondary",
                                                   "disabled": "Mui-disabled",
-                                                  "focusVisible": "Mui-focusVisible",
-                                                  "root": "MuiButtonBase-root",
+                                                  "edgeEnd": "MuiIconButton-edgeEnd",
+                                                  "edgeStart": "MuiIconButton-edgeStart",
+                                                  "label": "MuiIconButton-label",
+                                                  "root": "MuiIconButton-root",
+                                                  "sizeSmall": "MuiIconButton-sizeSmall",
                                                 }
                                               }
+                                              color="secondary"
                                               component="span"
-                                              disabled={false}
-                                              focusRipple={true}
                                               onBlur={[Function]}
                                               onFocus={[Function]}
                                               tabIndex={null}
                                             >
-                                              <span
-                                                aria-disabled={false}
-                                                className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-10 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
+                                              <WithStyles(ForwardRef(ButtonBase))
+                                                centerRipple={true}
+                                                className="MuiIconButton-root PrivateSwitchBase-root-10 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
+                                                component="span"
+                                                disabled={false}
+                                                focusRipple={true}
                                                 onBlur={[Function]}
-                                                onDragLeave={[Function]}
                                                 onFocus={[Function]}
-                                                onKeyDown={[Function]}
-                                                onKeyUp={[Function]}
-                                                onMouseDown={[Function]}
-                                                onMouseLeave={[Function]}
-                                                onMouseUp={[Function]}
-                                                onTouchEnd={[Function]}
-                                                onTouchMove={[Function]}
-                                                onTouchStart={[Function]}
                                                 tabIndex={null}
                                               >
-                                                <span
-                                                  className="MuiIconButton-label"
+                                                <ForwardRef(ButtonBase)
+                                                  centerRipple={true}
+                                                  className="MuiIconButton-root PrivateSwitchBase-root-10 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
+                                                  classes={
+                                                    Object {
+                                                      "disabled": "Mui-disabled",
+                                                      "focusVisible": "Mui-focusVisible",
+                                                      "root": "MuiButtonBase-root",
+                                                    }
+                                                  }
+                                                  component="span"
+                                                  disabled={false}
+                                                  focusRipple={true}
+                                                  onBlur={[Function]}
+                                                  onFocus={[Function]}
+                                                  tabIndex={null}
                                                 >
-                                                  <input
-                                                    aria-label="maintenance-checkbox-arialabel"
-                                                    checked={false}
-                                                    className="PrivateSwitchBase-input-13"
-                                                    data-indeterminate={false}
-                                                    onChange={[Function]}
-                                                    type="checkbox"
-                                                    value={false}
-                                                  />
-                                                  <ForwardRef(CheckBoxOutlineBlankIcon)>
-                                                    <WithStyles(ForwardRef(SvgIcon))>
-                                                      <ForwardRef(SvgIcon)
+                                                  <span
+                                                    aria-disabled={false}
+                                                    className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-10 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
+                                                    onBlur={[Function]}
+                                                    onDragLeave={[Function]}
+                                                    onFocus={[Function]}
+                                                    onKeyDown={[Function]}
+                                                    onKeyUp={[Function]}
+                                                    onMouseDown={[Function]}
+                                                    onMouseLeave={[Function]}
+                                                    onMouseUp={[Function]}
+                                                    onTouchEnd={[Function]}
+                                                    onTouchMove={[Function]}
+                                                    onTouchStart={[Function]}
+                                                    tabIndex={null}
+                                                  >
+                                                    <span
+                                                      className="MuiIconButton-label"
+                                                    >
+                                                      <input
+                                                        aria-label="maintenance-checkbox-arialabel"
+                                                        checked={false}
+                                                        className="PrivateSwitchBase-input-13"
+                                                        data-indeterminate={false}
+                                                        onChange={[Function]}
+                                                        type="checkbox"
+                                                        value={false}
+                                                      />
+                                                      <ForwardRef(CheckBoxOutlineBlankIcon)>
+                                                        <WithStyles(ForwardRef(SvgIcon))>
+                                                          <ForwardRef(SvgIcon)
+                                                            classes={
+                                                              Object {
+                                                                "colorAction": "MuiSvgIcon-colorAction",
+                                                                "colorDisabled": "MuiSvgIcon-colorDisabled",
+                                                                "colorError": "MuiSvgIcon-colorError",
+                                                                "colorPrimary": "MuiSvgIcon-colorPrimary",
+                                                                "colorSecondary": "MuiSvgIcon-colorSecondary",
+                                                                "fontSizeInherit": "MuiSvgIcon-fontSizeInherit",
+                                                                "fontSizeLarge": "MuiSvgIcon-fontSizeLarge",
+                                                                "fontSizeSmall": "MuiSvgIcon-fontSizeSmall",
+                                                                "root": "MuiSvgIcon-root",
+                                                              }
+                                                            }
+                                                          >
+                                                            <svg
+                                                              aria-hidden={true}
+                                                              className="MuiSvgIcon-root"
+                                                              focusable="false"
+                                                              viewBox="0 0 24 24"
+                                                            >
+                                                              <path
+                                                                d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                                                              />
+                                                            </svg>
+                                                          </ForwardRef(SvgIcon)>
+                                                        </WithStyles(ForwardRef(SvgIcon))>
+                                                      </ForwardRef(CheckBoxOutlineBlankIcon)>
+                                                    </span>
+                                                    <WithStyles(memo)
+                                                      center={true}
+                                                    >
+                                                      <ForwardRef(TouchRipple)
+                                                        center={true}
                                                         classes={
                                                           Object {
-                                                            "colorAction": "MuiSvgIcon-colorAction",
-                                                            "colorDisabled": "MuiSvgIcon-colorDisabled",
-                                                            "colorError": "MuiSvgIcon-colorError",
-                                                            "colorPrimary": "MuiSvgIcon-colorPrimary",
-                                                            "colorSecondary": "MuiSvgIcon-colorSecondary",
-                                                            "fontSizeInherit": "MuiSvgIcon-fontSizeInherit",
-                                                            "fontSizeLarge": "MuiSvgIcon-fontSizeLarge",
-                                                            "fontSizeSmall": "MuiSvgIcon-fontSizeSmall",
-                                                            "root": "MuiSvgIcon-root",
+                                                            "child": "MuiTouchRipple-child",
+                                                            "childLeaving": "MuiTouchRipple-childLeaving",
+                                                            "childPulsate": "MuiTouchRipple-childPulsate",
+                                                            "ripple": "MuiTouchRipple-ripple",
+                                                            "ripplePulsate": "MuiTouchRipple-ripplePulsate",
+                                                            "rippleVisible": "MuiTouchRipple-rippleVisible",
+                                                            "root": "MuiTouchRipple-root",
                                                           }
                                                         }
                                                       >
-                                                        <svg
-                                                          aria-hidden={true}
-                                                          className="MuiSvgIcon-root"
-                                                          focusable="false"
-                                                          viewBox="0 0 24 24"
+                                                        <span
+                                                          className="MuiTouchRipple-root"
                                                         >
-                                                          <path
-                                                            d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                                                          <TransitionGroup
+                                                            childFactory={[Function]}
+                                                            component={null}
+                                                            exit={true}
                                                           />
-                                                        </svg>
-                                                      </ForwardRef(SvgIcon)>
-                                                    </WithStyles(ForwardRef(SvgIcon))>
-                                                  </ForwardRef(CheckBoxOutlineBlankIcon)>
-                                                </span>
-                                                <WithStyles(memo)
-                                                  center={true}
-                                                >
-                                                  <ForwardRef(TouchRipple)
-                                                    center={true}
-                                                    classes={
-                                                      Object {
-                                                        "child": "MuiTouchRipple-child",
-                                                        "childLeaving": "MuiTouchRipple-childLeaving",
-                                                        "childPulsate": "MuiTouchRipple-childPulsate",
-                                                        "ripple": "MuiTouchRipple-ripple",
-                                                        "ripplePulsate": "MuiTouchRipple-ripplePulsate",
-                                                        "rippleVisible": "MuiTouchRipple-rippleVisible",
-                                                        "root": "MuiTouchRipple-root",
-                                                      }
-                                                    }
-                                                  >
-                                                    <span
-                                                      className="MuiTouchRipple-root"
-                                                    >
-                                                      <TransitionGroup
-                                                        childFactory={[Function]}
-                                                        component={null}
-                                                        exit={true}
-                                                      />
-                                                    </span>
-                                                  </ForwardRef(TouchRipple)>
-                                                </WithStyles(memo)>
-                                              </span>
-                                            </ForwardRef(ButtonBase)>
-                                          </WithStyles(ForwardRef(ButtonBase))>
-                                        </ForwardRef(IconButton)>
-                                      </WithStyles(ForwardRef(IconButton))>
-                                    </ForwardRef(SwitchBase)>
-                                  </WithStyles(ForwardRef(SwitchBase))>
-                                </ForwardRef(Checkbox)>
-                              </WithStyles(ForwardRef(Checkbox))>
-                              <WithStyles(ForwardRef(Typography))
-                                className="MuiFormControlLabel-label"
-                                component="span"
-                              >
-                                <ForwardRef(Typography)
-                                  className="MuiFormControlLabel-label"
-                                  classes={
-                                    Object {
-                                      "alignCenter": "MuiTypography-alignCenter",
-                                      "alignJustify": "MuiTypography-alignJustify",
-                                      "alignLeft": "MuiTypography-alignLeft",
-                                      "alignRight": "MuiTypography-alignRight",
-                                      "body1": "MuiTypography-body1",
-                                      "body2": "MuiTypography-body2",
-                                      "button": "MuiTypography-button",
-                                      "caption": "MuiTypography-caption",
-                                      "colorError": "MuiTypography-colorError",
-                                      "colorInherit": "MuiTypography-colorInherit",
-                                      "colorPrimary": "MuiTypography-colorPrimary",
-                                      "colorSecondary": "MuiTypography-colorSecondary",
-                                      "colorTextPrimary": "MuiTypography-colorTextPrimary",
-                                      "colorTextSecondary": "MuiTypography-colorTextSecondary",
-                                      "displayBlock": "MuiTypography-displayBlock",
-                                      "displayInline": "MuiTypography-displayInline",
-                                      "gutterBottom": "MuiTypography-gutterBottom",
-                                      "h1": "MuiTypography-h1",
-                                      "h2": "MuiTypography-h2",
-                                      "h3": "MuiTypography-h3",
-                                      "h4": "MuiTypography-h4",
-                                      "h5": "MuiTypography-h5",
-                                      "h6": "MuiTypography-h6",
-                                      "noWrap": "MuiTypography-noWrap",
-                                      "overline": "MuiTypography-overline",
-                                      "paragraph": "MuiTypography-paragraph",
-                                      "root": "MuiTypography-root",
-                                      "srOnly": "MuiTypography-srOnly",
-                                      "subtitle1": "MuiTypography-subtitle1",
-                                      "subtitle2": "MuiTypography-subtitle2",
-                                    }
-                                  }
-                                  component="span"
-                                >
-                                  <span
-                                    className="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+                                                        </span>
+                                                      </ForwardRef(TouchRipple)>
+                                                    </WithStyles(memo)>
+                                                  </span>
+                                                </ForwardRef(ButtonBase)>
+                                              </WithStyles(ForwardRef(ButtonBase))>
+                                            </ForwardRef(IconButton)>
+                                          </WithStyles(ForwardRef(IconButton))>
+                                        </ForwardRef(SwitchBase)>
+                                      </WithStyles(ForwardRef(SwitchBase))>
+                                    </ForwardRef(Checkbox)>
+                                  </WithStyles(ForwardRef(Checkbox))>
+                                  <WithStyles(ForwardRef(Typography))
+                                    className="MuiFormControlLabel-label"
+                                    component="span"
                                   >
-                                    display-checkbox
-                                  </span>
-                                </ForwardRef(Typography)>
-                              </WithStyles(ForwardRef(Typography))>
-                            </label>
-                          </ForwardRef(FormControlLabel)>
-                        </WithStyles(ForwardRef(FormControlLabel))>
-                        <WithStyles(ForwardRef(Button))
-                          color="primary"
-                          onClick={[Function]}
-                          style={
-                            Object {
-                              "float": "right",
-                            }
-                          }
-                          variant="contained"
-                        >
-                          <ForwardRef(Button)
-                            classes={
-                              Object {
-                                "colorInherit": "MuiButton-colorInherit",
-                                "contained": "MuiButton-contained",
-                                "containedPrimary": "MuiButton-containedPrimary",
-                                "containedSecondary": "MuiButton-containedSecondary",
-                                "containedSizeLarge": "MuiButton-containedSizeLarge",
-                                "containedSizeSmall": "MuiButton-containedSizeSmall",
-                                "disableElevation": "MuiButton-disableElevation",
-                                "disabled": "Mui-disabled",
-                                "endIcon": "MuiButton-endIcon",
-                                "focusVisible": "Mui-focusVisible",
-                                "fullWidth": "MuiButton-fullWidth",
-                                "iconSizeLarge": "MuiButton-iconSizeLarge",
-                                "iconSizeMedium": "MuiButton-iconSizeMedium",
-                                "iconSizeSmall": "MuiButton-iconSizeSmall",
-                                "label": "MuiButton-label",
-                                "outlined": "MuiButton-outlined",
-                                "outlinedPrimary": "MuiButton-outlinedPrimary",
-                                "outlinedSecondary": "MuiButton-outlinedSecondary",
-                                "outlinedSizeLarge": "MuiButton-outlinedSizeLarge",
-                                "outlinedSizeSmall": "MuiButton-outlinedSizeSmall",
-                                "root": "MuiButton-root",
-                                "sizeLarge": "MuiButton-sizeLarge",
-                                "sizeSmall": "MuiButton-sizeSmall",
-                                "startIcon": "MuiButton-startIcon",
-                                "text": "MuiButton-text",
-                                "textPrimary": "MuiButton-textPrimary",
-                                "textSecondary": "MuiButton-textSecondary",
-                                "textSizeLarge": "MuiButton-textSizeLarge",
-                                "textSizeSmall": "MuiButton-textSizeSmall",
-                              }
-                            }
-                            color="primary"
-                            onClick={[Function]}
-                            style={
-                              Object {
-                                "float": "right",
-                              }
-                            }
-                            variant="contained"
-                          >
-                            <WithStyles(ForwardRef(ButtonBase))
-                              className="MuiButton-root MuiButton-contained MuiButton-containedPrimary"
-                              component="button"
-                              disabled={false}
-                              focusRipple={true}
-                              focusVisibleClassName="Mui-focusVisible"
+                                    <ForwardRef(Typography)
+                                      className="MuiFormControlLabel-label"
+                                      classes={
+                                        Object {
+                                          "alignCenter": "MuiTypography-alignCenter",
+                                          "alignJustify": "MuiTypography-alignJustify",
+                                          "alignLeft": "MuiTypography-alignLeft",
+                                          "alignRight": "MuiTypography-alignRight",
+                                          "body1": "MuiTypography-body1",
+                                          "body2": "MuiTypography-body2",
+                                          "button": "MuiTypography-button",
+                                          "caption": "MuiTypography-caption",
+                                          "colorError": "MuiTypography-colorError",
+                                          "colorInherit": "MuiTypography-colorInherit",
+                                          "colorPrimary": "MuiTypography-colorPrimary",
+                                          "colorSecondary": "MuiTypography-colorSecondary",
+                                          "colorTextPrimary": "MuiTypography-colorTextPrimary",
+                                          "colorTextSecondary": "MuiTypography-colorTextSecondary",
+                                          "displayBlock": "MuiTypography-displayBlock",
+                                          "displayInline": "MuiTypography-displayInline",
+                                          "gutterBottom": "MuiTypography-gutterBottom",
+                                          "h1": "MuiTypography-h1",
+                                          "h2": "MuiTypography-h2",
+                                          "h3": "MuiTypography-h3",
+                                          "h4": "MuiTypography-h4",
+                                          "h5": "MuiTypography-h5",
+                                          "h6": "MuiTypography-h6",
+                                          "noWrap": "MuiTypography-noWrap",
+                                          "overline": "MuiTypography-overline",
+                                          "paragraph": "MuiTypography-paragraph",
+                                          "root": "MuiTypography-root",
+                                          "srOnly": "MuiTypography-srOnly",
+                                          "subtitle1": "MuiTypography-subtitle1",
+                                          "subtitle2": "MuiTypography-subtitle2",
+                                        }
+                                      }
+                                      component="span"
+                                    >
+                                      <span
+                                        className="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+                                      >
+                                        display-checkbox
+                                      </span>
+                                    </ForwardRef(Typography)>
+                                  </WithStyles(ForwardRef(Typography))>
+                                </label>
+                              </ForwardRef(FormControlLabel)>
+                            </WithStyles(ForwardRef(FormControlLabel))>
+                            <WithStyles(ForwardRef(Button))
+                              color="primary"
                               onClick={[Function]}
                               style={
                                 Object {
                                   "float": "right",
                                 }
                               }
-                              type="button"
+                              variant="contained"
                             >
-                              <ForwardRef(ButtonBase)
-                                className="MuiButton-root MuiButton-contained MuiButton-containedPrimary"
+                              <ForwardRef(Button)
                                 classes={
                                   Object {
+                                    "colorInherit": "MuiButton-colorInherit",
+                                    "contained": "MuiButton-contained",
+                                    "containedPrimary": "MuiButton-containedPrimary",
+                                    "containedSecondary": "MuiButton-containedSecondary",
+                                    "containedSizeLarge": "MuiButton-containedSizeLarge",
+                                    "containedSizeSmall": "MuiButton-containedSizeSmall",
+                                    "disableElevation": "MuiButton-disableElevation",
                                     "disabled": "Mui-disabled",
+                                    "endIcon": "MuiButton-endIcon",
                                     "focusVisible": "Mui-focusVisible",
-                                    "root": "MuiButtonBase-root",
+                                    "fullWidth": "MuiButton-fullWidth",
+                                    "iconSizeLarge": "MuiButton-iconSizeLarge",
+                                    "iconSizeMedium": "MuiButton-iconSizeMedium",
+                                    "iconSizeSmall": "MuiButton-iconSizeSmall",
+                                    "label": "MuiButton-label",
+                                    "outlined": "MuiButton-outlined",
+                                    "outlinedPrimary": "MuiButton-outlinedPrimary",
+                                    "outlinedSecondary": "MuiButton-outlinedSecondary",
+                                    "outlinedSizeLarge": "MuiButton-outlinedSizeLarge",
+                                    "outlinedSizeSmall": "MuiButton-outlinedSizeSmall",
+                                    "root": "MuiButton-root",
+                                    "sizeLarge": "MuiButton-sizeLarge",
+                                    "sizeSmall": "MuiButton-sizeSmall",
+                                    "startIcon": "MuiButton-startIcon",
+                                    "text": "MuiButton-text",
+                                    "textPrimary": "MuiButton-textPrimary",
+                                    "textSecondary": "MuiButton-textSecondary",
+                                    "textSizeLarge": "MuiButton-textSizeLarge",
+                                    "textSizeSmall": "MuiButton-textSizeSmall",
                                   }
                                 }
-                                component="button"
-                                disabled={false}
-                                focusRipple={true}
-                                focusVisibleClassName="Mui-focusVisible"
+                                color="primary"
                                 onClick={[Function]}
                                 style={
                                   Object {
                                     "float": "right",
                                   }
                                 }
-                                type="button"
+                                variant="contained"
                               >
-                                <button
-                                  className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"
+                                <WithStyles(ForwardRef(ButtonBase))
+                                  className="MuiButton-root MuiButton-contained MuiButton-containedPrimary"
+                                  component="button"
                                   disabled={false}
-                                  onBlur={[Function]}
+                                  focusRipple={true}
+                                  focusVisibleClassName="Mui-focusVisible"
                                   onClick={[Function]}
-                                  onDragLeave={[Function]}
-                                  onFocus={[Function]}
-                                  onKeyDown={[Function]}
-                                  onKeyUp={[Function]}
-                                  onMouseDown={[Function]}
-                                  onMouseLeave={[Function]}
-                                  onMouseUp={[Function]}
-                                  onTouchEnd={[Function]}
-                                  onTouchMove={[Function]}
-                                  onTouchStart={[Function]}
                                   style={
                                     Object {
                                       "float": "right",
                                     }
                                   }
-                                  tabIndex={0}
                                   type="button"
                                 >
-                                  <span
-                                    className="MuiButton-label"
+                                  <ForwardRef(ButtonBase)
+                                    className="MuiButton-root MuiButton-contained MuiButton-containedPrimary"
+                                    classes={
+                                      Object {
+                                        "disabled": "Mui-disabled",
+                                        "focusVisible": "Mui-focusVisible",
+                                        "root": "MuiButtonBase-root",
+                                      }
+                                    }
+                                    component="button"
+                                    disabled={false}
+                                    focusRipple={true}
+                                    focusVisibleClassName="Mui-focusVisible"
+                                    onClick={[Function]}
+                                    style={
+                                      Object {
+                                        "float": "right",
+                                      }
+                                    }
+                                    type="button"
                                   >
-                                    <WithStyles(ForwardRef(Typography))
-                                      color="inherit"
-                                      noWrap={true}
+                                    <button
+                                      className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"
+                                      disabled={false}
+                                      onBlur={[Function]}
+                                      onClick={[Function]}
+                                      onDragLeave={[Function]}
+                                      onFocus={[Function]}
+                                      onKeyDown={[Function]}
+                                      onKeyUp={[Function]}
+                                      onMouseDown={[Function]}
+                                      onMouseLeave={[Function]}
+                                      onMouseUp={[Function]}
+                                      onTouchEnd={[Function]}
+                                      onTouchMove={[Function]}
+                                      onTouchStart={[Function]}
                                       style={
                                         Object {
-                                          "marginTop": 3,
+                                          "float": "right",
                                         }
                                       }
+                                      tabIndex={0}
+                                      type="button"
                                     >
-                                      <ForwardRef(Typography)
-                                        classes={
-                                          Object {
-                                            "alignCenter": "MuiTypography-alignCenter",
-                                            "alignJustify": "MuiTypography-alignJustify",
-                                            "alignLeft": "MuiTypography-alignLeft",
-                                            "alignRight": "MuiTypography-alignRight",
-                                            "body1": "MuiTypography-body1",
-                                            "body2": "MuiTypography-body2",
-                                            "button": "MuiTypography-button",
-                                            "caption": "MuiTypography-caption",
-                                            "colorError": "MuiTypography-colorError",
-                                            "colorInherit": "MuiTypography-colorInherit",
-                                            "colorPrimary": "MuiTypography-colorPrimary",
-                                            "colorSecondary": "MuiTypography-colorSecondary",
-                                            "colorTextPrimary": "MuiTypography-colorTextPrimary",
-                                            "colorTextSecondary": "MuiTypography-colorTextSecondary",
-                                            "displayBlock": "MuiTypography-displayBlock",
-                                            "displayInline": "MuiTypography-displayInline",
-                                            "gutterBottom": "MuiTypography-gutterBottom",
-                                            "h1": "MuiTypography-h1",
-                                            "h2": "MuiTypography-h2",
-                                            "h3": "MuiTypography-h3",
-                                            "h4": "MuiTypography-h4",
-                                            "h5": "MuiTypography-h5",
-                                            "h6": "MuiTypography-h6",
-                                            "noWrap": "MuiTypography-noWrap",
-                                            "overline": "MuiTypography-overline",
-                                            "paragraph": "MuiTypography-paragraph",
-                                            "root": "MuiTypography-root",
-                                            "srOnly": "MuiTypography-srOnly",
-                                            "subtitle1": "MuiTypography-subtitle1",
-                                            "subtitle2": "MuiTypography-subtitle2",
-                                          }
-                                        }
-                                        color="inherit"
-                                        noWrap={true}
-                                        style={
-                                          Object {
-                                            "marginTop": 3,
-                                          }
-                                        }
+                                      <span
+                                        className="MuiButton-label"
                                       >
-                                        <p
-                                          className="MuiTypography-root MuiTypography-body1 MuiTypography-colorInherit MuiTypography-noWrap"
+                                        <WithStyles(ForwardRef(Typography))
+                                          color="inherit"
+                                          noWrap={true}
                                           style={
                                             Object {
                                               "marginTop": 3,
                                             }
                                           }
                                         >
-                                          save-button
-                                        </p>
-                                      </ForwardRef(Typography)>
-                                    </WithStyles(ForwardRef(Typography))>
-                                  </span>
-                                  <WithStyles(memo)
-                                    center={false}
-                                  >
-                                    <ForwardRef(TouchRipple)
-                                      center={false}
-                                      classes={
-                                        Object {
-                                          "child": "MuiTouchRipple-child",
-                                          "childLeaving": "MuiTouchRipple-childLeaving",
-                                          "childPulsate": "MuiTouchRipple-childPulsate",
-                                          "ripple": "MuiTouchRipple-ripple",
-                                          "ripplePulsate": "MuiTouchRipple-ripplePulsate",
-                                          "rippleVisible": "MuiTouchRipple-rippleVisible",
-                                          "root": "MuiTouchRipple-root",
-                                        }
-                                      }
-                                    >
-                                      <span
-                                        className="MuiTouchRipple-root"
-                                      >
-                                        <TransitionGroup
-                                          childFactory={[Function]}
-                                          component={null}
-                                          exit={true}
-                                        />
+                                          <ForwardRef(Typography)
+                                            classes={
+                                              Object {
+                                                "alignCenter": "MuiTypography-alignCenter",
+                                                "alignJustify": "MuiTypography-alignJustify",
+                                                "alignLeft": "MuiTypography-alignLeft",
+                                                "alignRight": "MuiTypography-alignRight",
+                                                "body1": "MuiTypography-body1",
+                                                "body2": "MuiTypography-body2",
+                                                "button": "MuiTypography-button",
+                                                "caption": "MuiTypography-caption",
+                                                "colorError": "MuiTypography-colorError",
+                                                "colorInherit": "MuiTypography-colorInherit",
+                                                "colorPrimary": "MuiTypography-colorPrimary",
+                                                "colorSecondary": "MuiTypography-colorSecondary",
+                                                "colorTextPrimary": "MuiTypography-colorTextPrimary",
+                                                "colorTextSecondary": "MuiTypography-colorTextSecondary",
+                                                "displayBlock": "MuiTypography-displayBlock",
+                                                "displayInline": "MuiTypography-displayInline",
+                                                "gutterBottom": "MuiTypography-gutterBottom",
+                                                "h1": "MuiTypography-h1",
+                                                "h2": "MuiTypography-h2",
+                                                "h3": "MuiTypography-h3",
+                                                "h4": "MuiTypography-h4",
+                                                "h5": "MuiTypography-h5",
+                                                "h6": "MuiTypography-h6",
+                                                "noWrap": "MuiTypography-noWrap",
+                                                "overline": "MuiTypography-overline",
+                                                "paragraph": "MuiTypography-paragraph",
+                                                "root": "MuiTypography-root",
+                                                "srOnly": "MuiTypography-srOnly",
+                                                "subtitle1": "MuiTypography-subtitle1",
+                                                "subtitle2": "MuiTypography-subtitle2",
+                                              }
+                                            }
+                                            color="inherit"
+                                            noWrap={true}
+                                            style={
+                                              Object {
+                                                "marginTop": 3,
+                                              }
+                                            }
+                                          >
+                                            <p
+                                              className="MuiTypography-root MuiTypography-body1 MuiTypography-colorInherit MuiTypography-noWrap"
+                                              style={
+                                                Object {
+                                                  "marginTop": 3,
+                                                }
+                                              }
+                                            >
+                                              save-button
+                                            </p>
+                                          </ForwardRef(Typography)>
+                                        </WithStyles(ForwardRef(Typography))>
                                       </span>
-                                    </ForwardRef(TouchRipple)>
-                                  </WithStyles(memo)>
-                                </button>
-                              </ForwardRef(ButtonBase)>
-                            </WithStyles(ForwardRef(ButtonBase))>
-                          </ForwardRef(Button)>
-                        </WithStyles(ForwardRef(Button))>
-                      </div>
-                    </div>
-                  </ForwardRef(Paper)>
-                </WithStyles(ForwardRef(Paper))>
-              </div>
-            </div>
+                                      <WithStyles(memo)
+                                        center={false}
+                                      >
+                                        <ForwardRef(TouchRipple)
+                                          center={false}
+                                          classes={
+                                            Object {
+                                              "child": "MuiTouchRipple-child",
+                                              "childLeaving": "MuiTouchRipple-childLeaving",
+                                              "childPulsate": "MuiTouchRipple-childPulsate",
+                                              "ripple": "MuiTouchRipple-ripple",
+                                              "ripplePulsate": "MuiTouchRipple-ripplePulsate",
+                                              "rippleVisible": "MuiTouchRipple-rippleVisible",
+                                              "root": "MuiTouchRipple-root",
+                                            }
+                                          }
+                                        >
+                                          <span
+                                            className="MuiTouchRipple-root"
+                                          >
+                                            <TransitionGroup
+                                              childFactory={[Function]}
+                                              component={null}
+                                              exit={true}
+                                            />
+                                          </span>
+                                        </ForwardRef(TouchRipple)>
+                                      </WithStyles(memo)>
+                                    </button>
+                                  </ForwardRef(ButtonBase)>
+                                </WithStyles(ForwardRef(ButtonBase))>
+                              </ForwardRef(Button)>
+                            </WithStyles(ForwardRef(Button))>
+                          </div>
+                        </div>
+                      </ForwardRef(Paper)>
+                    </WithStyles(ForwardRef(Paper))>
+                  </div>
+                </div>
+              </ForwardRef(Paper)>
+            </WithStyles(ForwardRef(Paper))>
           </AdminPage>
         </WithStyles(AdminPage)>
       </Connect(WithStyles(AdminPage))>

--- a/src/adminPage/adminPage.component.test.tsx
+++ b/src/adminPage/adminPage.component.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { createMount } from '@material-ui/core/test-utils';
 import { createLocation } from 'history';
-import { initialState } from '../state/reducers/scigateway.reducer';
+import { authState, initialState } from '../state/reducers/scigateway.reducer';
 import { StateType } from '../state/state.types';
 import configureStore from 'redux-mock-store';
 import AdminPage from './adminPage.component';
@@ -16,6 +16,7 @@ import {
   loadMaintenanceState,
   loadScheduledMaintenanceState,
 } from '../state/actions/scigateway.actions';
+import { MemoryRouter } from 'react-router';
 
 describe('Admin page component', () => {
   let mount;
@@ -26,12 +27,10 @@ describe('Admin page component', () => {
     mount = createMount();
     mockStore = configureStore([thunk]);
 
-    state = JSON.parse(
-      JSON.stringify({
-        scigateway: initialState,
-        router: { location: createLocation('/admin') },
-      })
-    );
+    state = {
+      scigateway: { ...initialState, authorisation: { ...authState } },
+      router: { location: createLocation('/admin') },
+    };
     state.scigateway.authorisation.provider = new TestAuthProvider(null);
   });
 
@@ -46,7 +45,9 @@ describe('Admin page component', () => {
 
     const wrapper = mount(
       <Provider store={testStore}>
-        <AdminPage />
+        <MemoryRouter initialEntries={[{ key: 'testKey' }]}>
+          <AdminPage />
+        </MemoryRouter>
       </Provider>
     );
 
@@ -58,20 +59,22 @@ describe('Admin page component', () => {
     const wrapper = mount(
       <Provider store={testStore}>
         <MuiThemeProvider theme={theme}>
-          <AdminPage />
+          <MemoryRouter initialEntries={[{ key: 'testKey' }]}>
+            <AdminPage />
+          </MemoryRouter>
         </MuiThemeProvider>
       </Provider>
     );
 
     const scheduledMaintenanceMessageInput = wrapper.find(
-      'textarea[aria-label="shceduled-maintenance-message-arialabel"]'
+      'textarea[aria-label="scheduled-maintenance-message-arialabel"]'
     );
     scheduledMaintenanceMessageInput.instance().value = 'test';
     scheduledMaintenanceMessageInput.simulate('change');
     wrapper
       .find('[aria-label="scheduled-maintenance-checkbox-arialabel"]')
       .simulate('change', { target: { checked: true } });
-    wrapper.find('button').first().simulate('click');
+    wrapper.find('button').at(1).simulate('click');
 
     await act(async () => {
       await flushPromises();
@@ -89,7 +92,9 @@ describe('Admin page component', () => {
     const wrapper = mount(
       <Provider store={testStore}>
         <MuiThemeProvider theme={theme}>
-          <AdminPage />
+          <MemoryRouter initialEntries={[{ key: 'testKey' }]}>
+            <AdminPage />
+          </MemoryRouter>
         </MuiThemeProvider>
       </Provider>
     );

--- a/src/adminPage/adminPage.component.test.tsx
+++ b/src/adminPage/adminPage.component.test.tsx
@@ -119,4 +119,22 @@ describe('Admin page component', () => {
       loadMaintenanceState({ show: true, message: 'test' })
     );
   });
+
+  it.skip('redirects to Admin Download table when Admin Downlod tab is clicked', () => {
+    const testStore = mockStore(state);
+    const wrapper = mount(
+      <Provider store={testStore}>
+        <MuiThemeProvider theme={theme}>
+          <MemoryRouter initialEntries={[{ key: 'testKey' }]}>
+            <AdminPage />
+          </MemoryRouter>
+        </MuiThemeProvider>
+      </Provider>
+    );
+
+    wrapper.find('#download-tab').hostNodes().simulate('click');
+
+    expect(testStore.getActions().length).toEqual(1);
+    expect(testStore.getActions()[0]).toEqual(push('/admin-download'));
+  });
 });

--- a/src/adminPage/adminPage.component.tsx
+++ b/src/adminPage/adminPage.component.tsx
@@ -131,7 +131,7 @@ const AdminPage = (props: CombinedAdminPageProps): React.ReactElement => {
             className={props.classes.textArea}
             aria-label={getString(
               props.res,
-              'shceduled-maintenance-message-arialabel'
+              'scheduled-maintenance-message-arialabel'
             )}
             rows={7}
             placeholder={getString(props.res, 'message-placeholder')}

--- a/src/adminPage/adminPage.component.tsx
+++ b/src/adminPage/adminPage.component.tsx
@@ -26,6 +26,9 @@ import {
   setMaintenanceState,
   setScheduledMaintenanceState,
 } from '../state/actions/scigateway.actions';
+import Tabs from '@material-ui/core/Tabs';
+import Tab from '@material-ui/core/Tab';
+import { Link } from 'react-router-dom';
 
 const styles = (theme: Theme): StyleRules =>
   createStyles({
@@ -87,124 +90,152 @@ const AdminPage = (props: CombinedAdminPageProps): React.ReactElement => {
   const [maintenance, setMaintenance] = useState<MaintenanceState>(
     props.maintenance
   );
+  const [tabValue, setTabValue] = React.useState<'maintenance' | 'download'>(
+    'maintenance'
+  );
 
   return (
     <div className={props.classes.root}>
       <Typography variant="h3" className={props.classes.titleText}>
         {getString(props.res, 'title')}
       </Typography>
-      <Paper className={props.classes.paper}>
-        <Typography variant="h4">
-          {getString(props.res, 'scheduled-maintenance-title')}
-        </Typography>
-        <TextareaAutosize
-          className={props.classes.textArea}
-          aria-label={getString(
-            props.res,
-            'shceduled-maintenance-message-arialabel'
-          )}
-          rows={7}
-          placeholder={getString(props.res, 'message-placeholder')}
-          value={scheduledMaintenance.message}
-          onChange={(e) =>
-            setScheduledMaintenance({
-              ...scheduledMaintenance,
-              message: e.currentTarget.value,
-            })
-          }
+      <Tabs
+        value={tabValue}
+        onChange={(event, newValue) => setTabValue(newValue)}
+      >
+        <Tab
+          id="maintenance-tab"
+          aria-controls="maintenance-panel"
+          label="Maintenance"
+          value="maintenance"
         />
-        <div style={{ display: 'row' }}>
-          <FormControlLabel
-            style={{ float: 'left' }}
-            value={scheduledMaintenance.show}
-            control={
-              <Checkbox
-                checked={scheduledMaintenance.show}
-                onChange={(e) =>
-                  setScheduledMaintenance({
-                    ...scheduledMaintenance,
-                    show: e.target.checked,
-                  })
-                }
-                inputProps={{
-                  'aria-label': getString(
-                    props.res,
-                    'scheduled-maintenance-checkbox-arialabel'
-                  ),
-                }}
-                color="secondary"
-              />
-            }
-            label={getString(props.res, 'display-checkbox')}
-            labelPlacement="end"
-          />
-          <Button
-            style={{ float: 'right' }}
-            variant="contained"
-            color="primary"
-            onClick={() => {
-              props.setScheduledMaintenanceState(scheduledMaintenance);
-            }}
-          >
-            <Typography color="inherit" noWrap style={{ marginTop: 3 }}>
-              {getString(props.res, 'save-button')}
-            </Typography>
-          </Button>
-        </div>
-      </Paper>
-      <Paper className={props.classes.paper}>
-        <Typography variant="h4">
-          {getString(props.res, 'maintenance-title')}
-        </Typography>
-        <TextareaAutosize
-          className={props.classes.textArea}
-          aria-label={getString(props.res, 'maintenance-message-arialabel')}
-          rows={7}
-          placeholder={getString(props.res, 'message-placeholder')}
-          value={maintenance.message}
-          onChange={(e) =>
-            setMaintenance({
-              ...maintenance,
-              message: e.currentTarget.value,
-            })
-          }
+        <Tab
+          id="download-tab"
+          label="Admin Download"
+          value="download"
+          component={Link}
+          to="/admin-download"
         />
-        <div style={{ display: 'row' }}>
-          <FormControlLabel
-            style={{ float: 'left' }}
-            value={maintenance.show}
-            control={
-              <Checkbox
-                checked={maintenance.show}
-                onChange={(e) =>
-                  setMaintenance({ ...maintenance, show: e.target.checked })
-                }
-                inputProps={{
-                  'aria-label': getString(
-                    props.res,
-                    'maintenance-checkbox-arialabel'
-                  ),
-                }}
-                color="secondary"
-              />
+      </Tabs>
+      <div
+        id="maintenance-panel"
+        aria-labelledby="maintenance-tab"
+        role="tabpanel"
+        hidden={tabValue !== 'maintenance'}
+      >
+        <Paper className={props.classes.paper}>
+          <Typography variant="h4">
+            {getString(props.res, 'scheduled-maintenance-title')}
+          </Typography>
+          <TextareaAutosize
+            className={props.classes.textArea}
+            aria-label={getString(
+              props.res,
+              'shceduled-maintenance-message-arialabel'
+            )}
+            rows={7}
+            placeholder={getString(props.res, 'message-placeholder')}
+            value={scheduledMaintenance.message}
+            onChange={(e) =>
+              setScheduledMaintenance({
+                ...scheduledMaintenance,
+                message: e.currentTarget.value,
+              })
             }
-            label={getString(props.res, 'display-checkbox')}
-            labelPlacement="end"
           />
-          <Button
-            style={{ float: 'right' }}
-            variant="contained"
-            color="primary"
-            onClick={() => {
-              props.setMaintenanceState(maintenance);
-            }}
-          >
-            <Typography color="inherit" noWrap style={{ marginTop: 3 }}>
-              {getString(props.res, 'save-button')}
-            </Typography>
-          </Button>
-        </div>
-      </Paper>
+          <div style={{ display: 'row' }}>
+            <FormControlLabel
+              style={{ float: 'left' }}
+              value={scheduledMaintenance.show}
+              control={
+                <Checkbox
+                  checked={scheduledMaintenance.show}
+                  onChange={(e) =>
+                    setScheduledMaintenance({
+                      ...scheduledMaintenance,
+                      show: e.target.checked,
+                    })
+                  }
+                  inputProps={{
+                    'aria-label': getString(
+                      props.res,
+                      'scheduled-maintenance-checkbox-arialabel'
+                    ),
+                  }}
+                  color="secondary"
+                />
+              }
+              label={getString(props.res, 'display-checkbox')}
+              labelPlacement="end"
+            />
+            <Button
+              style={{ float: 'right' }}
+              variant="contained"
+              color="primary"
+              onClick={() => {
+                props.setScheduledMaintenanceState(scheduledMaintenance);
+              }}
+            >
+              <Typography color="inherit" noWrap style={{ marginTop: 3 }}>
+                {getString(props.res, 'save-button')}
+              </Typography>
+            </Button>
+          </div>
+        </Paper>
+        <Paper className={props.classes.paper}>
+          <Typography variant="h4">
+            {getString(props.res, 'maintenance-title')}
+          </Typography>
+          <TextareaAutosize
+            className={props.classes.textArea}
+            aria-label={getString(props.res, 'maintenance-message-arialabel')}
+            rows={7}
+            placeholder={getString(props.res, 'message-placeholder')}
+            value={maintenance.message}
+            onChange={(e) =>
+              setMaintenance({
+                ...maintenance,
+                message: e.currentTarget.value,
+              })
+            }
+          />
+          <div style={{ display: 'row' }}>
+            <FormControlLabel
+              style={{ float: 'left' }}
+              value={maintenance.show}
+              control={
+                <Checkbox
+                  checked={maintenance.show}
+                  onChange={(e) =>
+                    setMaintenance({ ...maintenance, show: e.target.checked })
+                  }
+                  inputProps={{
+                    'aria-label': getString(
+                      props.res,
+                      'maintenance-checkbox-arialabel'
+                    ),
+                  }}
+                  color="secondary"
+                />
+              }
+              label={getString(props.res, 'display-checkbox')}
+              labelPlacement="end"
+            />
+            <Button
+              style={{ float: 'right' }}
+              variant="contained"
+              color="primary"
+              onClick={() => {
+                props.setMaintenanceState(maintenance);
+              }}
+            >
+              <Typography color="inherit" noWrap style={{ marginTop: 3 }}>
+                {getString(props.res, 'save-button')}
+              </Typography>
+            </Button>
+          </div>
+        </Paper>
+      </div>
     </div>
   );
 };

--- a/src/adminPage/adminPage.component.tsx
+++ b/src/adminPage/adminPage.component.tsx
@@ -34,6 +34,8 @@ const styles = (theme: Theme): StyleRules =>
   createStyles({
     root: {
       padding: theme.spacing(2),
+      flexGrow: 1,
+      backgroundColor: theme.palette.background.default,
     },
     titleText: {
       color: theme.palette.secondary.main,
@@ -95,7 +97,7 @@ const AdminPage = (props: CombinedAdminPageProps): React.ReactElement => {
   );
 
   return (
-    <div className={props.classes.root}>
+    <Paper className={props.classes.root}>
       <Typography variant="h3" className={props.classes.titleText}>
         {getString(props.res, 'title')}
       </Typography>
@@ -236,7 +238,7 @@ const AdminPage = (props: CombinedAdminPageProps): React.ReactElement => {
           </div>
         </Paper>
       </div>
-    </div>
+    </Paper>
   );
 };
 

--- a/src/cookieConsent/cookieConsent.component.test.tsx
+++ b/src/cookieConsent/cookieConsent.component.test.tsx
@@ -7,7 +7,7 @@ import CookieConsent, {
 import { createShallow, createMount } from '@material-ui/core/test-utils';
 import { StateType } from '../state/state.types';
 import configureStore from 'redux-mock-store';
-import { initialState } from '../state/reducers/scigateway.reducer';
+import { authState, initialState } from '../state/reducers/scigateway.reducer';
 import { initialiseAnalytics } from '../state/actions/scigateway.actions';
 import { Provider } from 'react-redux';
 import { buildTheme } from '../theming';
@@ -29,12 +29,10 @@ describe('Cookie consent component', () => {
     mount = createMount();
 
     mockStore = configureStore();
-    state = JSON.parse(
-      JSON.stringify({
-        scigateway: initialState,
-        router: { location: createLocation('/') },
-      })
-    );
+    state = {
+      scigateway: { ...initialState, authorisation: { ...authState } },
+      router: { location: createLocation('/') },
+    };
     state.scigateway.siteLoading = false;
     state.scigateway.analytics = {
       id: 'test id',

--- a/src/cookieConsent/cookiesPage.component.test.tsx
+++ b/src/cookieConsent/cookiesPage.component.test.tsx
@@ -6,7 +6,7 @@ import CookiesPage, {
 import { createShallow, createMount } from '@material-ui/core/test-utils';
 import { StateType } from '../state/state.types';
 import configureStore from 'redux-mock-store';
-import { initialState } from '../state/reducers/scigateway.reducer';
+import { authState, initialState } from '../state/reducers/scigateway.reducer';
 import { buildTheme } from '../theming';
 import { MuiThemeProvider } from '@material-ui/core/styles';
 import Cookies from 'js-cookie';
@@ -25,12 +25,10 @@ describe('Cookies page component', () => {
     mount = createMount();
 
     mockStore = configureStore();
-    state = JSON.parse(
-      JSON.stringify({
-        scigateway: initialState,
-        router: { location: createLocation('/cookies') },
-      })
-    );
+    state = {
+      scigateway: { ...initialState, authorisation: { ...authState } },
+      router: { location: createLocation('/cookies') },
+    };
 
     props = {
       res: undefined,

--- a/src/example.component.test.tsx
+++ b/src/example.component.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import ExampleComponent from './example.component';
 import { createShallow } from '@material-ui/core/test-utils';
 import configureStore from 'redux-mock-store';
-import { initialState } from './state/reducers/scigateway.reducer';
+import { authState, initialState } from './state/reducers/scigateway.reducer';
 import { StateType } from './state/state.types';
 
 describe('Example component', () => {
@@ -15,7 +15,7 @@ describe('Example component', () => {
 
     mockStore = configureStore();
     state = {
-      scigateway: initialState,
+      scigateway: { ...initialState, authorisation: { ...authState } },
     };
   });
 

--- a/src/loginPage/loginPage.component.test.tsx
+++ b/src/loginPage/loginPage.component.test.tsx
@@ -18,7 +18,7 @@ import { flushPromises } from '../setupTests';
 import { act } from 'react-dom/test-utils';
 import { StateType } from '../state/state.types';
 import configureStore from 'redux-mock-store';
-import { initialState } from '../state/reducers/scigateway.reducer';
+import { authState, initialState } from '../state/reducers/scigateway.reducer';
 import {
   loadAuthProvider,
   loadingAuthentication,
@@ -51,12 +51,10 @@ describe('Login page component', () => {
     mount = createMount();
     mockStore = configureStore([thunk]);
 
-    state = JSON.parse(
-      JSON.stringify({
-        scigateway: initialState,
-        router: { location: createLocation('/') },
-      })
-    );
+    state = {
+      scigateway: { ...initialState, authorisation: { ...authState } },
+      router: { location: createLocation('/') },
+    };
 
     props = {
       auth: {

--- a/src/mainAppBar/userProfile.component.test.tsx
+++ b/src/mainAppBar/userProfile.component.test.tsx
@@ -3,7 +3,7 @@ import UserProfileComponent from './userProfile.component';
 import { createShallow, createMount } from '@material-ui/core/test-utils';
 import { StateType } from '../state/state.types';
 import configureStore from 'redux-mock-store';
-import { initialState } from '../state/reducers/scigateway.reducer';
+import { authState, initialState } from '../state/reducers/scigateway.reducer';
 import { Provider } from 'react-redux';
 import { push } from 'connected-react-router';
 import { Avatar } from '@material-ui/core';
@@ -21,7 +21,9 @@ describe('User profile component', () => {
     mount = createMount();
 
     mockStore = configureStore([thunk]);
-    state = JSON.parse(JSON.stringify({ scigateway: initialState }));
+    state = {
+      scigateway: { ...initialState, authorisation: { ...authState } },
+    };
     state.scigateway.authorisation.provider = new TestAuthProvider(
       'test-token'
     );

--- a/src/maintenancePage/maintenancePage.component.test.tsx
+++ b/src/maintenancePage/maintenancePage.component.test.tsx
@@ -4,7 +4,7 @@ import configureStore from 'redux-mock-store';
 import { default as MaintenancePage } from './maintenancePage.component';
 import { Provider } from 'react-redux';
 import { StateType } from '../state/state.types';
-import { initialState } from '../state/reducers/scigateway.reducer';
+import { authState, initialState } from '../state/reducers/scigateway.reducer';
 
 describe('Maintenance page component', () => {
   let mount;
@@ -15,7 +15,9 @@ describe('Maintenance page component', () => {
     mount = createMount();
 
     mockStore = configureStore();
-    state = JSON.parse(JSON.stringify({ scigateway: initialState }));
+    state = {
+      scigateway: { ...initialState, authorisation: { ...authState } },
+    };
     state.scigateway.maintenance.message = 'test';
   });
 

--- a/src/navigationDrawer/__snapshots__/navigationDrawer.component.test.tsx.snap
+++ b/src/navigationDrawer/__snapshots__/navigationDrawer.component.test.tsx.snap
@@ -50,6 +50,31 @@ exports[`Navigation drawer component Navigation drawer renders correctly when op
 </WithStyles(ForwardRef(Drawer))>
 `;
 
+exports[`Navigation drawer component does not render admin plugins in list 1`] = `
+<WithStyles(ForwardRef(Drawer))
+  anchor="left"
+  className="NavigationDrawer-drawer-1"
+  classes={
+    Object {
+      "paper": "NavigationDrawer-drawerPaper-2",
+    }
+  }
+  open={true}
+  variant="persistent"
+>
+  <Styled(div)>
+    <WithStyles(ForwardRef(IconButton))
+      aria-label="Dropdown Menu"
+      onClick={[Function]}
+    >
+      <Memo(ForwardRef(ChevronLeftIcon)) />
+    </WithStyles(ForwardRef(IconButton))>
+  </Styled(div)>
+  <WithStyles(ForwardRef(Divider)) />
+  <WithStyles(ForwardRef(List)) />
+</WithStyles(ForwardRef(Drawer))>
+`;
+
 exports[`Navigation drawer component renders a plugin list grouped by sections ordered alphabetically when open 1`] = `
 <WithStyles(ForwardRef(Drawer))
   anchor="left"

--- a/src/navigationDrawer/navigationDrawer.component.test.tsx
+++ b/src/navigationDrawer/navigationDrawer.component.test.tsx
@@ -3,7 +3,7 @@ import configureStore from 'redux-mock-store';
 import { RouterState } from 'connected-react-router';
 import { createShallow, createMount } from '@material-ui/core/test-utils';
 import NavigationDrawer from './navigationDrawer.component';
-import { initialState } from '../state/reducers/scigateway.reducer';
+import { authState, initialState } from '../state/reducers/scigateway.reducer';
 import { StateType } from '../state/state.types';
 import { toggleDrawer } from '../state/actions/scigateway.actions';
 import { PluginConfig } from '../state/scigateway.types';
@@ -31,8 +31,8 @@ describe('Navigation drawer component', () => {
     mount = createMount();
     mockStore = configureStore();
     state = {
-      scigateway: initialState,
-      router: routerState,
+      scigateway: { ...initialState, authorisation: { ...authState } },
+      router: { ...routerState },
     };
   });
 
@@ -100,6 +100,26 @@ describe('Navigation drawer component', () => {
     expect(wrapper).toMatchSnapshot();
 
     expect(wrapper.find('[to="plugin_link"]').first()).toMatchSnapshot();
+  });
+
+  it('does not render admin plugins in list', () => {
+    const dummyPlugins: PluginConfig[] = [
+      {
+        order: 0,
+        plugin: 'data-plugin',
+        link: 'plugin_link',
+        section: 'DATA',
+        displayName: 'display name',
+        admin: true,
+      },
+    ];
+
+    state.scigateway.plugins = dummyPlugins;
+    state.scigateway.drawerOpen = true;
+
+    const wrapper = shallow(<NavigationDrawer store={mockStore(state)} />);
+
+    expect(wrapper).toMatchSnapshot();
   });
 
   it('renders a plugin with displayName but no logo or altText', () => {

--- a/src/navigationDrawer/navigationDrawer.component.tsx
+++ b/src/navigationDrawer/navigationDrawer.component.tsx
@@ -149,7 +149,10 @@ class NavigationDrawer extends Component<CombinedNavigationProps> {
 
   private renderRoutes(): React.ReactFragment {
     const { plugins } = this.props;
-    const sectionPlugins = structureMenuData(plugins);
+    // Do not include non admin plugins in the drawer list
+    const sectionPlugins = structureMenuData(
+      plugins.filter((plugin) => !plugin.admin)
+    );
     return (
       <List>
         {Object.keys(sectionPlugins)

--- a/src/notifications/notificationBadge.component.test.tsx
+++ b/src/notifications/notificationBadge.component.test.tsx
@@ -9,9 +9,10 @@ import Badge from '@material-ui/core/Badge';
 import { MuiThemeProvider } from '@material-ui/core/styles';
 import { buildTheme } from '../theming';
 import configureStore from 'redux-mock-store';
-import { initialState } from '../state/reducers/scigateway.reducer';
+import { authState, initialState } from '../state/reducers/scigateway.reducer';
 import { dismissMenuItem } from '../state/actions/scigateway.actions';
 import { Provider } from 'react-redux';
+import { StateType } from '../state/state.types';
 
 describe('Notification Badge component', () => {
   const theme = buildTheme(false);
@@ -19,6 +20,7 @@ describe('Notification Badge component', () => {
   let shallow;
   let mount;
   let mockStore;
+  let state: StateType;
   let props: CombinedNotificationBadgeProps;
 
   beforeEach(() => {
@@ -26,6 +28,9 @@ describe('Notification Badge component', () => {
     mount = createMount();
     mockStore = configureStore();
 
+    state = {
+      scigateway: { ...initialState, authorisation: { ...authState } },
+    };
     props = {
       notifications: [{ message: 'my message', severity: 'warning' }],
       deleteMenuItem: jest.fn(),
@@ -67,7 +72,6 @@ describe('Notification Badge component', () => {
   });
 
   it('sends dismissMenuItem action when dismissNotification prop is called', () => {
-    const state = { scigateway: initialState };
     state.scigateway.notifications = props.notifications;
     const testStore = mockStore(state);
 
@@ -95,7 +99,6 @@ describe('Notification Badge component', () => {
   });
 
   it('opens menu when button clicked and closes menu when there are no more notifications', () => {
-    const state = { scigateway: initialState };
     state.scigateway.notifications = props.notifications;
 
     let testStore = mockStore(state);

--- a/src/pageContainer.test.tsx
+++ b/src/pageContainer.test.tsx
@@ -12,7 +12,7 @@ import { MemoryRouter } from 'react-router';
 
 import PageContainer from './pageContainer.component';
 import { StateType } from './state/state.types';
-import { initialState } from './state/reducers/scigateway.reducer';
+import { authState, initialState } from './state/reducers/scigateway.reducer';
 
 describe('PageContainer - Tests', () => {
   let shallow;
@@ -30,12 +30,10 @@ describe('PageContainer - Tests', () => {
   beforeEach(() => {
     shallow = createShallow({ untilSelector: 'Grid' });
 
-    state = JSON.parse(
-      JSON.stringify({
-        scigateway: initialState,
-        router: { location: createLocation('/') },
-      })
-    );
+    state = {
+      scigateway: { ...initialState, authorisation: { ...authState } },
+      router: { location: createLocation('/') },
+    };
   });
 
   it('renders correctly', () => {

--- a/src/preloader/preloader.component.test.tsx
+++ b/src/preloader/preloader.component.test.tsx
@@ -3,7 +3,7 @@ import Preloader from './preloader.component';
 import { createShallow } from '@material-ui/core/test-utils';
 import configureStore from 'redux-mock-store';
 import { StateType } from '../state/state.types';
-import { initialState } from '../state/reducers/scigateway.reducer';
+import { authState, initialState } from '../state/reducers/scigateway.reducer';
 import { createLocation } from 'history';
 
 describe('Preloader component', () => {
@@ -15,7 +15,7 @@ describe('Preloader component', () => {
     shallow = createShallow({ untilSelector: 'div' });
 
     state = {
-      scigateway: initialState,
+      scigateway: { ...initialState, authorisation: { ...authState } },
       router: {
         action: 'POP',
         location: createLocation('/'),

--- a/src/routing/__snapshots__/authorisedRoute.component.test.tsx.snap
+++ b/src/routing/__snapshots__/authorisedRoute.component.test.tsx.snap
@@ -1,8 +1,33 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AuthorisedRoute component renders component when user logged in 1`] = `
+exports[`AuthorisedRoute component renders PageNotFound component when non admin user accesses admin component 1`] = `
+<div>
+  <WithStyles(PageNotFound) />
+</div>
+`;
+
+exports[`AuthorisedRoute component renders PageNotFound component when site is loading due to LoadingAuthProvider 1`] = `
+<div>
+  <WithStyles(PageNotFound) />
+</div>
+`;
+
+exports[`AuthorisedRoute component renders PageNotFound component when site is loading due to loading prop 1`] = `
+<div>
+  <WithStyles(PageNotFound) />
+</div>
+`;
+
+exports[`AuthorisedRoute component renders PageNotFound component when site is loading due to siteLoading prop 1`] = `
+<div>
+  <WithStyles(PageNotFound) />
+</div>
+`;
+
+exports[`AuthorisedRoute component renders admin component when admin user accesses it 1`] = `
 <div>
   <ComponentToProtect
+    adminPlugin={true}
     store={
       Object {
         "clearActions": [Function],
@@ -17,11 +42,41 @@ exports[`AuthorisedRoute component renders component when user logged in 1`] = `
 </div>
 `;
 
-exports[`AuthorisedRoute component renders nothing when site is loading due to LoadingAuthProvider 1`] = `<div />`;
+exports[`AuthorisedRoute component renders non admin component when admin user accesses it 1`] = `
+<div>
+  <ComponentToProtect
+    adminPlugin={false}
+    store={
+      Object {
+        "clearActions": [Function],
+        "dispatch": [Function],
+        "getActions": [Function],
+        "getState": [Function],
+        "replaceReducer": [Function],
+        "subscribe": [Function],
+      }
+    }
+  />
+</div>
+`;
 
-exports[`AuthorisedRoute component renders nothing when site is loading due to loading prop 1`] = `<div />`;
-
-exports[`AuthorisedRoute component renders nothing when site is loading due to siteLoading prop 1`] = `<div />`;
+exports[`AuthorisedRoute component renders non admin component when non admin user accesses it 1`] = `
+<div>
+  <ComponentToProtect
+    adminPlugin={false}
+    store={
+      Object {
+        "clearActions": [Function],
+        "dispatch": [Function],
+        "getActions": [Function],
+        "getState": [Function],
+        "replaceReducer": [Function],
+        "subscribe": [Function],
+      }
+    }
+  />
+</div>
+`;
 
 exports[`AuthorisedRoute component renders redirect when startUrl is configured and logged in 1`] = `
 <div>
@@ -49,5 +104,6 @@ exports[`AuthorisedRoute component renders redirect when user not logged in 1`] 
       }
     }
   />
+  <WithStyles(PageNotFound) />
 </div>
 `;

--- a/src/routing/__snapshots__/routing.component.test.tsx.snap
+++ b/src/routing/__snapshots__/routing.component.test.tsx.snap
@@ -1,6 +1,315 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Routing component does not render a route for a plugin when site is under maintenance 1`] = `
+exports[`Routing component renders a route for a plugin when site is under maintenance and user is admin 1`] = `
+<Provider
+  store={
+    Object {
+      "clearActions": [Function],
+      "dispatch": [Function],
+      "getActions": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+    }
+  }
+>
+  <MemoryRouter
+    initialEntries={
+      Array [
+        Object {
+          "key": "testKey",
+          "pathname": "/test_link",
+        },
+      ]
+    }
+  >
+    <Router
+      history={
+        Object {
+          "action": "POP",
+          "block": [Function],
+          "canGo": [Function],
+          "createHref": [Function],
+          "entries": Array [
+            Object {
+              "hash": "",
+              "key": "testKey",
+              "pathname": "/test_link",
+              "search": "",
+            },
+          ],
+          "go": [Function],
+          "goBack": [Function],
+          "goForward": [Function],
+          "index": 0,
+          "length": 1,
+          "listen": [Function],
+          "location": Object {
+            "hash": "",
+            "key": "testKey",
+            "pathname": "/test_link",
+            "search": "",
+          },
+          "push": [Function],
+          "replace": [Function],
+        }
+      }
+    >
+      <Connect(Routing)
+        classes={
+          Object {
+            "container": "container-class",
+            "containerShift": "containerShift-class",
+          }
+        }
+      >
+        <Routing
+          classes={
+            Object {
+              "container": "container-class",
+              "containerShift": "containerShift-class",
+            }
+          }
+          dispatch={[Function]}
+          drawerOpen={false}
+          location="/"
+          maintenance={
+            Object {
+              "message": "test",
+              "show": true,
+            }
+          }
+          plugins={
+            Array [
+              Object {
+                "displayName": "Test Plugin",
+                "link": "/test_link",
+                "order": 1,
+                "plugin": "test_plugin_name",
+                "section": "test section",
+              },
+            ]
+          }
+          userIsAdmin={true}
+          userIsloggedIn={true}
+        >
+          <div
+            className="container-class"
+          >
+            <Switch>
+              <Route
+                computedMatch={
+                  Object {
+                    "isExact": true,
+                    "params": Object {},
+                    "path": "/test_link",
+                    "url": "/test_link",
+                  }
+                }
+                key="test section_/test_link"
+                location={
+                  Object {
+                    "hash": "",
+                    "key": "testKey",
+                    "pathname": "/test_link",
+                    "search": "",
+                  }
+                }
+                path="/test_link"
+                render={[Function]}
+              >
+                <Connect(WithAuthComponent)
+                  adminPlugin={false}
+                  id="test_plugin_name"
+                >
+                  <WithAuthComponent
+                    adminPlugin={false}
+                    id="test_plugin_name"
+                    invalidToken={[Function]}
+                    loading={false}
+                    location="/"
+                    loggedIn={true}
+                    provider={
+                      TestAuthProvider {
+                        "authUrl": undefined,
+                        "autoLogin": undefined,
+                        "mnemonic": undefined,
+                        "redirectUrl": null,
+                        "token": "logged in",
+                        "user": null,
+                      }
+                    }
+                    requestPluginRerender={[Function]}
+                    userIsAdmin={true}
+                  >
+                    <div>
+                      <PluginPlaceHolder
+                        adminPlugin={false}
+                        id="test_plugin_name"
+                      >
+                        <div
+                          id="test_plugin_name"
+                        >
+                          test_plugin_name
+                           failed to load correctly
+                        </div>
+                      </PluginPlaceHolder>
+                    </div>
+                  </WithAuthComponent>
+                </Connect(WithAuthComponent)>
+              </Route>
+            </Switch>
+          </div>
+        </Routing>
+      </Connect(Routing)>
+    </Router>
+  </MemoryRouter>
+</Provider>
+`;
+
+exports[`Routing component renders a route for admin page 1`] = `
+<Provider
+  store={
+    Object {
+      "clearActions": [Function],
+      "dispatch": [Function],
+      "getActions": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+    }
+  }
+>
+  <MemoryRouter
+    initialEntries={
+      Array [
+        Object {
+          "key": "testKey",
+          "pathname": "/admin",
+        },
+      ]
+    }
+  >
+    <Router
+      history={
+        Object {
+          "action": "POP",
+          "block": [Function],
+          "canGo": [Function],
+          "createHref": [Function],
+          "entries": Array [
+            Object {
+              "hash": "",
+              "key": "testKey",
+              "pathname": "/admin",
+              "search": "",
+            },
+          ],
+          "go": [Function],
+          "goBack": [Function],
+          "goForward": [Function],
+          "index": 0,
+          "length": 1,
+          "listen": [Function],
+          "location": Object {
+            "hash": "",
+            "key": "testKey",
+            "pathname": "/admin",
+            "search": "",
+          },
+          "push": [Function],
+          "replace": [Function],
+        }
+      }
+    >
+      <Connect(Routing)
+        classes={
+          Object {
+            "container": "container-class",
+            "containerShift": "containerShift-class",
+          }
+        }
+      >
+        <Routing
+          classes={
+            Object {
+              "container": "container-class",
+              "containerShift": "containerShift-class",
+            }
+          }
+          dispatch={[Function]}
+          drawerOpen={false}
+          location="/"
+          maintenance={
+            Object {
+              "message": "",
+              "show": false,
+            }
+          }
+          plugins={Array []}
+          userIsAdmin={true}
+          userIsloggedIn={true}
+        >
+          <div
+            className="container-class"
+          >
+            <Switch>
+              <Route
+                computedMatch={
+                  Object {
+                    "isExact": true,
+                    "params": Object {},
+                    "path": "/admin",
+                    "url": "/admin",
+                  }
+                }
+                exact={true}
+                location={
+                  Object {
+                    "hash": "",
+                    "key": "testKey",
+                    "pathname": "/admin",
+                    "search": "",
+                  }
+                }
+                path="/admin"
+                render={[Function]}
+              >
+                <Connect(WithAuthComponent)>
+                  <WithAuthComponent
+                    invalidToken={[Function]}
+                    loading={false}
+                    location="/"
+                    loggedIn={true}
+                    provider={
+                      TestAuthProvider {
+                        "authUrl": undefined,
+                        "autoLogin": undefined,
+                        "mnemonic": undefined,
+                        "redirectUrl": null,
+                        "token": "logged in",
+                        "user": null,
+                      }
+                    }
+                    requestPluginRerender={[Function]}
+                    userIsAdmin={true}
+                  >
+                    <div>
+                      <Connect(AdminPage) />
+                    </div>
+                  </WithAuthComponent>
+                </Connect(WithAuthComponent)>
+              </Route>
+            </Switch>
+          </div>
+        </Routing>
+      </Connect(Routing)>
+    </Router>
+  </MemoryRouter>
+</Provider>
+`;
+
+exports[`Routing component renders a route for maintenance page when site is under maintenance and user is not admin 1`] = `
 <Provider
   store={
     Object {
@@ -91,7 +400,7 @@ exports[`Routing component does not render a route for a plugin when site is und
             ]
           }
           userIsAdmin={false}
-          userIsloggedIn={false}
+          userIsloggedIn={true}
         >
           <div
             className="container-class"
@@ -230,397 +539,6 @@ exports[`Routing component does not render a route for a plugin when site is und
                     }
                   }
                 />
-              </Route>
-            </Switch>
-          </div>
-        </Routing>
-      </Connect(Routing)>
-    </Router>
-  </MemoryRouter>
-</Provider>
-`;
-
-exports[`Routing component renders a route for a plugin 1`] = `
-<Provider
-  store={
-    Object {
-      "clearActions": [Function],
-      "dispatch": [Function],
-      "getActions": [Function],
-      "getState": [Function],
-      "replaceReducer": [Function],
-      "subscribe": [Function],
-    }
-  }
->
-  <MemoryRouter
-    initialEntries={
-      Array [
-        Object {
-          "key": "testKey",
-          "pathname": "/test_link",
-        },
-      ]
-    }
-  >
-    <Router
-      history={
-        Object {
-          "action": "POP",
-          "block": [Function],
-          "canGo": [Function],
-          "createHref": [Function],
-          "entries": Array [
-            Object {
-              "hash": "",
-              "key": "testKey",
-              "pathname": "/test_link",
-              "search": "",
-            },
-          ],
-          "go": [Function],
-          "goBack": [Function],
-          "goForward": [Function],
-          "index": 0,
-          "length": 1,
-          "listen": [Function],
-          "location": Object {
-            "hash": "",
-            "key": "testKey",
-            "pathname": "/test_link",
-            "search": "",
-          },
-          "push": [Function],
-          "replace": [Function],
-        }
-      }
-    >
-      <Connect(Routing)
-        classes={
-          Object {
-            "container": "container-class",
-            "containerShift": "containerShift-class",
-          }
-        }
-      >
-        <Routing
-          classes={
-            Object {
-              "container": "container-class",
-              "containerShift": "containerShift-class",
-            }
-          }
-          dispatch={[Function]}
-          drawerOpen={false}
-          location="/"
-          maintenance={
-            Object {
-              "message": "",
-              "show": false,
-            }
-          }
-          plugins={
-            Array [
-              Object {
-                "displayName": "Test Plugin",
-                "link": "/test_link",
-                "order": 1,
-                "plugin": "test_plugin_name",
-                "section": "test section",
-              },
-            ]
-          }
-          userIsAdmin={false}
-          userIsloggedIn={false}
-        >
-          <div
-            className="container-class"
-          >
-            <Switch>
-              <Route
-                computedMatch={
-                  Object {
-                    "isExact": true,
-                    "params": Object {},
-                    "path": "/test_link",
-                    "url": "/test_link",
-                  }
-                }
-                key="test section_/test_link"
-                location={
-                  Object {
-                    "hash": "",
-                    "key": "testKey",
-                    "pathname": "/test_link",
-                    "search": "",
-                  }
-                }
-                path="/test_link"
-                render={[Function]}
-              >
-                <Connect(WithAuthComponent)
-                  id="test_plugin_name"
-                >
-                  <WithAuthComponent
-                    id="test_plugin_name"
-                    invalidToken={[Function]}
-                    loading={true}
-                    location="/"
-                    loggedIn={false}
-                    provider={
-                      LoadingAuthProvider {
-                        "authUrl": undefined,
-                        "redirectUrl": null,
-                        "user": null,
-                      }
-                    }
-                    requestPluginRerender={[Function]}
-                  >
-                    <div />
-                  </WithAuthComponent>
-                </Connect(WithAuthComponent)>
-              </Route>
-            </Switch>
-          </div>
-        </Routing>
-      </Connect(Routing)>
-    </Router>
-  </MemoryRouter>
-</Provider>
-`;
-
-exports[`Routing component renders a route for admin page 1`] = `
-<Provider
-  store={
-    Object {
-      "clearActions": [Function],
-      "dispatch": [Function],
-      "getActions": [Function],
-      "getState": [Function],
-      "replaceReducer": [Function],
-      "subscribe": [Function],
-    }
-  }
->
-  <MemoryRouter
-    initialEntries={
-      Array [
-        Object {
-          "key": "testKey",
-          "pathname": "/admin",
-        },
-      ]
-    }
-  >
-    <Router
-      history={
-        Object {
-          "action": "POP",
-          "block": [Function],
-          "canGo": [Function],
-          "createHref": [Function],
-          "entries": Array [
-            Object {
-              "hash": "",
-              "key": "testKey",
-              "pathname": "/admin",
-              "search": "",
-            },
-          ],
-          "go": [Function],
-          "goBack": [Function],
-          "goForward": [Function],
-          "index": 0,
-          "length": 1,
-          "listen": [Function],
-          "location": Object {
-            "hash": "",
-            "key": "testKey",
-            "pathname": "/admin",
-            "search": "",
-          },
-          "push": [Function],
-          "replace": [Function],
-        }
-      }
-    >
-      <Connect(Routing)
-        classes={
-          Object {
-            "container": "container-class",
-            "containerShift": "containerShift-class",
-          }
-        }
-      >
-        <Routing
-          classes={
-            Object {
-              "container": "container-class",
-              "containerShift": "containerShift-class",
-            }
-          }
-          dispatch={[Function]}
-          drawerOpen={false}
-          location="/"
-          maintenance={
-            Object {
-              "message": "test",
-              "show": true,
-            }
-          }
-          plugins={
-            Array [
-              Object {
-                "displayName": "Test Plugin",
-                "link": "/test_link",
-                "order": 1,
-                "plugin": "test_plugin_name",
-                "section": "test section",
-              },
-            ]
-          }
-          userIsAdmin={true}
-          userIsloggedIn={true}
-        >
-          <div
-            className="container-class"
-          >
-            <Switch>
-              <Route
-                component={
-                  Object {
-                    "$$typeof": Symbol(react.memo),
-                    "WrappedComponent": [Function],
-                    "compare": null,
-                    "displayName": "Connect(WithAuthComponent)",
-                    "type": [Function],
-                  }
-                }
-                computedMatch={
-                  Object {
-                    "isExact": true,
-                    "params": Object {},
-                    "path": "/admin",
-                    "url": "/admin",
-                  }
-                }
-                exact={true}
-                location={
-                  Object {
-                    "hash": "",
-                    "key": "testKey",
-                    "pathname": "/admin",
-                    "search": "",
-                  }
-                }
-                path="/admin"
-              >
-                <Connect(WithAuthComponent)
-                  history={
-                    Object {
-                      "action": "POP",
-                      "block": [Function],
-                      "canGo": [Function],
-                      "createHref": [Function],
-                      "entries": Array [
-                        Object {
-                          "hash": "",
-                          "key": "testKey",
-                          "pathname": "/admin",
-                          "search": "",
-                        },
-                      ],
-                      "go": [Function],
-                      "goBack": [Function],
-                      "goForward": [Function],
-                      "index": 0,
-                      "length": 1,
-                      "listen": [Function],
-                      "location": Object {
-                        "hash": "",
-                        "key": "testKey",
-                        "pathname": "/admin",
-                        "search": "",
-                      },
-                      "push": [Function],
-                      "replace": [Function],
-                    }
-                  }
-                  location={
-                    Object {
-                      "hash": "",
-                      "key": "testKey",
-                      "pathname": "/admin",
-                      "search": "",
-                    }
-                  }
-                  match={
-                    Object {
-                      "isExact": true,
-                      "params": Object {},
-                      "path": "/admin",
-                      "url": "/admin",
-                    }
-                  }
-                >
-                  <WithAuthComponent
-                    history={
-                      Object {
-                        "action": "POP",
-                        "block": [Function],
-                        "canGo": [Function],
-                        "createHref": [Function],
-                        "entries": Array [
-                          Object {
-                            "hash": "",
-                            "key": "testKey",
-                            "pathname": "/admin",
-                            "search": "",
-                          },
-                        ],
-                        "go": [Function],
-                        "goBack": [Function],
-                        "goForward": [Function],
-                        "index": 0,
-                        "length": 1,
-                        "listen": [Function],
-                        "location": Object {
-                          "hash": "",
-                          "key": "testKey",
-                          "pathname": "/admin",
-                          "search": "",
-                        },
-                        "push": [Function],
-                        "replace": [Function],
-                      }
-                    }
-                    invalidToken={[Function]}
-                    loading={true}
-                    location="/"
-                    loggedIn={true}
-                    match={
-                      Object {
-                        "isExact": true,
-                        "params": Object {},
-                        "path": "/admin",
-                        "url": "/admin",
-                      }
-                    }
-                    provider={
-                      TestAuthProvider {
-                        "authUrl": undefined,
-                        "autoLogin": undefined,
-                        "mnemonic": undefined,
-                        "redirectUrl": null,
-                        "token": "logged in",
-                        "user": null,
-                      }
-                    }
-                    requestPluginRerender={[Function]}
-                  >
-                    <div />
-                  </WithAuthComponent>
-                </Connect(WithAuthComponent)>
               </Route>
             </Switch>
           </div>

--- a/src/routing/authorisedRoute.component.test.tsx
+++ b/src/routing/authorisedRoute.component.test.tsx
@@ -51,11 +51,11 @@ describe('AuthorisedRoute component', () => {
   });
 
   it('renders non admin component when non admin user accesses it', () => {
+    const testAuthProvider = new TestAuthProvider('test-token');
+    testAuthProvider.isAdmin = jest.fn().mockImplementationOnce(() => false);
+    state.scigateway.authorisation.provider = testAuthProvider;
     state.scigateway.siteLoading = false;
     state.scigateway.authorisation.loading = false;
-    state.scigateway.authorisation.provider = new TestAuthProvider(
-      'test-token'
-    );
 
     const AuthorisedComponent = withAuth(ComponentToProtect);
     const wrapper = shallow(

--- a/src/routing/authorisedRoute.component.tsx
+++ b/src/routing/authorisedRoute.component.tsx
@@ -8,10 +8,12 @@ import {
   invalidToken,
   requestPluginRerender,
 } from '../state/actions/scigateway.actions';
+import PageNotFound from '../pageNotFound/pageNotFound.component';
 
 interface WithAuthStateProps {
   loading: boolean;
   loggedIn: boolean;
+  userIsAdmin: boolean;
   provider: AuthProvider;
   location: string;
   startUrlState?: StateType;
@@ -32,6 +34,7 @@ const mapStateToProps = (state: StateType): WithAuthStateProps => ({
     state.scigateway.siteLoading ||
     isStartingUpOrLoading(state.scigateway.authorisation),
   loggedIn: state.scigateway.authorisation.provider.isLoggedIn(),
+  userIsAdmin: state.scigateway.authorisation.provider.isAdmin(),
   provider: state.scigateway.authorisation.provider,
   location: state.router.location.pathname,
   startUrlState: state.router.location.state,
@@ -60,6 +63,7 @@ export default function withAuth<T>(
       const {
         loading,
         loggedIn,
+        userIsAdmin,
         location,
         provider,
         startUrlState,
@@ -67,6 +71,9 @@ export default function withAuth<T>(
         invalidToken,
         ...componentProps
       } = this.props;
+      const adminPlugin =
+        'adminPlugin' in componentProps ? componentProps['adminPlugin'] : false;
+
       return (
         <div>
           {!loading && !loggedIn ? (
@@ -79,7 +86,9 @@ export default function withAuth<T>(
             />
           ) : null}
           {/* If using a plugin as the start page, redirect here so the plugin renders with the redirected url */}
-          {!loading && loggedIn ? (
+          {!loading &&
+          loggedIn &&
+          (!adminPlugin || (adminPlugin && userIsAdmin)) ? (
             startUrlState && startUrlState.scigateway.startUrl ? (
               <Redirect
                 push
@@ -88,7 +97,9 @@ export default function withAuth<T>(
             ) : (
               <ComponentToProtect {...(componentProps as T)} />
             )
-          ) : null}
+          ) : (
+            <PageNotFound />
+          )}
         </div>
       );
     }

--- a/src/routing/routing.component.tsx
+++ b/src/routing/routing.component.tsx
@@ -51,7 +51,10 @@ interface RoutingProps {
   userIsAdmin: boolean;
 }
 
-export class PluginPlaceHolder extends React.PureComponent<{ id: string }> {
+export class PluginPlaceHolder extends React.PureComponent<{
+  id: string;
+  adminPlugin: boolean;
+}> {
   public render(): React.ReactNode {
     const { id } = this.props;
     return <div id={id}>{id} failed to load correctly</div>;
@@ -59,6 +62,8 @@ export class PluginPlaceHolder extends React.PureComponent<{ id: string }> {
 }
 
 export const AuthorisedPlugin = withAuth(PluginPlaceHolder);
+// Prevents the component from updating when the draw is opened/ closed
+export const AuthorisedAdminPage = withAuth(AdminPage);
 
 class Routing extends React.Component<
   RoutingProps & WithStyles<typeof styles>
@@ -78,8 +83,9 @@ class Routing extends React.Component<
           <Route exact path="/" component={HomePage} />
           <Route exact path="/contact" component={ContactPage} />
           <Route exact path="/help" component={HelpPage} />
-          {this.props.userIsloggedIn && this.props.userIsAdmin ? (
-            <Route exact path="/admin" component={withAuth(AdminPage)} />
+          {/* Admin check required because the component does not have an adminPlugin prop */}
+          {this.props.userIsAdmin ? (
+            <Route exact path="/admin" render={() => <AuthorisedAdminPage />} />
           ) : null}
           <Route exact path="/login" component={LoginPage} />
           <Route exact path="/cookies" component={CookiesPage} />
@@ -90,7 +96,12 @@ class Routing extends React.Component<
               <Route
                 key={`${p.section}_${p.link}`}
                 path={p.link}
-                render={() => <AuthorisedPlugin id={p.plugin} />}
+                render={() => (
+                  <AuthorisedPlugin
+                    id={p.plugin}
+                    adminPlugin={p.admin ? p.admin : false}
+                  />
+                )}
               />
             ))
           )}

--- a/src/routing/routing.component.tsx
+++ b/src/routing/routing.component.tsx
@@ -89,7 +89,8 @@ class Routing extends React.Component<
           ) : null}
           <Route exact path="/login" component={LoginPage} />
           <Route exact path="/cookies" component={CookiesPage} />
-          {this.props.maintenance.show ? (
+          {/* Only display maintenance page to non-admin users when site under maintenance */}
+          {this.props.maintenance.show && !this.props.userIsAdmin ? (
             <Route component={MaintenancePage} />
           ) : (
             this.props.plugins.map((p) => (

--- a/src/state/middleware/scigateway.middleware.test.tsx
+++ b/src/state/middleware/scigateway.middleware.test.tsx
@@ -15,7 +15,7 @@ import { AddHelpTourStepsType } from '../scigateway.types';
 import { StateType } from '../state.types';
 import TestAuthProvider from '../../authentication/testAuthProvider';
 import { flushPromises } from '../../setupTests';
-import { initialState } from '../reducers/scigateway.reducer';
+import { authState, initialState } from '../reducers/scigateway.reducer';
 import { buildTheme } from '../../theming';
 
 describe('scigateway middleware', () => {
@@ -23,7 +23,7 @@ describe('scigateway middleware', () => {
   let handler: (event: Event) => void;
   let store: MockStoreEnhanced;
   const getState: () => StateType = () => ({
-    scigateway: initialState,
+    scigateway: { ...initialState, authorisation: { ...authState } },
     router: {
       action: 'POP',
       location: createLocation('/'),

--- a/src/state/reducers/scigateway.reducer.test.tsx
+++ b/src/state/reducers/scigateway.reducer.test.tsx
@@ -23,6 +23,7 @@ import {
 import ScigatewayReducer, {
   initialState,
   handleAuthProviderUpdate,
+  authState,
 } from './scigateway.reducer';
 import { SignOutType } from '../scigateway.types';
 import { ScigatewayState } from '../state.types';
@@ -35,7 +36,7 @@ describe('scigateway reducer', () => {
   let state: ScigatewayState;
 
   beforeEach(() => {
-    state = initialState;
+    state = { ...initialState, authorisation: { ...authState } };
   });
 
   it('should return state for actions it does not care about', () => {

--- a/src/state/scigateway.types.tsx
+++ b/src/state/scigateway.types.tsx
@@ -69,6 +69,7 @@ export interface RegisterRoutePayload {
   link: string;
   plugin: string;
   displayName: string;
+  admin?: boolean;
   order: number;
   helpText?: string;
   logoLightMode?: string;
@@ -82,6 +83,7 @@ export interface PluginConfig {
   link: string;
   plugin: string;
   displayName: string;
+  admin?: boolean;
   order: number;
   helpText?: string;
   logoLightMode?: string;

--- a/src/state/strings.test.tsx
+++ b/src/state/strings.test.tsx
@@ -2,7 +2,7 @@ import { getAppStrings, getString } from './strings';
 import { AppStrings } from './scigateway.types';
 import { ScigatewayState, StateType } from './state.types';
 import { RouterState } from 'connected-react-router';
-import { initialState } from './reducers/scigateway.reducer';
+import { authState, initialState } from './reducers/scigateway.reducer';
 
 describe('strings', () => {
   describe('getString', () => {
@@ -46,15 +46,16 @@ describe('strings', () => {
 
     const scigatewayState: ScigatewayState = {
       ...initialState,
+      authorisation: { ...authState },
       res: {
-        'section-name': testRes,
-        'unused-section': otherSection,
+        'section-name': { ...testRes },
+        'unused-section': { ...otherSection },
       },
     };
 
     const state: StateType = {
-      router: routerState,
-      scigateway: scigatewayState,
+      router: { ...routerState },
+      scigateway: { ...scigatewayState },
     };
 
     it('returns key element from state object if section exists', () => {


### PR DESCRIPTION
## Description
Allows for DataGateway admin routes to be created if `"admin": true` is added to the route object in the `*-settings.json` file. Protects such routes so that only admins can access them by checking whether the user is admin or not and by not creating links to them in the navigation drawer. Displays the `PageNotFound` page if a non-admin user navigates to an admin route. This functionality is needed for the Admin Download table that will be created in DataGateway Download as part of the [Add TopCAT admin download table](https://github.com/ral-facilities/datagateway/issues/613) issue. In preparation for this work, I created two tabs in the Admin page - _Maintenance_ and _Admin Download_. The former is active by default and its panel displays the maintenance text boxes that admins can use to turn maintenance on and off, whereas the latter tab does not have a panel but instead is set to direct to the Admin Download table route `/admin-download` when an admin clicks on it.

Moved some of the admin plugin/ route checks to the `authorisedRoute` component as it makes more sense to have them in there though such checks are still required for a couple of things in the `routing` component - I left comments in the code that explains why they are needed. Also made some changes so that maintenance page is not displayed to admin users when they navigate to the plugins while the site is under maintenance.

While debugging some of the failing unit tests, I discovered that the state persists between unit tests. It turns out this is due to object mutation - when we are assigning values to the `state` object, we are passing the imported `initialState` constant to the `scigateway` object. This passes the memory pointer of `initialState` to `state.scigateway` so when we change any of the values of the `state.scigateway` in the tests, it also changes the values in `initialState`. The same thing happens with the `authorisation` property of the `initialState` constant because it is referencing the `authState` constant. To prevent these mutations, the `initialState` and the `authState` need to be spread. I applied these changes to the other unit tests in the code base as part of the [`f37e5c1`](https://github.com/ral-facilities/scigateway/pull/679/commits/f37e5c1fbb36bcde7c1cfeb27c497a794aaff2fa) commit.

I tried writing a unit test for the _Admin Download_ tab but I couldn't get it to work. Was testing for whether a `push('/admin-download')` action is sent to the store when this tab is clicked. I think it is to do with the click not simulating properly. Here is the code I wrote:
```TypeScript
it('redirects to Admin Download table when Admin Downlod tab is clicked', () => {
  const testStore = mockStore(state);
  const wrapper = mount(
    <Provider store={testStore}>
      <MuiThemeProvider theme={theme}>
        <MemoryRouter initialEntries={[{ key: 'testKey' }]}>
          <AdminPage />
        </MemoryRouter>
      </MuiThemeProvider>
    </Provider>
  );

  wrapper.find('#download-tab').hostNodes().simulate('click');

  expect(testStore.getActions().length).toEqual(1);
  expect(testStore.getActions()[0]).toEqual(push('/admin-download'));
});
```

## Testing instructions
Create an admin DataGateway Download route and treat that as the Admin Download table. This can be done by adding a route to the `datagateway-download-settings.json` file (note `"admin": true`):
```JSON
...
  "routes": [
    {
      "section": "Test",
      "link": "/admin-download",
      "displayName": "Admin Download",
      "admin": true,
      "order": 0
    },
...
  ],
...
```
Deploy SciGateway together with DataGateway Download.

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] The navigation drawer does not contain a link to the admin route.
- [ ] PageNotFound page is displayed when a non-admin user manually navigates to `/admin-download`.
- [ ] DataGateway Download table is displayed when an admin user manually navigates to `/admin-download`.
- [ ] _Maintenance_ tab is active by default in Admin page.
- [ ] An admin user is redirected to the DataGateway Download table after clicking on the _Admin Download_ tab from the Admin page.
- [ ] Create another non-admin route by either deploying another DataGateway plugin or adding a second route to the  `datagateway-download-settings.json` file. Make sure that a link is created for it in the navigation drawer and that both admin and non-admin users can access it.
- [ ] Put site into maintenance and check that the maintenance page is still displayed when a non-admin user navigates to a plugin but it is not displayed for non-admin users.

## Agile board tracking
closes #625 