### PR TITLE
Bugfix/fix plugin loading #732

### DIFF
--- a/src/routing/routing.component.tsx
+++ b/src/routing/routing.component.tsx
@@ -66,6 +66,15 @@ export const AuthorisedPlugin = withAuth(PluginPlaceHolder);
 // Prevents the component from updating when the draw is opened/ closed
 export const AuthorisedAdminPage = withAuth(AdminPage);
 
+export const scigatewayRoutes = {
+  home: '/',
+  contact: '/contact',
+  help: '/help',
+  admin: '/admin',
+  login: '/login',
+  cookies: '/cookies',
+};
+
 class Routing extends React.Component<
   RoutingProps & WithStyles<typeof styles>
 > {
@@ -82,21 +91,33 @@ class Routing extends React.Component<
       >
         {/* Redirect to a homepageUrl if set. Otherwise, route to / */}
         <Switch>
-          <Route exact path="/">
+          <Route exact path={scigatewayRoutes.home}>
             {this.props.homepageUrl && this.props.homepageUrl !== '/' ? (
               <Redirect to={this.props.homepageUrl} />
             ) : (
               <HomePage />
             )}
           </Route>
-          <Route exact path="/contact" component={ContactPage} />
-          <Route exact path="/help" component={HelpPage} />
+          <Route
+            exact
+            path={scigatewayRoutes.contact}
+            component={ContactPage}
+          />
+          <Route exact path={scigatewayRoutes.help} component={HelpPage} />
           {/* Admin check required because the component does not have an adminPlugin prop */}
           {this.props.userIsAdmin ? (
-            <Route exact path="/admin" render={() => <AuthorisedAdminPage />} />
+            <Route
+              exact
+              path={scigatewayRoutes.admin}
+              render={() => <AuthorisedAdminPage />}
+            />
           ) : null}
-          <Route exact path="/login" component={LoginPage} />
-          <Route exact path="/cookies" component={CookiesPage} />
+          <Route exact path={scigatewayRoutes.login} component={LoginPage} />
+          <Route
+            exact
+            path={scigatewayRoutes.cookies}
+            component={CookiesPage}
+          />
           {/* Only display maintenance page to non-admin users when site under maintenance */}
           {this.props.maintenance.show && !this.props.userIsAdmin ? (
             <Route component={MaintenancePage} />

--- a/src/routing/routing.component.tsx
+++ b/src/routing/routing.component.tsx
@@ -8,7 +8,11 @@ import {
 } from '@material-ui/core/styles';
 import { Route, Switch, Redirect } from 'react-router';
 import { StateType } from '../state/state.types';
-import { MaintenanceState, PluginConfig } from '../state/scigateway.types';
+import {
+  MaintenanceState,
+  PluginConfig,
+  scigatewayRoutes,
+} from '../state/scigateway.types';
 import { connect } from 'react-redux';
 import HomePage from '../homePage/homePage.component';
 import ContactPage from '../contactPage/contactPage.component';
@@ -65,15 +69,6 @@ export class PluginPlaceHolder extends React.PureComponent<{
 export const AuthorisedPlugin = withAuth(PluginPlaceHolder);
 // Prevents the component from updating when the draw is opened/ closed
 export const AuthorisedAdminPage = withAuth(AdminPage);
-
-export const scigatewayRoutes = {
-  home: '/',
-  contact: '/contact',
-  help: '/help',
-  admin: '/admin',
-  login: '/login',
-  cookies: '/cookies',
-};
 
 class Routing extends React.Component<
   RoutingProps & WithStyles<typeof styles>

--- a/src/state/actions/scigateway.actions.test.tsx
+++ b/src/state/actions/scigateway.actions.test.tsx
@@ -69,6 +69,11 @@ describe('scigateway actions', () => {
       .mockImplementation(() => Promise.resolve());
   });
 
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
   it('toggleDrawer only needs a type', () => {
     const action = toggleDrawer();
     expect(action.type).toEqual(ToggleDrawerType);

--- a/src/state/actions/scigateway.actions.test.tsx
+++ b/src/state/actions/scigateway.actions.test.tsx
@@ -551,9 +551,7 @@ describe('scigateway actions', () => {
     });
   });
 
-  // TODO Test is passing locally, but failing Travis as darkMode is always
-  //      false in storage. Skip for now.
-  it.skip('should load dark mode preference into store', async () => {
+  it('should load dark mode preference into store', async () => {
     (mockAxios.get as jest.Mock).mockImplementation(() =>
       Promise.resolve({
         data: {
@@ -562,15 +560,25 @@ describe('scigateway actions', () => {
       })
     );
 
-    localStorage.setItem('darkMode', 'true');
+    jest.spyOn(window.localStorage.__proto__, 'getItem');
+    window.localStorage.__proto__.getItem = jest
+      .fn()
+      .mockImplementation((name) => (name === 'darkMode' ? 'true' : 'false'));
 
     const asyncAction = configureSite();
     const actions: Action[] = [];
     const dispatch = (action: Action): number => actions.push(action);
-    const getState = (): Partial<StateType> => ({ scigateway: initialState });
+    const getState = (): Partial<StateType> => ({
+      scigateway: initialState,
+      router: {
+        location: { ...createLocation('/'), query: {} },
+        action: 'PUSH',
+      },
+    });
 
     await asyncAction(dispatch, getState);
 
+    expect(localStorage.getItem).toBeCalledWith('darkMode');
     expect(actions).toContainEqual(loadDarkModePreference(true));
   });
 

--- a/src/state/actions/scigateway.actions.tsx
+++ b/src/state/actions/scigateway.actions.tsx
@@ -47,9 +47,11 @@ import {
   HomepageUrlPayload,
   ToggleDrawerType,
   ToggleHelpType,
+  RegisterRouteType,
 } from '../scigateway.types';
 import { ActionType, StateType, ThunkResult } from '../state.types';
 import loadMicroFrontends from './loadMicroFrontends';
+import { scigatewayRoutes } from '../../routing/routing.component';
 
 export const configureStrings = (
   appStrings: ApplicationStrings
@@ -280,7 +282,35 @@ export const configureSite = (): ThunkResult<Promise<void>> => {
         }
 
         return Promise.all(loadingPromises).then(() => {
-          dispatch(siteLoadingUpdate(false));
+          // if we're on a non-scigateway url, attempt to wait for matching register route event
+          // to help prevent showing a 404 page before the right route has been registered
+          const currUrl = getState().router.location.pathname;
+          if (!Object.values(scigatewayRoutes).includes(currUrl)) {
+            let eventFired = false;
+            const handler = (event: Event): void => {
+              const pluginMessage = event as CustomEvent<AnyAction>;
+
+              if (
+                pluginMessage?.detail?.type === RegisterRouteType &&
+                currUrl === pluginMessage.detail.payload.link
+              ) {
+                dispatch(siteLoadingUpdate(false));
+                eventFired = true;
+                document.removeEventListener('scigateway', handler);
+              }
+            };
+
+            setTimeout(function () {
+              if (!eventFired) {
+                dispatch(siteLoadingUpdate(false));
+              }
+              document.removeEventListener('scigateway', handler);
+            }, 3000);
+
+            document.addEventListener('scigateway', handler);
+          } else {
+            dispatch(siteLoadingUpdate(false));
+          }
         });
       })
       .catch((error) => {

--- a/src/state/actions/scigateway.actions.tsx
+++ b/src/state/actions/scigateway.actions.tsx
@@ -48,10 +48,10 @@ import {
   ToggleDrawerType,
   ToggleHelpType,
   RegisterRouteType,
+  scigatewayRoutes,
 } from '../scigateway.types';
 import { ActionType, StateType, ThunkResult } from '../state.types';
 import loadMicroFrontends from './loadMicroFrontends';
-import { scigatewayRoutes } from '../../routing/routing.component';
 
 export const configureStrings = (
   appStrings: ApplicationStrings

--- a/src/state/middleware/scigateway.middleware.tsx
+++ b/src/state/middleware/scigateway.middleware.tsx
@@ -119,14 +119,6 @@ export const listenToPlugins = (
           // Send theme options once registered.
           dispatch(sendThemeOptions(theme));
 
-          // if we're currently at the URL we're registering, we might need to rerender
-          if (
-            getState().router.location.pathname ===
-            pluginMessage.detail.payload.link
-          ) {
-            dispatch(requestPluginRerender());
-          }
-
           break;
 
         case NotificationType:
@@ -195,7 +187,6 @@ const ScigatewayMiddleware: Middleware = ((
     next(action);
     const theme = buildTheme(action.payload.darkMode);
     store.dispatch(sendThemeOptions(theme));
-    console.log('requesting plugin rerender after loading darkmode');
     return store.dispatch(requestPluginRerender());
   }
 

--- a/src/state/middleware/scigateway.middleware.tsx
+++ b/src/state/middleware/scigateway.middleware.tsx
@@ -118,6 +118,15 @@ export const listenToPlugins = (
 
           // Send theme options once registered.
           dispatch(sendThemeOptions(theme));
+
+          // if we're currently at the URL we're registering, we might need to rerender
+          if (
+            getState().router.location.pathname ===
+            pluginMessage.detail.payload.link
+          ) {
+            dispatch(requestPluginRerender());
+          }
+
           break;
 
         case NotificationType:
@@ -186,6 +195,7 @@ const ScigatewayMiddleware: Middleware = ((
     next(action);
     const theme = buildTheme(action.payload.darkMode);
     store.dispatch(sendThemeOptions(theme));
+    console.log('requesting plugin rerender after loading darkmode');
     return store.dispatch(requestPluginRerender());
   }
 

--- a/src/state/scigateway.types.tsx
+++ b/src/state/scigateway.types.tsx
@@ -31,6 +31,15 @@ export const AddHelpTourStepsType = 'scigateway:add_help_tour_steps';
 export const RegisterStartUrlType = 'scigateway:register_start_url';
 export const RegisterHomepageUrlType = 'scigateway:register_homepage_url';
 
+export const scigatewayRoutes = {
+  home: '/',
+  contact: '/contact',
+  help: '/help',
+  admin: '/admin',
+  login: '/login',
+  cookies: '/cookies',
+};
+
 export interface NotificationPayload {
   message: string;
   severity: string;


### PR DESCRIPTION
## Description
Fixes the bug where plugins would sometimes not be loaded when loaded directly (e.g. when trying to load `/browse/investigation`). This bug was discovered due to the changes in dataview to allow plugin routes to be configurable, which meant they were loaded later on after the plugin settings files were loaded which then revealed this issue. This PR fixes the issue by checking if we are on a "potential plugin route" (i.e. any route that scigateway doesn't know about) and listening for the register route event from the plugin that corresponds to our current location. I also added a 3 second timeout to this listening, as otherwise the site would never load if someone navigated to a route that should 404.

Additionally, since I was looking at `scigateway.actions.test.tsx`, I had a look at the darkMode test which was skipped and realised it wasn't mocking localStorage. Mocking it makes the test pass in CI again so this PR also fixes #500 

## Testing instructions
- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] Check that when navigating directly to a plugin route the plugin always loads correctly. I will shortly be adding this to diamond preprod so this can be checked there (and behaviour contrasted against any of the other machines)
 
## Agile board tracking
Fixes #732