### PR TITLE
Small changes to navigation drawer #737

### DIFF
--- a/src/navigationDrawer/__snapshots__/navigationDrawer.component.test.tsx.snap
+++ b/src/navigationDrawer/__snapshots__/navigationDrawer.component.test.tsx.snap
@@ -72,11 +72,17 @@ exports[`Navigation drawer component does not display link to homepage if a home
   </Styled(div)>
   <WithStyles(ForwardRef(Divider)) />
   <WithStyles(ForwardRef(List))>
-    <WithStyles(ForwardRef(ListItem))>
+    <WithStyles(ForwardRef(ListItem))
+      classes={
+        Object {
+          "root": "NavigationDrawer-sectionTitle-3",
+        }
+      }
+    >
       <WithStyles(ForwardRef(ListItemText))
         classes={
           Object {
-            "primary": "NavigationDrawer-sectionTitle-3",
+            "primary": "NavigationDrawer-sectionTitleText-4",
           }
         }
         primary="DATA"
@@ -99,6 +105,7 @@ exports[`Navigation drawer component does not display link to homepage if a home
             "render": [Function],
           }
         }
+        dense={true}
         id="plugin-link-plugin_link"
         key="0"
         to="plugin_link"
@@ -106,7 +113,7 @@ exports[`Navigation drawer component does not display link to homepage if a home
         <WithStyles(ForwardRef(ListItemText))
           classes={
             Object {
-              "primary": "NavigationDrawer-menuItem-4",
+              "primary": "NavigationDrawer-menuItem-5",
             }
           }
           inset={true}
@@ -170,11 +177,17 @@ exports[`Navigation drawer component renders a plugin list grouped by sections o
   </Styled(div)>
   <WithStyles(ForwardRef(Divider)) />
   <WithStyles(ForwardRef(List))>
-    <WithStyles(ForwardRef(ListItem))>
+    <WithStyles(ForwardRef(ListItem))
+      classes={
+        Object {
+          "root": "NavigationDrawer-sectionTitle-3",
+        }
+      }
+    >
       <WithStyles(ForwardRef(ListItemText))
         classes={
           Object {
-            "primary": "NavigationDrawer-sectionTitle-3",
+            "primary": "NavigationDrawer-sectionTitleText-4",
           }
         }
         primary="ANALYSIS"
@@ -197,6 +210,7 @@ exports[`Navigation drawer component renders a plugin list grouped by sections o
             "render": [Function],
           }
         }
+        dense={true}
         id="plugin-link-link"
         key="0"
         to="link"
@@ -204,7 +218,7 @@ exports[`Navigation drawer component renders a plugin list grouped by sections o
         <WithStyles(ForwardRef(ListItemText))
           classes={
             Object {
-              "primary": "NavigationDrawer-menuItem-4",
+              "primary": "NavigationDrawer-menuItem-5",
             }
           }
           inset={true}
@@ -225,6 +239,7 @@ exports[`Navigation drawer component renders a plugin list grouped by sections o
             "render": [Function],
           }
         }
+        dense={true}
         id="plugin-link-link"
         key="1"
         to="link"
@@ -232,7 +247,7 @@ exports[`Navigation drawer component renders a plugin list grouped by sections o
         <WithStyles(ForwardRef(ListItemText))
           classes={
             Object {
-              "primary": "NavigationDrawer-menuItem-4",
+              "primary": "NavigationDrawer-menuItem-5",
             }
           }
           inset={true}
@@ -245,11 +260,17 @@ exports[`Navigation drawer component renders a plugin list grouped by sections o
         />
       </WithStyles(ForwardRef(ListItem))>
     </WithStyles(ForwardRef(List))>
-    <WithStyles(ForwardRef(ListItem))>
+    <WithStyles(ForwardRef(ListItem))
+      classes={
+        Object {
+          "root": "NavigationDrawer-sectionTitle-3",
+        }
+      }
+    >
       <WithStyles(ForwardRef(ListItemText))
         classes={
           Object {
-            "primary": "NavigationDrawer-sectionTitle-3",
+            "primary": "NavigationDrawer-sectionTitleText-4",
           }
         }
         primary="DATA"
@@ -272,6 +293,7 @@ exports[`Navigation drawer component renders a plugin list grouped by sections o
             "render": [Function],
           }
         }
+        dense={true}
         id="plugin-link-link"
         key="0"
         to="link"
@@ -279,7 +301,7 @@ exports[`Navigation drawer component renders a plugin list grouped by sections o
         <WithStyles(ForwardRef(ListItemText))
           classes={
             Object {
-              "primary": "NavigationDrawer-menuItem-4",
+              "primary": "NavigationDrawer-menuItem-5",
             }
           }
           inset={true}
@@ -300,6 +322,7 @@ exports[`Navigation drawer component renders a plugin list grouped by sections o
             "render": [Function],
           }
         }
+        dense={true}
         id="plugin-link-link"
         key="1"
         to="link"
@@ -307,7 +330,7 @@ exports[`Navigation drawer component renders a plugin list grouped by sections o
         <WithStyles(ForwardRef(ListItemText))
           classes={
             Object {
-              "primary": "NavigationDrawer-menuItem-4",
+              "primary": "NavigationDrawer-menuItem-5",
             }
           }
           inset={true}
@@ -328,6 +351,7 @@ exports[`Navigation drawer component renders a plugin list grouped by sections o
             "render": [Function],
           }
         }
+        dense={true}
         id="plugin-link-link"
         key="2"
         to="link"
@@ -335,7 +359,7 @@ exports[`Navigation drawer component renders a plugin list grouped by sections o
         <WithStyles(ForwardRef(ListItemText))
           classes={
             Object {
-              "primary": "NavigationDrawer-menuItem-4",
+              "primary": "NavigationDrawer-menuItem-5",
             }
           }
           inset={true}
@@ -356,6 +380,7 @@ exports[`Navigation drawer component renders a plugin list grouped by sections o
             "render": [Function],
           }
         }
+        dense={true}
         id="plugin-link-plugin_link"
         key="3"
         to="plugin_link"
@@ -363,7 +388,7 @@ exports[`Navigation drawer component renders a plugin list grouped by sections o
         <WithStyles(ForwardRef(ListItemText))
           classes={
             Object {
-              "primary": "NavigationDrawer-menuItem-4",
+              "primary": "NavigationDrawer-menuItem-5",
             }
           }
           inset={true}
@@ -390,6 +415,7 @@ exports[`Navigation drawer component renders a plugin list grouped by sections o
       "render": [Function],
     }
   }
+  dense={true}
   id="plugin-link-plugin_link"
   key="3"
   to="plugin_link"
@@ -397,7 +423,7 @@ exports[`Navigation drawer component renders a plugin list grouped by sections o
   <WithStyles(ForwardRef(ListItemText))
     classes={
       Object {
-        "primary": "NavigationDrawer-menuItem-4",
+        "primary": "NavigationDrawer-menuItem-5",
       }
     }
     inset={true}

--- a/src/navigationDrawer/navigationDrawer.component.test.tsx
+++ b/src/navigationDrawer/navigationDrawer.component.test.tsx
@@ -151,7 +151,7 @@ describe('Navigation drawer component', () => {
     expect(wrapper.find('[to="homepage"]')).toEqual({});
   });
 
-  it('renders a plugin with displayName but no logo or altText', () => {
+  it('renders a plugin', () => {
     const dummyPlugins: PluginConfig[] = [
       {
         order: 0,
@@ -171,40 +171,11 @@ describe('Navigation drawer component', () => {
       </MemoryRouter>
     );
 
-    expect(wrapper.find('img')).toHaveLength(0);
     const listItemText = wrapper.find(ListItemText).last();
     expect(listItemText.text()).toEqual('\xa0display name');
-    expect(listItemText.prop('inset')).toBeTruthy();
   });
 
-  it('renders a plugin with displayName and altText but no logo', () => {
-    const dummyPlugins: PluginConfig[] = [
-      {
-        order: 0,
-        plugin: 'data-plugin',
-        link: 'plugin_link',
-        section: 'DATA',
-        displayName: '\xa0display name',
-        logoAltText: 'DataGateway',
-      },
-    ];
-    state.scigateway.plugins = dummyPlugins;
-    state.scigateway.drawerOpen = true;
-
-    const testStore = mockStore(state);
-    const wrapper = mount(
-      <MemoryRouter initialEntries={[{ key: 'testKey' }]}>
-        <NavigationDrawer store={testStore} />
-      </MemoryRouter>
-    );
-
-    expect(wrapper.find('img')).toHaveLength(0);
-    const listItemText = wrapper.find(ListItemText).last();
-    expect(listItemText.text()).toEqual('DataGateway\xa0display name');
-    expect(listItemText.prop('inset')).toBeTruthy();
-  });
-
-  it('renders a plugin with logoLightMode', () => {
+  it('renders the light mode logo at the top', () => {
     const dummyPlugins: PluginConfig[] = [
       {
         order: 0,
@@ -219,6 +190,7 @@ describe('Navigation drawer component', () => {
     ];
     state.scigateway.plugins = dummyPlugins;
     state.scigateway.drawerOpen = true;
+    state.scigateway.darkMode = false;
 
     const testStore = mockStore(state);
     const wrapper = mount(
@@ -227,13 +199,11 @@ describe('Navigation drawer component', () => {
       </MemoryRouter>
     );
 
+    expect(wrapper.find('img')).toHaveLength(1);
     expect(wrapper.find('img').prop('src')).toEqual('/lightLogo.svg');
-    const listItemText = wrapper.find(ListItemText).last();
-    expect(listItemText.text()).toEqual('\xa0display name');
-    expect(listItemText.prop('inset')).toBeFalsy();
   });
 
-  it('renders a plugin with logoDarkMode', () => {
+  it('renders the dark mode logo at the top', () => {
     const dummyPlugins: PluginConfig[] = [
       {
         order: 0,
@@ -257,9 +227,7 @@ describe('Navigation drawer component', () => {
       </MemoryRouter>
     );
 
+    expect(wrapper.find('img')).toHaveLength(1);
     expect(wrapper.find('img').prop('src')).toEqual('/darkLogo.svg');
-    const listItemText = wrapper.find(ListItemText).last();
-    expect(listItemText.text()).toEqual('\xa0display name');
-    expect(listItemText.prop('inset')).toBeFalsy();
   });
 });

--- a/src/navigationDrawer/navigationDrawer.component.tsx
+++ b/src/navigationDrawer/navigationDrawer.component.tsx
@@ -193,9 +193,8 @@ class NavigationDrawer extends Component<CombinedNavigationProps> {
   public render(): React.ReactElement {
     const { plugins } = this.props;
     const imgSrc = this.props.darkMode
-      ? plugins[0].logoDarkMode
-      : plugins[0].logoLightMode;
-    console.log(imgSrc);
+      ? plugins[0]?.logoDarkMode
+      : plugins[0]?.logoLightMode;
     return (
       <Drawer
         className={this.props.classes.drawer}

--- a/src/navigationDrawer/navigationDrawer.component.tsx
+++ b/src/navigationDrawer/navigationDrawer.component.tsx
@@ -61,7 +61,7 @@ const styles = (theme: Theme): StyleRules =>
     //   justifyContent: 'flex-end',
     // },
     sectionTitle: {
-      textAlign: 'center',
+      textAlign: 'left',
       paddingTop: 0,
       paddingBottom: 0,
     },
@@ -69,10 +69,11 @@ const styles = (theme: Theme): StyleRules =>
       color: theme.palette.text.primary,
     },
     menuItem: {
-      textAlign: 'center',
+      textAlign: 'left',
       color: theme.palette.text.secondary,
     },
     menuLogo: {
+      paddingRight: 100,
       paddingTop: 10,
       paddingBottom: 10,
       height: 30,

--- a/src/navigationDrawer/navigationDrawer.component.tsx
+++ b/src/navigationDrawer/navigationDrawer.component.tsx
@@ -61,14 +61,21 @@ const styles = (theme: Theme): StyleRules =>
     //   justifyContent: 'flex-end',
     // },
     sectionTitle: {
-      color: theme.palette.text.secondary,
+      textAlign: 'center',
+      paddingTop: 0,
+      paddingBottom: 0,
+    },
+    sectionTitleText: {
+      color: theme.palette.text.primary,
     },
     menuItem: {
+      textAlign: 'center',
       color: theme.palette.text.secondary,
     },
     menuLogo: {
-      paddingLeft: 56,
-      height: 20,
+      paddingTop: 10,
+      paddingBottom: 10,
+      height: 30,
       color: theme.palette.text.secondary,
     },
   });
@@ -103,14 +110,16 @@ class NavigationDrawer extends Component<CombinedNavigationProps> {
         to={plugin.link}
         id={`plugin-link-${plugin.link.replace(/\//g, '-')}`}
         button
+        dense
       >
-        {imgSrc && (
+        {/* Uncomment this to add DataGateway logo next to each button */}
+        {/* {imgSrc && (
           <img
             className={this.props.classes.menuLogo}
             alt={plugin.logoAltText}
             src={imgSrc}
           />
-        )}
+        )} */}
         <ListItemText
           inset={!imgSrc}
           primary={displayText}
@@ -130,12 +139,16 @@ class NavigationDrawer extends Component<CombinedNavigationProps> {
   ): React.ReactElement {
     return (
       <Fragment key={index}>
-        <ListItem>
+        <ListItem
+          classes={{
+            root: this.props.classes.sectionTitle,
+          }}
+        >
           <ListItemText
             primary={sectionName}
             primaryTypographyProps={{ variant: 'h6' }}
             classes={{
-              primary: this.props.classes.sectionTitle,
+              primary: this.props.classes.sectionTitleText,
             }}
           />
         </ListItem>
@@ -178,6 +191,11 @@ class NavigationDrawer extends Component<CombinedNavigationProps> {
   }
 
   public render(): React.ReactElement {
+    const { plugins } = this.props;
+    const imgSrc = this.props.darkMode
+      ? plugins[0].logoDarkMode
+      : plugins[0].logoLightMode;
+    console.log(imgSrc);
     return (
       <Drawer
         className={this.props.classes.drawer}
@@ -199,6 +217,13 @@ class NavigationDrawer extends Component<CombinedNavigationProps> {
         </StyledHeader>
         {/* </div> */}
         <Divider />
+        {imgSrc && (
+          <img
+            className={this.props.classes.menuLogo}
+            alt={plugins[0].logoAltText}
+            src={imgSrc}
+          />
+        )}
         {this.renderRoutes()}
       </Drawer>
     );


### PR DESCRIPTION
## Description
This addresses a couple of small changes to the navigation drawer requested from a recent demo of SciGateway. The requests are described in the issue and aim to improve readability and reduce clutter.

A summary of changes is as follows:
- reduced spacing between menu headings and sub headings
- DataGateway logo now appears only once on the nav drawer: at the top
- centered all elements (arguably looks better but let me know your thoughts)
- changed colour of section headings from secondary theme color (grey) to primary theme color (black) 

For reference, here are some comparison images.

Current navigation drawer (light):
![current](https://user-images.githubusercontent.com/71134574/120692694-073a3a00-c4a0-11eb-8287-dd26e9624663.PNG)

Current navigation drawer (dark):
![current-dark](https://user-images.githubusercontent.com/71134574/120692744-16b98300-c4a0-11eb-8b21-914558bd1e40.PNG)

New navigation drawer (light):
![new](https://user-images.githubusercontent.com/71134574/120694252-e2df5d00-c4a1-11eb-85e7-3f14c43c48a4.PNG)

New navigation drawer (dark):
![new-dark](https://user-images.githubusercontent.com/71134574/120694262-e541b700-c4a1-11eb-98c5-da1425346785.PNG)

## Testing instructions
At least one DataGateway plugin needs to be loaded so that the navigation drawer is available. Compare the differences between this new one and the one on preprod.

- [x] Review code
- [x] Check Actions build
- [x] Review changes to test coverage
- [x] Check nav drawer matches the one in the above screenshot for both light and dark mode
- [x] Test links work
- [x] Test headings and sub headings appear as normal

## Agile board tracking
Closes #737