### PR TITLE
Consistent theme across all pages #760

### DIFF
--- a/src/state/middleware/scigateway.middleware.test.tsx
+++ b/src/state/middleware/scigateway.middleware.test.tsx
@@ -227,6 +227,27 @@ describe('scigateway middleware', () => {
     );
   });
 
+  it('should extract dark mode value from user preferences', () => {
+    Storage.prototype.getItem = jest.fn().mockReturnValueOnce(undefined);
+    window.matchMedia = jest.fn().mockReturnValueOnce({ matches: true });
+    const theme = buildTheme(true);
+    const sendThemeOptionsAction = {
+      type: SendThemeOptionsType,
+      payload: {
+        theme,
+        broadcast: true,
+      },
+    };
+
+    listenToPlugins(store.dispatch, getState);
+
+    handler(new CustomEvent('test', { detail: registerRouteAction }));
+    expect(window.matchMedia).toHaveBeenCalled();
+    expect(JSON.stringify(store.getActions()[1])).toEqual(
+      JSON.stringify(sendThemeOptionsAction)
+    );
+  });
+
   it('should listen for events and fire registerroute action', () => {
     listenToPlugins(store.dispatch, getState);
 

--- a/src/state/middleware/scigateway.middleware.tsx
+++ b/src/state/middleware/scigateway.middleware.tsx
@@ -67,16 +67,6 @@ export const listenToPlugins = (
   dispatch: Dispatch,
   getState: () => StateType
 ): void => {
-  let darkModePreference;
-  const darkModeLocalStorage = localStorage.getItem('darkMode');
-  if (darkModeLocalStorage) {
-    darkModePreference = darkModeLocalStorage === 'true' ? true : false;
-  } else {
-    const mq = window.matchMedia('(prefers-color-scheme: dark)');
-    darkModePreference = mq.matches;
-  }
-  const theme = buildTheme(darkModePreference);
-
   document.addEventListener(microFrontendMessageId, (event) => {
     const pluginMessage = event as microFrontendMessageType;
 
@@ -135,6 +125,15 @@ export const listenToPlugins = (
             );
           }
 
+          let darkModePreference: boolean;
+          const darkModeLocalStorage = localStorage.getItem('darkMode');
+          if (darkModeLocalStorage) {
+            darkModePreference = darkModeLocalStorage === 'true' ? true : false;
+          } else {
+            const mq = window.matchMedia('(prefers-color-scheme: dark)');
+            darkModePreference = mq.matches;
+          }
+          const theme = buildTheme(darkModePreference);
           // Send theme options once registered.
           dispatch(sendThemeOptions(theme));
 


### PR DESCRIPTION
## Description
This fix ensures a consistent light or dark mode across all pages. A bug was causing SciGateway to remain in dark mode while the plugins were rendering in light mode. This can be seen when setting SciGateway to dark mode, navigating to one plugin route, which will be correctly themed, but navigating to other routes will cause a mix of light and dark mode.

The cause of this was established to be SciGateway constructing a theme for plugins with an erroneous dark mode value, despite the dark mode boolean in localStorage still being correct. Why this has suddenly started happening, I still don't know and I couldn't find any point in the code that caused this value to change. However, I identified a fix by simply moving the code that fetches the current dark mode value from localStorage directly before the dispatch of the theme to the plugins. This ensures the plugins always have the most up to date dark mode value whenever a change in route occurs.

## Testing instructions
Set up SciGateway with at least two plugins to properly test the theme is consistent between a range of routes. Navigate between a variety of routes and pages while changing the dark mode value and ensure the theme remains consistent throughout.

- [x] Review code
- [x] Check Actions build
- [x] Review changes to test coverage

## Agile board tracking
Closes #760