### PR TITLE
Logo dynamically changes based on currently loaded plugin #739

### DIFF
--- a/src/mainAppBar/__snapshots__/mainAppBar.component.test.tsx.snap
+++ b/src/mainAppBar/__snapshots__/mainAppBar.component.test.tsx.snap
@@ -1,541 +1,129 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Main app bar component app bar indented when drawer is open 1`] = `
-<div
-  className="MainAppBar-root-1"
->
-  <WithStyles(ForwardRef(AppBar))
-    className="MainAppBar-appBar-2 MainAppBar-appBarShift-3"
-    position="static"
-  >
-    <WithStyles(ForwardRef(Toolbar))>
-      <WithStyles(ForwardRef(IconButton))
-        aria-label="Open navigation menu"
-        className="MainAppBar-menuButton-7 MainAppBar-hide-9 tour-nav-menu"
-        color="inherit"
-        onClick={[Function]}
-      >
-        <Memo(ForwardRef(MenuIcon)) />
-      </WithStyles(ForwardRef(IconButton))>
-      <WithStyles(ForwardRef(Button))
-        aria-label="Homepage"
-        className="MainAppBar-titleButton-5 tour-title"
-        onClick={[Function]}
-      >
-        <img
-          alt="title"
-          src="scigateway-white-text-blue-mark-logo.svg"
-        />
-      </WithStyles(ForwardRef(Button))>
-      <WithStyles(ForwardRef(Button))
-        aria-label="Contactpage"
-        className="MainAppBar-button-6 tour-contact"
-        onClick={[Function]}
-        style={
-          Object {
-            "paddingTop": 3,
-          }
-        }
-      >
-        <WithStyles(ForwardRef(Typography))
-          color="inherit"
-          noWrap={true}
-          style={
-            Object {
-              "marginTop": 3,
-            }
-          }
-        >
-          contact
-        </WithStyles(ForwardRef(Typography))>
-      </WithStyles(ForwardRef(Button))>
-      <WithStyles(ForwardRef(Button))
-        aria-label="Helppage"
-        className="MainAppBar-button-6 tour-help"
-        onClick={[Function]}
-        style={
-          Object {
-            "paddingTop": 3,
-          }
-        }
-      >
-        <WithStyles(ForwardRef(Typography))
-          color="inherit"
-          noWrap={true}
-          style={
-            Object {
-              "marginTop": 3,
-            }
-          }
-        >
-          help
-        </WithStyles(ForwardRef(Typography))>
-      </WithStyles(ForwardRef(Button))>
-      <WithStyles(ForwardRef(Button))
-        aria-label="Adminpage"
-        className="MainAppBar-button-6 tour-admin"
-        onClick={[Function]}
-        style={
-          Object {
-            "paddingTop": 3,
-          }
-        }
-      >
-        <WithStyles(ForwardRef(Typography))
-          color="inherit"
-          noWrap={true}
-          style={
-            Object {
-              "marginTop": 3,
-            }
-          }
-        >
-          admin
-        </WithStyles(ForwardRef(Typography))>
-      </WithStyles(ForwardRef(Button))>
-      <div
-        className="MainAppBar-grow-4"
-      />
-      <WithStyles(ForwardRef(IconButton))
-        aria-label="Help"
-        className="MainAppBar-button-6"
-        onClick={[Function]}
-      >
-        <Memo(ForwardRef(HelpOutlineIcon)) />
-      </WithStyles(ForwardRef(IconButton))>
-      <WithStyles(ForwardRef(IconButton))
-        aria-label="Open browser settings"
-        className="MainAppBar-button-6 tour-settings"
-        onClick={[Function]}
-      >
-        <Memo(ForwardRef(SettingsIcon)) />
-      </WithStyles(ForwardRef(IconButton))>
-      <WithStyles(ForwardRef(Menu))
-        anchorEl={null}
-        id="settings"
-        onClose={[Function]}
-        open={false}
-      >
-        <WithStyles(ForwardRef(MenuItem))
-          id="item-manage-cookies"
-          onClick={[Function]}
-        >
-          <WithStyles(ForwardRef(ListItemIcon))>
-            <Memo(ForwardRef(TuneIcon)) />
-          </WithStyles(ForwardRef(ListItemIcon))>
-          <WithStyles(ForwardRef(ListItemText))
-            primary="manage-cookies-button"
-          />
-        </WithStyles(ForwardRef(MenuItem))>
-        <WithStyles(ForwardRef(MenuItem))
-          id="item-dark-mode"
-          onClick={[Function]}
-        >
-          <WithStyles(ForwardRef(ListItemIcon))>
-            <Memo(ForwardRef(Brightness4Icon)) />
-          </WithStyles(ForwardRef(ListItemIcon))>
-          <WithStyles(ForwardRef(ListItemText))
-            primary="toggle-dark-mode"
-          />
-        </WithStyles(ForwardRef(MenuItem))>
-      </WithStyles(ForwardRef(Menu))>
-      <Connect(WithStyles(NotificationBadge)) />
-      <Connect(WithStyles(UserProfileComponent)) />
-    </WithStyles(ForwardRef(Toolbar))>
-  </WithStyles(ForwardRef(AppBar))>
-</div>
+Object {
+  "classes": Object {
+    "appBar": "MainAppBar-appBar-50",
+    "appBarShift": "MainAppBar-appBarShift-51",
+    "button": "MainAppBar-button-54",
+    "grow": "MainAppBar-grow-52",
+    "hide": "MainAppBar-hide-57",
+    "menuButton": "MainAppBar-menuButton-55",
+    "menuButtonPlaceholder": "MainAppBar-menuButtonPlaceholder-56",
+    "root": "MainAppBar-root-49",
+    "titleButton": "MainAppBar-titleButton-53",
+  },
+  "darkMode": false,
+  "drawerOpen": true,
+  "loggedIn": true,
+  "manageCookies": [Function],
+  "navigateToAdminPage": [Function],
+  "navigateToContactPage": [Function],
+  "navigateToHelpPage": [Function],
+  "navigateToHome": [Function],
+  "plugins": Array [],
+  "res": undefined,
+  "showAdminPageButton": true,
+  "showContactButton": true,
+  "showHelpPageButton": true,
+  "toggleDarkMode": [Function],
+  "toggleDrawer": [Function],
+  "toggleHelp": [Function],
+}
 `;
 
 exports[`Main app bar component app bar renders correctly 1`] = `
-<div
-  className="MainAppBar-root-1"
->
-  <WithStyles(ForwardRef(AppBar))
-    className="MainAppBar-appBar-2"
-    position="static"
-  >
-    <WithStyles(ForwardRef(Toolbar))>
-      <WithStyles(ForwardRef(IconButton))
-        aria-label="Open navigation menu"
-        className="MainAppBar-menuButton-7 tour-nav-menu"
-        color="inherit"
-        onClick={[Function]}
-      >
-        <Memo(ForwardRef(MenuIcon)) />
-      </WithStyles(ForwardRef(IconButton))>
-      <WithStyles(ForwardRef(Button))
-        aria-label="Homepage"
-        className="MainAppBar-titleButton-5 tour-title"
-        onClick={[Function]}
-      >
-        <img
-          alt="title"
-          src="scigateway-white-text-blue-mark-logo.svg"
-        />
-      </WithStyles(ForwardRef(Button))>
-      <WithStyles(ForwardRef(Button))
-        aria-label="Contactpage"
-        className="MainAppBar-button-6 tour-contact"
-        onClick={[Function]}
-        style={
-          Object {
-            "paddingTop": 3,
-          }
-        }
-      >
-        <WithStyles(ForwardRef(Typography))
-          color="inherit"
-          noWrap={true}
-          style={
-            Object {
-              "marginTop": 3,
-            }
-          }
-        >
-          contact
-        </WithStyles(ForwardRef(Typography))>
-      </WithStyles(ForwardRef(Button))>
-      <WithStyles(ForwardRef(Button))
-        aria-label="Helppage"
-        className="MainAppBar-button-6 tour-help"
-        onClick={[Function]}
-        style={
-          Object {
-            "paddingTop": 3,
-          }
-        }
-      >
-        <WithStyles(ForwardRef(Typography))
-          color="inherit"
-          noWrap={true}
-          style={
-            Object {
-              "marginTop": 3,
-            }
-          }
-        >
-          help
-        </WithStyles(ForwardRef(Typography))>
-      </WithStyles(ForwardRef(Button))>
-      <WithStyles(ForwardRef(Button))
-        aria-label="Adminpage"
-        className="MainAppBar-button-6 tour-admin"
-        onClick={[Function]}
-        style={
-          Object {
-            "paddingTop": 3,
-          }
-        }
-      >
-        <WithStyles(ForwardRef(Typography))
-          color="inherit"
-          noWrap={true}
-          style={
-            Object {
-              "marginTop": 3,
-            }
-          }
-        >
-          admin
-        </WithStyles(ForwardRef(Typography))>
-      </WithStyles(ForwardRef(Button))>
-      <div
-        className="MainAppBar-grow-4"
-      />
-      <WithStyles(ForwardRef(IconButton))
-        aria-label="Help"
-        className="MainAppBar-button-6"
-        onClick={[Function]}
-      >
-        <Memo(ForwardRef(HelpOutlineIcon)) />
-      </WithStyles(ForwardRef(IconButton))>
-      <WithStyles(ForwardRef(IconButton))
-        aria-label="Open browser settings"
-        className="MainAppBar-button-6 tour-settings"
-        onClick={[Function]}
-      >
-        <Memo(ForwardRef(SettingsIcon)) />
-      </WithStyles(ForwardRef(IconButton))>
-      <WithStyles(ForwardRef(Menu))
-        anchorEl={null}
-        id="settings"
-        onClose={[Function]}
-        open={false}
-      >
-        <WithStyles(ForwardRef(MenuItem))
-          id="item-manage-cookies"
-          onClick={[Function]}
-        >
-          <WithStyles(ForwardRef(ListItemIcon))>
-            <Memo(ForwardRef(TuneIcon)) />
-          </WithStyles(ForwardRef(ListItemIcon))>
-          <WithStyles(ForwardRef(ListItemText))
-            primary="manage-cookies-button"
-          />
-        </WithStyles(ForwardRef(MenuItem))>
-        <WithStyles(ForwardRef(MenuItem))
-          id="item-dark-mode"
-          onClick={[Function]}
-        >
-          <WithStyles(ForwardRef(ListItemIcon))>
-            <Memo(ForwardRef(Brightness4Icon)) />
-          </WithStyles(ForwardRef(ListItemIcon))>
-          <WithStyles(ForwardRef(ListItemText))
-            primary="toggle-dark-mode"
-          />
-        </WithStyles(ForwardRef(MenuItem))>
-      </WithStyles(ForwardRef(Menu))>
-      <Connect(WithStyles(NotificationBadge)) />
-      <Connect(WithStyles(UserProfileComponent)) />
-    </WithStyles(ForwardRef(Toolbar))>
-  </WithStyles(ForwardRef(AppBar))>
-</div>
+Object {
+  "classes": Object {
+    "appBar": "MainAppBar-appBar-2",
+    "appBarShift": "MainAppBar-appBarShift-3",
+    "button": "MainAppBar-button-6",
+    "grow": "MainAppBar-grow-4",
+    "hide": "MainAppBar-hide-9",
+    "menuButton": "MainAppBar-menuButton-7",
+    "menuButtonPlaceholder": "MainAppBar-menuButtonPlaceholder-8",
+    "root": "MainAppBar-root-1",
+    "titleButton": "MainAppBar-titleButton-5",
+  },
+  "darkMode": false,
+  "drawerOpen": false,
+  "loggedIn": true,
+  "manageCookies": [Function],
+  "navigateToAdminPage": [Function],
+  "navigateToContactPage": [Function],
+  "navigateToHelpPage": [Function],
+  "navigateToHome": [Function],
+  "plugins": Array [],
+  "res": undefined,
+  "showAdminPageButton": true,
+  "showContactButton": true,
+  "showHelpPageButton": true,
+  "toggleDarkMode": [Function],
+  "toggleDrawer": [Function],
+  "toggleHelp": [Function],
+}
 `;
 
 exports[`Main app bar component does not render Help button when feature is false 1`] = `
-<div
-  className="MainAppBar-root-1"
->
-  <WithStyles(ForwardRef(AppBar))
-    className="MainAppBar-appBar-2"
-    position="static"
-  >
-    <WithStyles(ForwardRef(Toolbar))>
-      <WithStyles(ForwardRef(IconButton))
-        aria-label="Open navigation menu"
-        className="MainAppBar-menuButton-7 tour-nav-menu"
-        color="inherit"
-        onClick={[Function]}
-      >
-        <Memo(ForwardRef(MenuIcon)) />
-      </WithStyles(ForwardRef(IconButton))>
-      <WithStyles(ForwardRef(Button))
-        aria-label="Homepage"
-        className="MainAppBar-titleButton-5 tour-title"
-        onClick={[Function]}
-      >
-        <img
-          alt="title"
-          src="scigateway-white-text-blue-mark-logo.svg"
-        />
-      </WithStyles(ForwardRef(Button))>
-      <WithStyles(ForwardRef(Button))
-        aria-label="Contactpage"
-        className="MainAppBar-button-6 tour-contact"
-        onClick={[Function]}
-        style={
-          Object {
-            "paddingTop": 3,
-          }
-        }
-      >
-        <WithStyles(ForwardRef(Typography))
-          color="inherit"
-          noWrap={true}
-          style={
-            Object {
-              "marginTop": 3,
-            }
-          }
-        >
-          contact
-        </WithStyles(ForwardRef(Typography))>
-      </WithStyles(ForwardRef(Button))>
-      <WithStyles(ForwardRef(Button))
-        aria-label="Adminpage"
-        className="MainAppBar-button-6 tour-admin"
-        onClick={[Function]}
-        style={
-          Object {
-            "paddingTop": 3,
-          }
-        }
-      >
-        <WithStyles(ForwardRef(Typography))
-          color="inherit"
-          noWrap={true}
-          style={
-            Object {
-              "marginTop": 3,
-            }
-          }
-        >
-          admin
-        </WithStyles(ForwardRef(Typography))>
-      </WithStyles(ForwardRef(Button))>
-      <div
-        className="MainAppBar-grow-4"
-      />
-      <WithStyles(ForwardRef(IconButton))
-        aria-label="Help"
-        className="MainAppBar-button-6"
-        onClick={[Function]}
-      >
-        <Memo(ForwardRef(HelpOutlineIcon)) />
-      </WithStyles(ForwardRef(IconButton))>
-      <WithStyles(ForwardRef(IconButton))
-        aria-label="Open browser settings"
-        className="MainAppBar-button-6 tour-settings"
-        onClick={[Function]}
-      >
-        <Memo(ForwardRef(SettingsIcon)) />
-      </WithStyles(ForwardRef(IconButton))>
-      <WithStyles(ForwardRef(Menu))
-        anchorEl={null}
-        id="settings"
-        onClose={[Function]}
-        open={false}
-      >
-        <WithStyles(ForwardRef(MenuItem))
-          id="item-manage-cookies"
-          onClick={[Function]}
-        >
-          <WithStyles(ForwardRef(ListItemIcon))>
-            <Memo(ForwardRef(TuneIcon)) />
-          </WithStyles(ForwardRef(ListItemIcon))>
-          <WithStyles(ForwardRef(ListItemText))
-            primary="manage-cookies-button"
-          />
-        </WithStyles(ForwardRef(MenuItem))>
-        <WithStyles(ForwardRef(MenuItem))
-          id="item-dark-mode"
-          onClick={[Function]}
-        >
-          <WithStyles(ForwardRef(ListItemIcon))>
-            <Memo(ForwardRef(Brightness4Icon)) />
-          </WithStyles(ForwardRef(ListItemIcon))>
-          <WithStyles(ForwardRef(ListItemText))
-            primary="toggle-dark-mode"
-          />
-        </WithStyles(ForwardRef(MenuItem))>
-      </WithStyles(ForwardRef(Menu))>
-      <Connect(WithStyles(NotificationBadge)) />
-      <Connect(WithStyles(UserProfileComponent)) />
-    </WithStyles(ForwardRef(Toolbar))>
-  </WithStyles(ForwardRef(AppBar))>
-</div>
+Object {
+  "classes": Object {
+    "appBar": "MainAppBar-appBar-34",
+    "appBarShift": "MainAppBar-appBarShift-35",
+    "button": "MainAppBar-button-38",
+    "grow": "MainAppBar-grow-36",
+    "hide": "MainAppBar-hide-41",
+    "menuButton": "MainAppBar-menuButton-39",
+    "menuButtonPlaceholder": "MainAppBar-menuButtonPlaceholder-40",
+    "root": "MainAppBar-root-33",
+    "titleButton": "MainAppBar-titleButton-37",
+  },
+  "darkMode": false,
+  "drawerOpen": false,
+  "loggedIn": true,
+  "manageCookies": [Function],
+  "navigateToAdminPage": [Function],
+  "navigateToContactPage": [Function],
+  "navigateToHelpPage": [Function],
+  "navigateToHome": [Function],
+  "plugins": Array [],
+  "res": undefined,
+  "showAdminPageButton": true,
+  "showContactButton": true,
+  "showHelpPageButton": false,
+  "toggleDarkMode": [Function],
+  "toggleDrawer": [Function],
+  "toggleHelp": [Function],
+}
 `;
 
 exports[`Main app bar component does not render contact button when feature is false 1`] = `
-<div
-  className="MainAppBar-root-1"
->
-  <WithStyles(ForwardRef(AppBar))
-    className="MainAppBar-appBar-2"
-    position="static"
-  >
-    <WithStyles(ForwardRef(Toolbar))>
-      <WithStyles(ForwardRef(IconButton))
-        aria-label="Open navigation menu"
-        className="MainAppBar-menuButton-7 tour-nav-menu"
-        color="inherit"
-        onClick={[Function]}
-      >
-        <Memo(ForwardRef(MenuIcon)) />
-      </WithStyles(ForwardRef(IconButton))>
-      <WithStyles(ForwardRef(Button))
-        aria-label="Homepage"
-        className="MainAppBar-titleButton-5 tour-title"
-        onClick={[Function]}
-      >
-        <img
-          alt="title"
-          src="scigateway-white-text-blue-mark-logo.svg"
-        />
-      </WithStyles(ForwardRef(Button))>
-      <WithStyles(ForwardRef(Button))
-        aria-label="Helppage"
-        className="MainAppBar-button-6 tour-help"
-        onClick={[Function]}
-        style={
-          Object {
-            "paddingTop": 3,
-          }
-        }
-      >
-        <WithStyles(ForwardRef(Typography))
-          color="inherit"
-          noWrap={true}
-          style={
-            Object {
-              "marginTop": 3,
-            }
-          }
-        >
-          help
-        </WithStyles(ForwardRef(Typography))>
-      </WithStyles(ForwardRef(Button))>
-      <WithStyles(ForwardRef(Button))
-        aria-label="Adminpage"
-        className="MainAppBar-button-6 tour-admin"
-        onClick={[Function]}
-        style={
-          Object {
-            "paddingTop": 3,
-          }
-        }
-      >
-        <WithStyles(ForwardRef(Typography))
-          color="inherit"
-          noWrap={true}
-          style={
-            Object {
-              "marginTop": 3,
-            }
-          }
-        >
-          admin
-        </WithStyles(ForwardRef(Typography))>
-      </WithStyles(ForwardRef(Button))>
-      <div
-        className="MainAppBar-grow-4"
-      />
-      <WithStyles(ForwardRef(IconButton))
-        aria-label="Help"
-        className="MainAppBar-button-6"
-        onClick={[Function]}
-      >
-        <Memo(ForwardRef(HelpOutlineIcon)) />
-      </WithStyles(ForwardRef(IconButton))>
-      <WithStyles(ForwardRef(IconButton))
-        aria-label="Open browser settings"
-        className="MainAppBar-button-6 tour-settings"
-        onClick={[Function]}
-      >
-        <Memo(ForwardRef(SettingsIcon)) />
-      </WithStyles(ForwardRef(IconButton))>
-      <WithStyles(ForwardRef(Menu))
-        anchorEl={null}
-        id="settings"
-        onClose={[Function]}
-        open={false}
-      >
-        <WithStyles(ForwardRef(MenuItem))
-          id="item-manage-cookies"
-          onClick={[Function]}
-        >
-          <WithStyles(ForwardRef(ListItemIcon))>
-            <Memo(ForwardRef(TuneIcon)) />
-          </WithStyles(ForwardRef(ListItemIcon))>
-          <WithStyles(ForwardRef(ListItemText))
-            primary="manage-cookies-button"
-          />
-        </WithStyles(ForwardRef(MenuItem))>
-        <WithStyles(ForwardRef(MenuItem))
-          id="item-dark-mode"
-          onClick={[Function]}
-        >
-          <WithStyles(ForwardRef(ListItemIcon))>
-            <Memo(ForwardRef(Brightness4Icon)) />
-          </WithStyles(ForwardRef(ListItemIcon))>
-          <WithStyles(ForwardRef(ListItemText))
-            primary="toggle-dark-mode"
-          />
-        </WithStyles(ForwardRef(MenuItem))>
-      </WithStyles(ForwardRef(Menu))>
-      <Connect(WithStyles(NotificationBadge)) />
-      <Connect(WithStyles(UserProfileComponent)) />
-    </WithStyles(ForwardRef(Toolbar))>
-  </WithStyles(ForwardRef(AppBar))>
-</div>
+Object {
+  "classes": Object {
+    "appBar": "MainAppBar-appBar-18",
+    "appBarShift": "MainAppBar-appBarShift-19",
+    "button": "MainAppBar-button-22",
+    "grow": "MainAppBar-grow-20",
+    "hide": "MainAppBar-hide-25",
+    "menuButton": "MainAppBar-menuButton-23",
+    "menuButtonPlaceholder": "MainAppBar-menuButtonPlaceholder-24",
+    "root": "MainAppBar-root-17",
+    "titleButton": "MainAppBar-titleButton-21",
+  },
+  "darkMode": false,
+  "drawerOpen": false,
+  "loggedIn": true,
+  "manageCookies": [Function],
+  "navigateToAdminPage": [Function],
+  "navigateToContactPage": [Function],
+  "navigateToHelpPage": [Function],
+  "navigateToHome": [Function],
+  "plugins": Array [],
+  "res": undefined,
+  "showAdminPageButton": true,
+  "showContactButton": false,
+  "showHelpPageButton": true,
+  "toggleDarkMode": [Function],
+  "toggleDrawer": [Function],
+  "toggleHelp": [Function],
+}
 `;

--- a/src/mainAppBar/mainAppBar.component.test.tsx
+++ b/src/mainAppBar/mainAppBar.component.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import MainAppBarComponent from './mainAppBar.component';
-import { createShallow, createMount } from '@material-ui/core/test-utils';
+import { createMount } from '@material-ui/core/test-utils';
 import { StateType } from '../state/state.types';
+import { PluginConfig } from '../state/scigateway.types';
 import configureStore from 'redux-mock-store';
 import { push } from 'connected-react-router';
 import { initialState } from '../state/reducers/scigateway.reducer';
@@ -11,16 +12,32 @@ import TestAuthProvider from '../authentication/testAuthProvider';
 import { buildTheme } from '../theming';
 import { MuiThemeProvider } from '@material-ui/core/styles';
 import { loadDarkModePreference } from '../state/actions/scigateway.actions';
+import { createMemoryHistory, History } from 'history';
+import { ReactWrapper } from 'enzyme';
+import { Router } from 'react-router';
+import ScigatewayLogo from '../images/scigateway-white-text-blue-mark-logo.svg';
 
 describe('Main app bar component', () => {
-  let shallow;
   let mount;
   let mockStore;
   let state: StateType;
+  let history: History;
+
+  const createWrapper = (testStore): ReactWrapper => {
+    return mount(
+      <MuiThemeProvider theme={theme}>
+        <Provider store={testStore}>
+          <Router history={history}>
+            <MainAppBarComponent />
+          </Router>
+        </Provider>
+      </MuiThemeProvider>
+    );
+  };
 
   beforeEach(() => {
-    shallow = createShallow({ untilSelector: 'div' });
     mount = createMount();
+    history = createMemoryHistory();
 
     mockStore = configureStore();
     state = JSON.parse(JSON.stringify({ scigateway: initialState }));
@@ -34,38 +51,35 @@ describe('Main app bar component', () => {
   const theme = buildTheme(false);
 
   it('app bar renders correctly', () => {
-    const wrapper = shallow(<MainAppBarComponent store={mockStore(state)} />);
-    expect(wrapper).toMatchSnapshot();
+    const testStore = mockStore(state);
+    const wrapper = createWrapper(testStore);
+    expect(wrapper.find('MainAppBar').props()).toMatchSnapshot();
   });
 
   it('does not render contact button when feature is false', () => {
     state.scigateway.features.showContactButton = false;
-    const wrapper = shallow(<MainAppBarComponent store={mockStore(state)} />);
-    expect(wrapper).toMatchSnapshot();
+    const testStore = mockStore(state);
+    const wrapper = createWrapper(testStore);
+    expect(wrapper.find('MainAppBar').props()).toMatchSnapshot();
   });
 
   it('does not render Help button when feature is false', () => {
     state.scigateway.features.showHelpPageButton = false;
-    const wrapper = shallow(<MainAppBarComponent store={mockStore(state)} />);
-    expect(wrapper).toMatchSnapshot();
+    const testStore = mockStore(state);
+    const wrapper = createWrapper(testStore);
+    expect(wrapper.find('MainAppBar').props()).toMatchSnapshot();
   });
 
   it('app bar indented when drawer is open', () => {
     state.scigateway.drawerOpen = true;
-
-    const wrapper = shallow(<MainAppBarComponent store={mockStore(state)} />);
-    expect(wrapper).toMatchSnapshot();
+    const testStore = mockStore(state);
+    const wrapper = createWrapper(testStore);
+    expect(wrapper.find('MainAppBar').props()).toMatchSnapshot();
   });
 
   it('sends toggleDrawer action when menu clicked', () => {
     const testStore = mockStore(state);
-    const wrapper = mount(
-      <MuiThemeProvider theme={theme}>
-        <Provider store={testStore}>
-          <MainAppBarComponent />
-        </Provider>
-      </MuiThemeProvider>
-    );
+    const wrapper = createWrapper(testStore);
 
     wrapper.find('button').first().simulate('click');
 
@@ -75,13 +89,7 @@ describe('Main app bar component', () => {
 
   it('redirects to base url when title clicked', () => {
     const testStore = mockStore(state);
-    const wrapper = mount(
-      <MuiThemeProvider theme={theme}>
-        <Provider store={testStore}>
-          <MainAppBarComponent />
-        </Provider>
-      </MuiThemeProvider>
-    );
+    const wrapper = createWrapper(testStore);
 
     wrapper.find('button[aria-label="Homepage"]').first().simulate('click');
 
@@ -91,13 +99,7 @@ describe('Main app bar component', () => {
 
   it('redirects to Contact page when Contact button clicked', () => {
     const testStore = mockStore(state);
-    const wrapper = mount(
-      <MuiThemeProvider theme={theme}>
-        <Provider store={testStore}>
-          <MainAppBarComponent />
-        </Provider>
-      </MuiThemeProvider>
-    );
+    const wrapper = createWrapper(testStore);
 
     wrapper.find('button[aria-label="Contactpage"]').first().simulate('click');
 
@@ -107,13 +109,7 @@ describe('Main app bar component', () => {
 
   it('redirects to Help page when Help button clicked', () => {
     const testStore = mockStore(state);
-    const wrapper = mount(
-      <MuiThemeProvider theme={theme}>
-        <Provider store={testStore}>
-          <MainAppBarComponent />
-        </Provider>
-      </MuiThemeProvider>
-    );
+    const wrapper = createWrapper(testStore);
 
     wrapper.find('button[aria-label="Helppage"]').first().simulate('click');
 
@@ -123,13 +119,7 @@ describe('Main app bar component', () => {
 
   it('redirects to Admin page when Admin button clicked', () => {
     const testStore = mockStore(state);
-    const wrapper = mount(
-      <MuiThemeProvider theme={theme}>
-        <Provider store={testStore}>
-          <MainAppBarComponent />
-        </Provider>
-      </MuiThemeProvider>
-    );
+    const wrapper = createWrapper(testStore);
 
     wrapper.find('button[aria-label="Adminpage"]').first().simulate('click');
 
@@ -139,13 +129,7 @@ describe('Main app bar component', () => {
 
   it('sends toggleHelp action when help button is clicked', () => {
     const testStore = mockStore(state);
-    const wrapper = mount(
-      <MuiThemeProvider theme={theme}>
-        <Provider store={testStore}>
-          <MainAppBarComponent />
-        </Provider>
-      </MuiThemeProvider>
-    );
+    const wrapper = createWrapper(testStore);
 
     wrapper.find('button[aria-label="Help"]').first().simulate('click');
 
@@ -155,13 +139,7 @@ describe('Main app bar component', () => {
 
   it('opens settings when button clicked', () => {
     const testStore = mockStore(state);
-    const wrapper = mount(
-      <MuiThemeProvider theme={theme}>
-        <Provider store={testStore}>
-          <MainAppBarComponent />
-        </Provider>
-      </MuiThemeProvider>
-    );
+    const wrapper = createWrapper(testStore);
 
     expect(wrapper.find('#settings').first().prop('open')).toBeFalsy();
 
@@ -174,13 +152,7 @@ describe('Main app bar component', () => {
 
   it('opens cookie policy/management page if manage cookies clicked', () => {
     const testStore = mockStore(state);
-    const wrapper = mount(
-      <MuiThemeProvider theme={theme}>
-        <Provider store={testStore}>
-          <MainAppBarComponent />
-        </Provider>
-      </MuiThemeProvider>
-    );
+    const wrapper = createWrapper(testStore);
 
     // Click the user menu button and click on the manage cookies menu item.
     wrapper
@@ -194,13 +166,7 @@ describe('Main app bar component', () => {
 
   it('sends load dark mode prefrence action if toggle dark mode is clicked', () => {
     const testStore = mockStore(state);
-    const wrapper = mount(
-      <MuiThemeProvider theme={theme}>
-        <Provider store={testStore}>
-          <MainAppBarComponent />
-        </Provider>
-      </MuiThemeProvider>
-    );
+    const wrapper = createWrapper(testStore);
 
     // Click the user menu button and click on the manage cookies menu item.
     wrapper
@@ -210,5 +176,87 @@ describe('Main app bar component', () => {
 
     expect(testStore.getActions().length).toEqual(1);
     expect(testStore.getActions()[0]).toEqual(loadDarkModePreference(true));
+  });
+
+  it('sets plugin logo', () => {
+    const plugin: PluginConfig = {
+      section: 'section',
+      link: '/link',
+      plugin: 'plugin',
+      displayName: 'pluginName',
+      order: 1,
+      logoDarkMode: 'pluginLogo',
+    };
+    state.scigateway.plugins = [plugin];
+
+    const testStore = mockStore(state);
+    const wrapper = mount(
+      <div id="plugin">
+        <MuiThemeProvider theme={theme}>
+          <Provider store={testStore}>
+            <Router history={history}>
+              <MainAppBarComponent />
+            </Router>
+          </Provider>
+        </MuiThemeProvider>
+      </div>
+    );
+
+    expect(wrapper.find('img').prop('src')).toEqual('pluginLogo');
+  });
+
+  it('sets Scigateway logo if no plugins are loaded or no plugins match found plugin or if plugin does not provide logo', () => {
+    let testStore = mockStore(state);
+    let wrapper = createWrapper(testStore);
+    expect(wrapper.find('img').prop('src')).toEqual(ScigatewayLogo);
+
+    let plugin: PluginConfig = {
+      section: 'section',
+      link: '/link',
+      plugin: 'plugin1',
+      displayName: 'pluginName',
+      order: 1,
+      logoDarkMode: 'pluginLogo',
+    };
+    state.scigateway.plugins = [plugin];
+
+    testStore = mockStore(state);
+    wrapper = mount(
+      <div id="plugin2">
+        <MuiThemeProvider theme={theme}>
+          <Provider store={testStore}>
+            <Router history={history}>
+              <MainAppBarComponent />
+            </Router>
+          </Provider>
+        </MuiThemeProvider>
+      </div>
+    );
+
+    expect(wrapper.find('img').prop('src')).toEqual(ScigatewayLogo);
+
+    plugin = {
+      section: 'section',
+      link: '/link',
+      plugin: 'plugin',
+      displayName: 'pluginName',
+      order: 1,
+    };
+    state.scigateway.plugins = [plugin];
+
+    testStore = mockStore(state);
+    wrapper = mount(
+      <div id="plugin">
+        <MuiThemeProvider theme={theme}>
+          <Provider store={testStore}>
+            <Router history={history}>
+              <MainAppBarComponent />
+            </Router>
+          </Provider>
+        </MuiThemeProvider>
+      </div>
+    );
+
+    expect(wrapper.find('img').prop('src')).toEqual(ScigatewayLogo);
   });
 });

--- a/src/mainAppBar/mainAppBar.component.tsx
+++ b/src/mainAppBar/mainAppBar.component.tsx
@@ -34,6 +34,7 @@ import { UKRITheme } from '../theming';
 import UserProfileComponent from './userProfile.component';
 import NotificationBadgeComponent from '../notifications/notificationBadge.component';
 import { PluginConfig } from '../state/scigateway.types';
+import { useLocation } from 'react-router-dom';
 
 interface MainAppProps {
   drawerOpen: boolean;
@@ -112,6 +113,7 @@ type CombinedMainAppBarProps = MainAppProps &
 
 const MainAppBar = (props: CombinedMainAppBarProps): React.ReactElement => {
   const [getMenuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
+  const [logo, setLogo] = useState<string>(ScigatewayLogo);
   const closeMenu = (): void => setMenuAnchor(null);
   const manageCookies = (): void => {
     closeMenu();
@@ -123,7 +125,23 @@ const MainAppBar = (props: CombinedMainAppBarProps): React.ReactElement => {
     props.toggleDarkMode(toggledPreference);
   };
 
-  const logo = props.plugins ? props.plugins[0]?.logoDarkMode : undefined;
+  const location = useLocation();
+
+  React.useEffect(() => {
+    let set = false;
+    if (props.plugins) {
+      for (let i = 0; i < props.plugins.length; i++) {
+        if (document.getElementById(props.plugins[i].plugin) !== null) {
+          setLogo(props.plugins[i].logoDarkMode ?? ScigatewayLogo);
+          set = true;
+          break;
+        }
+      }
+    }
+    if (!set || !props.plugins) {
+      setLogo(ScigatewayLogo);
+    }
+  }, [props.plugins, location]);
 
   return (
     <div className={props.classes.root}>
@@ -155,10 +173,7 @@ const MainAppBar = (props: CombinedMainAppBarProps): React.ReactElement => {
             onClick={props.navigateToHome}
             aria-label="Homepage"
           >
-            <img
-              src={logo ?? ScigatewayLogo}
-              alt={getString(props.res, 'title')}
-            />
+            <img src={logo} alt={getString(props.res, 'title')} />
           </Button>
           {props.showContactButton ? (
             <Button

--- a/src/mainAppBar/mainAppBar.component.tsx
+++ b/src/mainAppBar/mainAppBar.component.tsx
@@ -129,7 +129,7 @@ const MainAppBar = (props: CombinedMainAppBarProps): React.ReactElement => {
 
   React.useEffect(() => {
     let set = false;
-    if (props.plugins) {
+    if (props.plugins && props.plugins.length >= 1) {
       for (let i = 0; i < props.plugins.length; i++) {
         if (document.getElementById(props.plugins[i].plugin) !== null) {
           setLogo(props.plugins[i].logoDarkMode ?? ScigatewayLogo);

--- a/src/mainAppBar/mainAppBar.component.tsx
+++ b/src/mainAppBar/mainAppBar.component.tsx
@@ -33,6 +33,7 @@ import { getAppStrings, getString } from '../state/strings';
 import { UKRITheme } from '../theming';
 import UserProfileComponent from './userProfile.component';
 import NotificationBadgeComponent from '../notifications/notificationBadge.component';
+import { PluginConfig } from '../state/scigateway.types';
 
 interface MainAppProps {
   drawerOpen: boolean;
@@ -42,6 +43,7 @@ interface MainAppProps {
   showAdminPageButton: boolean;
   loggedIn: boolean;
   darkMode: boolean;
+  plugins?: PluginConfig[];
 }
 
 interface MainAppDispatchProps {
@@ -120,6 +122,9 @@ const MainAppBar = (props: CombinedMainAppBarProps): React.ReactElement => {
     localStorage.setItem('darkMode', toggledPreference.toString());
     props.toggleDarkMode(toggledPreference);
   };
+
+  const logo = props.plugins ? props.plugins[0]?.logoDarkMode : undefined;
+
   return (
     <div className={props.classes.root}>
       <AppBar
@@ -150,7 +155,10 @@ const MainAppBar = (props: CombinedMainAppBarProps): React.ReactElement => {
             onClick={props.navigateToHome}
             aria-label="Homepage"
           >
-            <img src={ScigatewayLogo} alt={getString(props.res, 'title')} />
+            <img
+              src={logo ?? ScigatewayLogo}
+              alt={getString(props.res, 'title')}
+            />
           </Button>
           {props.showContactButton ? (
             <Button
@@ -244,6 +252,7 @@ const mapStateToProps = (state: StateType): MainAppProps => ({
     state.scigateway.authorisation.provider.isAdmin(),
   res: getAppStrings(state, 'main-appbar'),
   darkMode: state.scigateway.darkMode,
+  plugins: state.scigateway.plugins,
 });
 
 const mapDispatchToProps = (dispatch: Dispatch): MainAppDispatchProps => ({


### PR DESCRIPTION
## Description
This change allows for the logo that appears at the top of the page to automatically change based on which plugin the user is currently viewing. For example, if navigating to a DataGateway plugin, the logo should change to the DataGateway logo. This includes any custom homepage as this is loaded via a plugin itself, so will inherit that plugin logo. This solution is flexible so that no matter what future plugins are developed, as long as they provide a logo, it will be loaded.

This solution works by detecting which plugin ID can be found on the DOM. For example, if DataGateway Dataview is loaded, a `<div id="datagateway-dataview">` will exist. _If a plugin ID is found on the page but the plugin itself does not provide a logo or if no plugins ID is found on the page, then the SciGateway logo will be displayed as a last resort_ (better than having no logo at the top, which would then prevent the user from being able to navigate to the homepage).

## Testing instructions
This can be tested by loading at least one DataGateway plugin with SciGateway. The SciGateway homepage should display at the website root, including the SciGateway logo at the top. When navigating to a DataGateway plugin, the logo should switch to the DataGateway logo. Try navigating between multiple routes and the SciGateway homepage to make sure the logo changes. This simulates a use case where the user may navigate between unrelated plugins. However, in production, the SciGateway logo should not be displayed to users at any point to avoid confusion for end users (as mentioned in the issue description).

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
Closes #739