### PR TITLE
Removing `startUrl` functionality and tests #708

### DIFF
--- a/src/routing/__snapshots__/authorisedRoute.component.test.tsx.snap
+++ b/src/routing/__snapshots__/authorisedRoute.component.test.tsx.snap
@@ -78,7 +78,7 @@ exports[`AuthorisedRoute component renders non admin component when non admin us
 </div>
 `;
 
-exports[`AuthorisedRoute component renders redirect when startUrl is configured and logged in 1`] = `
+exports[`AuthorisedRoute component renders redirect when homepageUrl is configured and logged in 1`] = `
 <div>
   <Redirect
     push={true}

--- a/src/routing/authorisedRoute.component.test.tsx
+++ b/src/routing/authorisedRoute.component.test.tsx
@@ -95,13 +95,13 @@ describe('AuthorisedRoute component', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
-  it('renders redirect when startUrl is configured and logged in', () => {
+  it('renders redirect when homepageUrl is configured and logged in', () => {
     state.scigateway.siteLoading = false;
     state.scigateway.authorisation.loading = false;
     state.scigateway.authorisation.provider = new TestAuthProvider(
       'test-token'
     );
-    state.router.location.state = { scigateway: { startUrl: '/test' } };
+    state.router.location.state = { scigateway: { homepageUrl: '/test' } };
 
     const AuthorisedComponent = withAuth(ComponentToProtect);
     const wrapper = shallow(

--- a/src/routing/authorisedRoute.component.tsx
+++ b/src/routing/authorisedRoute.component.tsx
@@ -16,7 +16,7 @@ interface WithAuthStateProps {
   userIsAdmin: boolean;
   provider: AuthProvider;
   location: string;
-  startUrlState?: StateType;
+  homepageUrlState?: StateType;
 }
 
 interface WithAuthDispatchProps {
@@ -37,7 +37,7 @@ const mapStateToProps = (state: StateType): WithAuthStateProps => ({
   userIsAdmin: state.scigateway.authorisation.provider.isAdmin(),
   provider: state.scigateway.authorisation.provider,
   location: state.router.location.pathname,
-  startUrlState: state.router.location.state,
+  homepageUrlState: state.router.location.state,
 });
 
 const mapDispatchToProps = (dispatch: Dispatch): WithAuthDispatchProps => ({
@@ -66,7 +66,7 @@ export default function withAuth<T>(
         userIsAdmin,
         location,
         provider,
-        startUrlState,
+        homepageUrlState,
         requestPluginRerender,
         invalidToken,
         ...componentProps
@@ -89,10 +89,10 @@ export default function withAuth<T>(
           {!loading &&
           loggedIn &&
           (!adminPlugin || (adminPlugin && userIsAdmin)) ? (
-            startUrlState && startUrlState.scigateway.startUrl ? (
+            homepageUrlState && homepageUrlState.scigateway.homepageUrl ? (
               <Redirect
                 push
-                to={{ pathname: startUrlState.scigateway.startUrl }}
+                to={{ pathname: homepageUrlState.scigateway.homepageUrl }}
               />
             ) : (
               <ComponentToProtect {...(componentProps as T)} />

--- a/src/state/actions/scigateway.actions.test.tsx
+++ b/src/state/actions/scigateway.actions.test.tsx
@@ -17,7 +17,6 @@ import {
   invalidToken,
   loadedAuthentication,
   loadDarkModePreference,
-  registerStartUrl,
   registerHomepageUrl,
   loadScheduledMaintenanceState,
   loadMaintenanceState,
@@ -233,31 +232,6 @@ describe('scigateway actions', () => {
     expect(actions).toContainEqual(
       loadFeatureSwitches({ showContactButton: true })
     );
-  });
-
-  it('given a startUrl registration is run', async () => {
-    (mockAxios.get as jest.Mock).mockImplementation(() =>
-      Promise.resolve({
-        data: {
-          startUrl: '/test',
-        },
-      })
-    );
-
-    const asyncAction = configureSite();
-    const actions: Action[] = [];
-    const dispatch = (action: Action): number => actions.push(action);
-    const getState = (): Partial<StateType> => ({
-      scigateway: initialState,
-      router: {
-        location: { ...createLocation('/'), query: {} },
-        action: 'PUSH',
-      },
-    });
-
-    await asyncAction(dispatch, getState);
-
-    expect(actions).toContainEqual(registerStartUrl('/test'));
   });
 
   it('given a homepageUrl registration is run', async () => {

--- a/src/state/actions/scigateway.actions.tsx
+++ b/src/state/actions/scigateway.actions.tsx
@@ -33,7 +33,6 @@ import {
   MaintenanceState,
   MaintenanceStatePayLoad,
   NotificationType,
-  RegisterStartUrlType,
   RegisterHomepageUrlType,
   RequestPluginRerenderType,
   ScheduledMaintenanceState,
@@ -43,7 +42,6 @@ import {
   SignOutType,
   SiteLoadingPayload,
   SiteLoadingType,
-  StartUrlPayload,
   HomepageUrlPayload,
   ToggleDrawerType,
   ToggleHelpType,
@@ -81,15 +79,6 @@ export const loadFeatureSwitches = (
   type: ConfigureFeatureSwitchesType,
   payload: {
     switches: featureSwitches,
-  },
-});
-
-export const registerStartUrl = (
-  startUrl: string
-): ActionType<StartUrlPayload> => ({
-  type: RegisterStartUrlType,
-  payload: {
-    startUrl: startUrl,
   },
 });
 
@@ -262,10 +251,6 @@ export const configureSite = (): ThunkResult<Promise<void>> => {
         }
 
         dispatch(addHelpTourSteps(settings['help-tour-steps']));
-
-        if (settings['startUrl']) {
-          dispatch(registerStartUrl(settings['startUrl']));
-        }
 
         if (settings['homepageUrl']) {
           dispatch(registerHomepageUrl(settings['homepageUrl']));

--- a/src/state/middleware/scigateway.middleware.test.tsx
+++ b/src/state/middleware/scigateway.middleware.test.tsx
@@ -374,42 +374,7 @@ describe('scigateway middleware', () => {
     );
   });
 
-  it('should listen for events and fire registerroute action and redirect to startUrl', () => {
-    const getState: () => StateType = () => ({
-      scigateway: { ...initialState, startUrl: '/plugin1/analysis2' },
-      router: {
-        action: 'POP',
-        location: createLocation('/'),
-      },
-    });
-
-    listenToPlugins(store.dispatch, getState);
-
-    handler(
-      new CustomEvent('test', {
-        detail: registerRouteAction,
-      })
-    );
-
-    expect(document.addEventListener).toHaveBeenCalled();
-    expect(store.getActions().length).toEqual(3);
-    expect(store.getActions()[0]).toEqual(registerRouteAction);
-    expect(store.getActions()[1]).toEqual({
-      type: '@@router/CALL_HISTORY_METHOD',
-      payload: {
-        method: 'push',
-        args: [
-          '/plugin1/analysis2',
-          { scigateway: { startUrl: '/plugin1/analysis2' } },
-        ],
-      },
-    });
-    expect(JSON.stringify(store.getActions()[2])).toEqual(
-      JSON.stringify(sendThemeOptionsAction)
-    );
-  });
-
-  it('should listen for events and fire registerroute action and redirect to startUrl', () => {
+  it('should listen for events and fire registerroute action and redirect to homepageUrl', () => {
     const testHomepageUrl = '/plugin1/analysis2';
     const getState: () => StateType = () => ({
       scigateway: { ...initialState, homepageUrl: testHomepageUrl },

--- a/src/state/middleware/scigateway.middleware.tsx
+++ b/src/state/middleware/scigateway.middleware.tsx
@@ -102,18 +102,8 @@ export const listenToPlugins = (
             );
           }
 
-          // Redirect to optional startUrl if set and current url is the normal homepage '/'
           if (
-            getState().router.location.pathname === '/' &&
-            getState().scigateway.startUrl === pluginMessage.detail.payload.link
-          ) {
-            dispatch(
-              push(pluginMessage.detail.payload.link, {
-                scigateway: { startUrl: pluginMessage.detail.payload.link },
-              })
-            );
-          } else if (
-            // Redirect to homepage if set. This overrides any startUrl currently set
+            // Redirect to homepage if one is set and current path is /
             getState().router.location.pathname === '/' &&
             getState().scigateway.homepageUrl ===
               pluginMessage.detail.payload.link

--- a/src/state/reducers/scigateway.reducer.test.tsx
+++ b/src/state/reducers/scigateway.reducer.test.tsx
@@ -16,7 +16,6 @@ import {
   invalidToken,
   loadedAuthentication,
   loadDarkModePreference,
-  registerStartUrl,
   registerHomepageUrl,
   loadScheduledMaintenanceState,
   loadMaintenanceState,
@@ -333,14 +332,6 @@ describe('scigateway reducer', () => {
 
     expect(updatedState.maintenance.show).toBeTruthy();
     expect(updatedState.maintenance.message).toEqual('test');
-  });
-
-  it('should register the startUrl when provided', () => {
-    expect(state.startUrl).toBeFalsy();
-
-    const updatedState = ScigatewayReducer(state, registerStartUrl('/test'));
-
-    expect(updatedState.startUrl).toEqual('/test');
   });
 
   it('should register the homepageUrl when provided', () => {

--- a/src/state/reducers/scigateway.reducer.tsx
+++ b/src/state/reducers/scigateway.reducer.tsx
@@ -29,8 +29,6 @@ import {
   LoadedAuthType,
   LoadDarkModePreferenceType,
   LoadDarkModePreferencePayload,
-  StartUrlPayload,
-  RegisterStartUrlType,
   HomepageUrlPayload,
   RegisterHomepageUrlType,
   LoadScheduledMaintenanceStateType,
@@ -244,16 +242,6 @@ export function handleLoadMaintenanceState(
   };
 }
 
-export function handleRegisterStartUrl(
-  state: ScigatewayState,
-  payload: StartUrlPayload
-): ScigatewayState {
-  return {
-    ...state,
-    startUrl: payload.startUrl,
-  };
-}
-
 export function handleRegisterHomepageUrl(
   state: ScigatewayState,
   payload: HomepageUrlPayload
@@ -427,7 +415,6 @@ const ScigatewayReducer = createReducer(initialState, {
   [ToggleHelpType]: handleToggleHelp,
   [AddHelpTourStepsType]: handleAddHelpTourSteps,
   [LoadDarkModePreferenceType]: handleLoadDarkModePreference,
-  [RegisterStartUrlType]: handleRegisterStartUrl,
   [RegisterHomepageUrlType]: handleRegisterHomepageUrl,
 });
 

--- a/src/state/scigateway.types.tsx
+++ b/src/state/scigateway.types.tsx
@@ -28,7 +28,6 @@ export const ConfigureAnalyticsType = 'scigateway:configure_analytics';
 export const InitialiseAnalyticsType = 'scigateway:initialise_analytics';
 export const ToggleHelpType = 'scigateway:toggle_help';
 export const AddHelpTourStepsType = 'scigateway:add_help_tour_steps';
-export const RegisterStartUrlType = 'scigateway:register_start_url';
 export const RegisterHomepageUrlType = 'scigateway:register_homepage_url';
 
 export const scigatewayRoutes = {
@@ -68,10 +67,6 @@ export interface FeatureSwitchesPayload {
 export interface FeatureSwitches {
   showContactButton: boolean;
   showHelpPageButton: boolean;
-}
-
-export interface StartUrlPayload {
-  startUrl: string;
 }
 
 export interface HomepageUrlPayload {

--- a/src/state/state.types.tsx
+++ b/src/state/state.types.tsx
@@ -34,7 +34,6 @@ export interface ScigatewayState {
   features: FeatureSwitches;
   analytics?: AnalyticsState;
   darkMode: boolean;
-  startUrl?: string;
   homepageUrl?: string;
   scheduledMaintenance: ScheduledMaintenanceState;
   maintenance: MaintenanceState;


### PR DESCRIPTION
## Description
This removes all functionality relating to the `startUrl` setting found in `settings.json`. None of this is required anymore due to the work done in https://github.com/ral-facilities/scigateway/pull/704 which redirects all traffic to a custom plugin homepage if set. `startUrl` was always used to redirect traffic that went directly to the website root to a set plugin path, e.g. `/browse/investigation`. However, this isn't required anymore because, in production, a custom homepage will always be set that we'll want to redirect to instead (or, failing that, the SciGateway homepage).

This PR removes all references to `startUrl` as well as any tests related to it. Also changing a couple of names in code to `homepageUrl` where relevant functionality overlaps (`homepageUrl` is the new setting that has replaced `startUrl`, this functionality was merged in the above mentioned pull request).

## Testing instructions
Check that redirects work as expected and any `startUrl` setting mentioned in `settings.json` doesn't do anything anymore. Add a `homepageUrl` to check that the homepage functionality continues to work as expected, e.g.:
```
"homepageUrl": "/datagateway"
```

- [x] Review code
- [x] Check Actions build
- [x] Review changes to test coverage

## Agile board tracking
Closes #708