### PR TITLE
Contact us page - avoid repeating title

### DIFF
--- a/public/res/default.json
+++ b/public/res/default.json
@@ -32,7 +32,6 @@
   },
   "contact-page": {
     "title": "Contact",
-    "contact-details-title": "Contact Us",
     "contact-details-description": "For problems with SciGateway, please contact <a href=\"mailto:example@email.com?subject=Feedback From SciGateway\">example@email.com</a>"
   },
   "help-page": {

--- a/src/contactPage/contactPage.component.tsx
+++ b/src/contactPage/contactPage.component.tsx
@@ -61,9 +61,6 @@ const ContactPage = (props: CombinedContactPageProps): React.ReactElement => {
         {getString(props.res, 'title')}
       </Typography>
       <div className={props.classes.container}>
-        <Typography variant="h4">
-          {getString(props.res, 'contact-details-title')}
-        </Typography>
         <Typography
           variant="body1"
           className={props.classes.contactDetails}

--- a/src/mainAppBar/mainAppBar.component.tsx
+++ b/src/mainAppBar/mainAppBar.component.tsx
@@ -139,13 +139,6 @@ const MainAppBar = (props: CombinedMainAppBarProps): React.ReactElement => {
             break;
           }
         }
-
-        //If logo is still not set, use the logo from the first loaded one
-        //This ensures datagateway will have correct logo even when on contact and help pages which do not have contents defined by the plugins
-        if (!set) {
-          setLogo(props.plugins[0].logoDarkMode ?? ScigatewayLogo);
-          set = true;
-        }
       }
       if (!set || !props.plugins) {
         setLogo(ScigatewayLogo);

--- a/src/mainAppBar/mainAppBar.component.tsx
+++ b/src/mainAppBar/mainAppBar.component.tsx
@@ -139,6 +139,13 @@ const MainAppBar = (props: CombinedMainAppBarProps): React.ReactElement => {
             break;
           }
         }
+
+        //If logo is still not set, use the logo from the first loaded one
+        //This ensures datagateway will have correct logo even when on contact and help pages which do not have contents defined by the plugins
+        if (!set) {
+          setLogo(props.plugins[0].logoDarkMode ?? ScigatewayLogo);
+          set = true;
+        }
       }
       if (!set || !props.plugins) {
         setLogo(ScigatewayLogo);


### PR DESCRIPTION
## Description
Removes 'Contact Us' heading on the contact page to avoid repeating the title.

## Testing instructions

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
Closes #775