### PR TITLE
Make dark mode background darker and links lighter (#795)

### DIFF
--- a/src/contactPage/__snapshots__/contactPage.component.test.tsx.snap
+++ b/src/contactPage/__snapshots__/contactPage.component.test.tsx.snap
@@ -27,6 +27,11 @@ exports[`Contact page componet should render correctly 1`] = `
       },
       "direction": "ltr",
       "drawerWidth": 300,
+      "link": Object {
+        "active": "#E94D36",
+        "default": "#1E5DF8",
+        "visited": "#BE2BBB",
+      },
       "mixins": Object {
         "gutters": [Function],
         "toolbar": Object {

--- a/src/contactPage/contactPage.component.tsx
+++ b/src/contactPage/contactPage.component.tsx
@@ -20,13 +20,13 @@ const styles = (theme: Theme): StyleRules =>
       backgroundColor: theme.palette.background.default,
       '& a': {
         '&:link': {
-          color: (theme as UKRITheme).ukri.bright.blue,
+          color: (theme as UKRITheme).link.default,
         },
         '&:visited': {
-          color: (theme as UKRITheme).ukri.bright.purple,
+          color: (theme as UKRITheme).link.visited,
         },
         '&:active': {
-          color: (theme as UKRITheme).ukri.bright.red,
+          color: (theme as UKRITheme).link.active,
         },
       },
     },

--- a/src/cookieConsent/cookiesPage.component.tsx
+++ b/src/cookieConsent/cookiesPage.component.tsx
@@ -26,13 +26,13 @@ const styles = (theme: Theme): StyleRules =>
       backgroundColor: theme.palette.background.default,
       '& a': {
         '&:link': {
-          color: (theme as UKRITheme).ukri.bright.blue,
+          color: (theme as UKRITheme).link.default,
         },
         '&:visited': {
-          color: (theme as UKRITheme).ukri.bright.purple,
+          color: (theme as UKRITheme).link.visited,
         },
         '&:active': {
-          color: (theme as UKRITheme).ukri.bright.red,
+          color: (theme as UKRITheme).link.active,
         },
       },
     },

--- a/src/footer/footer.component.tsx
+++ b/src/footer/footer.component.tsx
@@ -10,6 +10,7 @@ import { getAppStrings, getString } from '../state/strings';
 import { connect } from 'react-redux';
 import { StateType } from '../state/state.types';
 import { AppStrings } from '../state/scigateway.types';
+import { UKRITheme } from '../theming';
 
 const styles = (theme: Theme): StyleRules =>
   createStyles({
@@ -23,13 +24,13 @@ const styles = (theme: Theme): StyleRules =>
       backgroundColor: theme.palette.background.default,
       '& a': {
         '&:link': {
-          color: theme.palette.type === 'dark' ? '#257fff' : '1E5DF8',
+          color: (theme as UKRITheme).link.default,
         },
         '&:visited': {
-          color: '#BE2BBB',
+          color: (theme as UKRITheme).link.visited,
         },
         '&:active': {
-          color: '#E94D36',
+          color: (theme as UKRITheme).link.active,
         },
       },
     },

--- a/src/footer/footer.component.tsx
+++ b/src/footer/footer.component.tsx
@@ -23,7 +23,7 @@ const styles = (theme: Theme): StyleRules =>
       backgroundColor: theme.palette.background.default,
       '& a': {
         '&:link': {
-          color: '#257fff ',
+          color: theme.palette.type === 'dark' ? '#257fff' : '1E5DF8',
         },
         '&:visited': {
           color: '#BE2BBB',

--- a/src/footer/footer.component.tsx
+++ b/src/footer/footer.component.tsx
@@ -23,7 +23,7 @@ const styles = (theme: Theme): StyleRules =>
       backgroundColor: theme.palette.background.default,
       '& a': {
         '&:link': {
-          color: '#1E5DF8',
+          color: '#257fff ',
         },
         '&:visited': {
           color: '#BE2BBB',

--- a/src/helpPage/__snapshots__/helpPage.component.test.tsx.snap
+++ b/src/helpPage/__snapshots__/helpPage.component.test.tsx.snap
@@ -27,6 +27,11 @@ exports[`Help page component should render correctly 1`] = `
       },
       "direction": "ltr",
       "drawerWidth": 300,
+      "link": Object {
+        "active": "#E94D36",
+        "default": "#1E5DF8",
+        "visited": "#BE2BBB",
+      },
       "mixins": Object {
         "gutters": [Function],
         "toolbar": Object {

--- a/src/helpPage/helpPage.component.tsx
+++ b/src/helpPage/helpPage.component.tsx
@@ -20,13 +20,13 @@ const styles = (theme: Theme): StyleRules =>
       backgroundColor: theme.palette.background.default,
       '& a': {
         '&:link': {
-          color: (theme as UKRITheme).ukri.bright.blue,
+          color: (theme as UKRITheme).link.default,
         },
         '&:visited': {
-          color: (theme as UKRITheme).ukri.bright.purple,
+          color: (theme as UKRITheme).link.visited,
         },
         '&:active': {
-          color: (theme as UKRITheme).ukri.bright.red,
+          color: (theme as UKRITheme).link.active,
         },
       },
     },

--- a/src/theming.tsx
+++ b/src/theming.tsx
@@ -25,6 +25,11 @@ export interface UKRIThemeOptions extends ThemeOptions {
     };
   };
   drawerWidth: number;
+  link: {
+    default: string;
+    visited: string;
+    active: string;
+  };
 }
 
 export interface UKRITheme extends Theme {
@@ -47,6 +52,11 @@ export interface UKRITheme extends Theme {
     };
   };
   drawerWidth: number;
+  link: {
+    default: string;
+    visited: string;
+    active: string;
+  };
 }
 
 export const buildTheme = (darkModePreference: boolean): Theme => {
@@ -86,6 +96,11 @@ export const buildTheme = (darkModePreference: boolean): Theme => {
         },
       },
       drawerWidth: 300,
+      link: {
+        default: '#257fff',
+        visited: '#BE2BBB',
+        active: '#E94D36',
+      },
       overrides: {
         MuiLink: {
           root: {
@@ -136,6 +151,11 @@ export const buildTheme = (darkModePreference: boolean): Theme => {
         },
       },
       drawerWidth: 300,
+      link: {
+        default: '#1E5DF8',
+        visited: '#BE2BBB',
+        active: '#E94D36',
+      },
       overrides: {
         MuiBadge: {
           colorPrimary: {

--- a/src/theming.tsx
+++ b/src/theming.tsx
@@ -63,7 +63,8 @@ export const buildTheme = (darkModePreference: boolean): Theme => {
           main: '#80ACFF',
         },
         background: {
-          default: '#212121',
+          default: '#1B1B1B',
+          paper: '#3A3A3A',
         },
       },
       ukri: {
@@ -88,7 +89,7 @@ export const buildTheme = (darkModePreference: boolean): Theme => {
       overrides: {
         MuiLink: {
           root: {
-            color: '#80ACFF',
+            color: '#86b4ff',
           },
         },
         MuiTabs: {


### PR DESCRIPTION
## Description
This fixes contrast issues with some of the URLs on https://github.com/ral-facilities/datagateway/issues/867 and https://github.com/ral-facilities/datagateway/issues/901, as well as fixing https://github.com/ral-facilities/datagateway/issues/898, https://github.com/ral-facilities/datagateway/issues/900, #793, #792. This also makes the dark mode background slightly darker in order to make it easier to make foreground colours compliant with WCAG 2.0.

## Testing instructions

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
Closes ral-facilities/datagateway#898, Closes ral-facilities/datagateway#900, Closes #793, Closes #792