### PR TITLE
Add overrides for year/month selector colours in date pickers (#795)

### DIFF
--- a/src/contactPage/__snapshots__/contactPage.component.test.tsx.snap
+++ b/src/contactPage/__snapshots__/contactPage.component.test.tsx.snap
@@ -60,6 +60,11 @@ exports[`Contact page componet should render correctly 1`] = `
             "color": "#727272",
           },
         },
+        "MuiPickersMonth": Object {
+          "monthDisabled": Object {
+            "color": "#727272",
+          },
+        },
         "MuiPickersToolbar": Object {
           "toolbar": Object {
             "backgroundColor": "#003088",

--- a/src/contactPage/__snapshots__/contactPage.component.test.tsx.snap
+++ b/src/contactPage/__snapshots__/contactPage.component.test.tsx.snap
@@ -52,7 +52,7 @@ exports[`Contact page componet should render correctly 1`] = `
         },
         "MuiPickersCalendarHeader": Object {
           "dayLabel": Object {
-            "color": "727272",
+            "color": "#727272",
           },
         },
         "MuiPickersDay": Object {
@@ -63,6 +63,11 @@ exports[`Contact page componet should render correctly 1`] = `
         "MuiPickersToolbar": Object {
           "toolbar": Object {
             "backgroundColor": "#003088",
+          },
+        },
+        "MuiPickersYear": Object {
+          "yearDisabled": Object {
+            "color": "#727272",
           },
         },
       },

--- a/src/contactPage/__snapshots__/contactPage.component.test.tsx.snap
+++ b/src/contactPage/__snapshots__/contactPage.component.test.tsx.snap
@@ -50,6 +50,27 @@ exports[`Contact page componet should render correctly 1`] = `
             "backgroundColor": "#FF6900",
           },
         },
+        "MuiFormHelperText": Object {
+          "root": Object {
+            "&$error": Object {
+              "color": "#AC1600",
+            },
+          },
+        },
+        "MuiInput": Object {
+          "underline": Object {
+            "&$error:after": Object {
+              "borderBottomColor": "#AC1600",
+            },
+          },
+        },
+        "MuiOutlinedInput": Object {
+          "root": Object {
+            "&$error $notchedOutline": Object {
+              "borderColor": "#AC1600",
+            },
+          },
+        },
         "MuiPickersCalendarHeader": Object {
           "dayLabel": Object {
             "color": "#727272",

--- a/src/helpPage/__snapshots__/helpPage.component.test.tsx.snap
+++ b/src/helpPage/__snapshots__/helpPage.component.test.tsx.snap
@@ -52,7 +52,7 @@ exports[`Help page component should render correctly 1`] = `
         },
         "MuiPickersCalendarHeader": Object {
           "dayLabel": Object {
-            "color": "727272",
+            "color": "#727272",
           },
         },
         "MuiPickersDay": Object {
@@ -63,6 +63,11 @@ exports[`Help page component should render correctly 1`] = `
         "MuiPickersToolbar": Object {
           "toolbar": Object {
             "backgroundColor": "#003088",
+          },
+        },
+        "MuiPickersYear": Object {
+          "yearDisabled": Object {
+            "color": "#727272",
           },
         },
       },

--- a/src/helpPage/__snapshots__/helpPage.component.test.tsx.snap
+++ b/src/helpPage/__snapshots__/helpPage.component.test.tsx.snap
@@ -50,6 +50,27 @@ exports[`Help page component should render correctly 1`] = `
             "backgroundColor": "#FF6900",
           },
         },
+        "MuiFormHelperText": Object {
+          "root": Object {
+            "&$error": Object {
+              "color": "#AC1600",
+            },
+          },
+        },
+        "MuiInput": Object {
+          "underline": Object {
+            "&$error:after": Object {
+              "borderBottomColor": "#AC1600",
+            },
+          },
+        },
+        "MuiOutlinedInput": Object {
+          "root": Object {
+            "&$error $notchedOutline": Object {
+              "borderColor": "#AC1600",
+            },
+          },
+        },
         "MuiPickersCalendarHeader": Object {
           "dayLabel": Object {
             "color": "#727272",

--- a/src/helpPage/__snapshots__/helpPage.component.test.tsx.snap
+++ b/src/helpPage/__snapshots__/helpPage.component.test.tsx.snap
@@ -60,6 +60,11 @@ exports[`Help page component should render correctly 1`] = `
             "color": "#727272",
           },
         },
+        "MuiPickersMonth": Object {
+          "monthDisabled": Object {
+            "color": "#727272",
+          },
+        },
         "MuiPickersToolbar": Object {
           "toolbar": Object {
             "backgroundColor": "#003088",

--- a/src/theming.tsx
+++ b/src/theming.tsx
@@ -173,6 +173,11 @@ export const buildTheme = (darkModePreference: boolean): Theme => {
           },
         },
         MuiPickersYear: {
+          root: {
+            '&:active': {
+              color: '#86b4ff',
+            },
+          },
           yearSelected: {
             color: '#86b4ff',
           },
@@ -181,6 +186,11 @@ export const buildTheme = (darkModePreference: boolean): Theme => {
           },
         },
         MuiPickersMonth: {
+          root: {
+            '&:active': {
+              color: '#86b4ff',
+            },
+          },
           monthSelected: {
             color: '#86b4ff',
           },

--- a/src/theming.tsx
+++ b/src/theming.tsx
@@ -151,6 +151,22 @@ export const buildTheme = (darkModePreference: boolean): Theme => {
             color: '#A4A4A4',
           },
         },
+        MuiPickersYear: {
+          yearSelected: {
+            color: '#86b4ff',
+          },
+          yearDisabled: {
+            color: '#A4A4A4',
+          },
+        },
+        MuiPickersMonth: {
+          monthSelected: {
+            color: '#86b4ff',
+          },
+          monthDisabled: {
+            color: '#A4A4A4',
+          },
+        },
       },
     };
   } else {
@@ -208,11 +224,16 @@ export const buildTheme = (darkModePreference: boolean): Theme => {
         },
         MuiPickersCalendarHeader: {
           dayLabel: {
-            color: '727272',
+            color: '#727272',
           },
         },
         MuiPickersDay: {
           dayDisabled: {
+            color: '#727272',
+          },
+        },
+        MuiPickersYear: {
+          yearDisabled: {
             color: '#727272',
           },
         },

--- a/src/theming.tsx
+++ b/src/theming.tsx
@@ -177,6 +177,9 @@ export const buildTheme = (darkModePreference: boolean): Theme => {
             '&:active': {
               color: '#86b4ff',
             },
+            '&:focus': {
+              color: '#86b4ff',
+            },
           },
           yearSelected: {
             color: '#86b4ff',
@@ -188,6 +191,9 @@ export const buildTheme = (darkModePreference: boolean): Theme => {
         MuiPickersMonth: {
           root: {
             '&:active': {
+              color: '#86b4ff',
+            },
+            '&:focus': {
               color: '#86b4ff',
             },
           },

--- a/src/theming.tsx
+++ b/src/theming.tsx
@@ -136,6 +136,27 @@ export const buildTheme = (darkModePreference: boolean): Theme => {
             backgroundColor: '#FF6900',
           },
         },
+        MuiInput: {
+          underline: {
+            '&$error:after': {
+              borderBottomColor: '#FF7F73',
+            },
+          },
+        },
+        MuiOutlinedInput: {
+          root: {
+            '&$error $notchedOutline': {
+              borderColor: '#FF7F73',
+            },
+          },
+        },
+        MuiFormHelperText: {
+          root: {
+            '&$error': {
+              color: '#FF7F73',
+            },
+          },
+        },
         MuiPickersToolbar: {
           toolbar: {
             backgroundColor: '#003088',
@@ -220,6 +241,27 @@ export const buildTheme = (darkModePreference: boolean): Theme => {
         MuiPickersToolbar: {
           toolbar: {
             backgroundColor: '#003088',
+          },
+        },
+        MuiInput: {
+          underline: {
+            '&$error:after': {
+              borderBottomColor: '#AC1600',
+            },
+          },
+        },
+        MuiOutlinedInput: {
+          root: {
+            '&$error $notchedOutline': {
+              borderColor: '#AC1600',
+            },
+          },
+        },
+        MuiFormHelperText: {
+          root: {
+            '&$error': {
+              color: '#AC1600',
+            },
           },
         },
         MuiPickersCalendarHeader: {

--- a/src/theming.tsx
+++ b/src/theming.tsx
@@ -237,6 +237,11 @@ export const buildTheme = (darkModePreference: boolean): Theme => {
             color: '#727272',
           },
         },
+        MuiPickersMonth: {
+          monthDisabled: {
+            color: '#727272',
+          },
+        },
       },
     };
   }


### PR DESCRIPTION
## Description
This overrides the colour of the months/years in date pickers to fix contrast issues. This is related to https://github.com/ral-facilities/datagateway/pull/910.

![image](https://user-images.githubusercontent.com/90245114/140907318-2dac9db7-fefd-4f40-827f-0fea10eb0056.png)

The year header however does not seem to have an override and seems to require MUI v5 to fix.
![image](https://user-images.githubusercontent.com/90245114/140907458-05726659-6186-458c-8f37-faa318eee725.png)


## Testing instructions

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking