### PR TITLE
Override current day colour in dark mode (#795)

### DIFF
--- a/src/theming.tsx
+++ b/src/theming.tsx
@@ -168,6 +168,9 @@ export const buildTheme = (darkModePreference: boolean): Theme => {
           },
         },
         MuiPickersDay: {
+          current: {
+            color: '#86b4ff',
+          },
           dayDisabled: {
             color: '#A4A4A4',
           },


### PR DESCRIPTION
## Description
Fix contrast issue with current day on date picker in dark mode as mentioned on #802 :
![image](https://user-images.githubusercontent.com/90245114/141101061-c5cfc12f-7594-4e79-8567-5a501f2abc87.png)


## Testing instructions

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking