### PR TITLE
fixing the error colour for form labels #803

### DIFF
--- a/src/contactPage/__snapshots__/contactPage.component.test.tsx.snap
+++ b/src/contactPage/__snapshots__/contactPage.component.test.tsx.snap
@@ -57,6 +57,18 @@ exports[`Contact page componet should render correctly 1`] = `
             },
           },
         },
+        "MuiFormLabel": Object {
+          "asterisk": Object {
+            "&$error": Object {
+              "color": "#AC1600",
+            },
+          },
+          "root": Object {
+            "&$error": Object {
+              "color": "#AC1600",
+            },
+          },
+        },
         "MuiInput": Object {
           "underline": Object {
             "&$error:after": Object {

--- a/src/helpPage/__snapshots__/helpPage.component.test.tsx.snap
+++ b/src/helpPage/__snapshots__/helpPage.component.test.tsx.snap
@@ -57,6 +57,18 @@ exports[`Help page component should render correctly 1`] = `
             },
           },
         },
+        "MuiFormLabel": Object {
+          "asterisk": Object {
+            "&$error": Object {
+              "color": "#AC1600",
+            },
+          },
+          "root": Object {
+            "&$error": Object {
+              "color": "#AC1600",
+            },
+          },
+        },
         "MuiInput": Object {
           "underline": Object {
             "&$error:after": Object {

--- a/src/theming.tsx
+++ b/src/theming.tsx
@@ -131,6 +131,18 @@ export const buildTheme = (darkModePreference: boolean): Theme => {
             textDecoration: 'underline',
           },
         },
+        MuiFormLabel: {
+          root: {
+            '&$error': {
+              color: '#FF7F73',
+            },
+          },
+          asterisk: {
+            '&$error': {
+              color: '#FF7F73',
+            },
+          },
+        },
         MuiBadge: {
           colorPrimary: {
             backgroundColor: '#FF6900',
@@ -249,6 +261,18 @@ export const buildTheme = (darkModePreference: boolean): Theme => {
         active: '#E94D36',
       },
       overrides: {
+        MuiFormLabel: {
+          root: {
+            '&$error': {
+              color: '#AC1600',
+            },
+          },
+          asterisk: {
+            '&$error': {
+              color: '#AC1600',
+            },
+          },
+        },
         MuiBadge: {
           colorPrimary: {
             backgroundColor: '#FF6900',


### PR DESCRIPTION
## Description
The error colour of instruction text next to the tick boxes on search don't have enough contrast on datagateway search.





  
![Screenshot 2021-11-10 110529](https://user-images.githubusercontent.com/83226114/141102723-9bd6712c-9601-4432-97c5-5918ddb60956.png)
<br><br>
![Screenshot 2021-11-10 110513](https://user-images.githubusercontent.com/83226114/141102729-d1306999-8993-4e36-baf3-45914a52669a.png)

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] {more steps here}

## Agile board tracking
closes #803