### PR TITLE
High contrast modes and improve theme customisation #795

### DIFF
--- a/public/res/default.json
+++ b/public/res/default.json
@@ -6,6 +6,7 @@
     "admin": "Admin",
     "manage-cookies-button": "Manage cookies",
     "toggle-dark-mode": "Toggle Dark Mode",
+    "toggle-high-contrast-mode": "Toggle High Contrast Mode",
     "no-notifications": "No notifications"
   },
   "login": {

--- a/src/contactPage/__snapshots__/contactPage.component.test.tsx.snap
+++ b/src/contactPage/__snapshots__/contactPage.component.test.tsx.snap
@@ -25,13 +25,28 @@ exports[`Contact page componet should render correctly 1`] = `
         },
         "width": [Function],
       },
+      "colours": Object {
+        "background": "#FAFAFA",
+        "blue": "#003088",
+        "darkGreen": "#3E863E",
+        "darkOrange": "#C34F00",
+        "grey": "#727272",
+        "information": "#003088",
+        "lightOrange": "#FF6900",
+        "link": Object {
+          "active": "#E94D36",
+          "default": "#1E5DF8",
+          "visited": "#BE2BBB",
+        },
+        "orange": "#C34F00",
+        "paper": "#FFF",
+        "primary": "#003088",
+        "red": "#AC1600",
+        "secondary": "#003088",
+        "warning": "#FFA500",
+      },
       "direction": "ltr",
       "drawerWidth": 300,
-      "link": Object {
-        "active": "#E94D36",
-        "default": "#1E5DF8",
-        "visited": "#BE2BBB",
-      },
       "mixins": Object {
         "gutters": [Function],
         "toolbar": Object {
@@ -47,7 +62,8 @@ exports[`Contact page componet should render correctly 1`] = `
       "overrides": Object {
         "MuiBadge": Object {
           "colorPrimary": Object {
-            "backgroundColor": "#FF6900",
+            "backgroundColor": "#C34F00",
+            "color": "white",
           },
         },
         "MuiFormHelperText": Object {
@@ -67,6 +83,9 @@ exports[`Contact page componet should render correctly 1`] = `
             "&$error": Object {
               "color": "#AC1600",
             },
+            "&$focused": Object {
+              "color": "#003088",
+            },
           },
         },
         "MuiInput": Object {
@@ -74,6 +93,14 @@ exports[`Contact page componet should render correctly 1`] = `
             "&$error:after": Object {
               "borderBottomColor": "#AC1600",
             },
+            "&:after": Object {
+              "borderBottomColor": "#003088",
+            },
+          },
+        },
+        "MuiLink": Object {
+          "root": Object {
+            "color": "#003088",
           },
         },
         "MuiOutlinedInput": Object {
@@ -89,6 +116,9 @@ exports[`Contact page componet should render correctly 1`] = `
           },
         },
         "MuiPickersDay": Object {
+          "current": Object {
+            "color": "#003088",
+          },
           "dayDisabled": Object {
             "color": "#727272",
           },
@@ -97,6 +127,17 @@ exports[`Contact page componet should render correctly 1`] = `
           "monthDisabled": Object {
             "color": "#727272",
           },
+          "monthSelected": Object {
+            "color": "#003088",
+          },
+          "root": Object {
+            "&:active": Object {
+              "color": "#003088",
+            },
+            "&:focus": Object {
+              "color": "#003088",
+            },
+          },
         },
         "MuiPickersToolbar": Object {
           "toolbar": Object {
@@ -104,8 +145,25 @@ exports[`Contact page componet should render correctly 1`] = `
           },
         },
         "MuiPickersYear": Object {
+          "root": Object {
+            "&:active": Object {
+              "color": "#003088",
+            },
+            "&:focus": Object {
+              "color": "#003088",
+            },
+          },
           "yearDisabled": Object {
             "color": "#727272",
+          },
+          "yearSelected": Object {
+            "color": "#003088",
+          },
+        },
+        "MuiTabs": Object {
+          "indicator": Object {
+            "color": "#003088",
+            "textDecoration": "underline",
           },
         },
       },
@@ -125,8 +183,8 @@ exports[`Contact page componet should render correctly 1`] = `
         },
         "augmentColor": [Function],
         "background": Object {
-          "default": "#fafafa",
-          "paper": "#fff",
+          "default": "#FAFAFA",
+          "paper": "#FFF",
         },
         "common": Object {
           "black": "#000",
@@ -349,30 +407,6 @@ exports[`Contact page componet should render correctly 1`] = `
           "fontWeight": 500,
           "letterSpacing": "0.00714em",
           "lineHeight": 1.57,
-        },
-      },
-      "ukri": Object {
-        "bright": Object {
-          "blue": "#1E5DF8",
-          "green": "#67C04D",
-          "orange": "#FF6900",
-          "purple": "#BE2BBB",
-          "red": "#E94D36",
-          "yellow": "#FBBB10",
-        },
-        "contrast": Object {
-          "blue": "#003088",
-          "grey": "#727272",
-          "orange": "#C34F00",
-          "red": "#AC1600",
-        },
-        "deep": Object {
-          "blue": "#003088",
-          "green": "#3E863E",
-          "orange": "#C13D33",
-          "purple": "#8A1A9B",
-          "red": "#A91B2E",
-          "yellow": "#F08900",
         },
       },
       "zIndex": Object {

--- a/src/contactPage/__snapshots__/contactPage.component.test.tsx.snap
+++ b/src/contactPage/__snapshots__/contactPage.component.test.tsx.snap
@@ -28,6 +28,7 @@ exports[`Contact page componet should render correctly 1`] = `
       "colours": Object {
         "background": "#FAFAFA",
         "blue": "#003088",
+        "contrastGrey": "#E0E0E0",
         "darkGreen": "#3E863E",
         "darkOrange": "#C34F00",
         "grey": "#727272",
@@ -64,6 +65,11 @@ exports[`Contact page componet should render correctly 1`] = `
           "colorPrimary": Object {
             "backgroundColor": "#C34F00",
             "color": "white",
+          },
+        },
+        "MuiChip": Object {
+          "root": Object {
+            "backgroundColor": "#E0E0E0",
           },
         },
         "MuiFormHelperText": Object {

--- a/src/contactPage/contactPage.component.tsx
+++ b/src/contactPage/contactPage.component.tsx
@@ -20,13 +20,13 @@ const styles = (theme: Theme): StyleRules =>
       backgroundColor: theme.palette.background.default,
       '& a': {
         '&:link': {
-          color: (theme as UKRITheme).link.default,
+          color: (theme as UKRITheme).colours.link.default,
         },
         '&:visited': {
-          color: (theme as UKRITheme).link.visited,
+          color: (theme as UKRITheme).colours.link.visited,
         },
         '&:active': {
-          color: (theme as UKRITheme).link.active,
+          color: (theme as UKRITheme).colours.link.active,
         },
       },
     },

--- a/src/cookieConsent/cookieConsent.component.tsx
+++ b/src/cookieConsent/cookieConsent.component.tsx
@@ -25,7 +25,7 @@ const styles = (theme: Theme): StyleRules =>
   createStyles({
     root: {
       color: theme.palette.primary.contrastText,
-      backgroundColor: (theme as UKRITheme).ukri.deep.green,
+      backgroundColor: (theme as UKRITheme).colours.darkGreen,
     },
     button: {
       color: theme.palette.primary.contrastText,

--- a/src/cookieConsent/cookiesPage.component.tsx
+++ b/src/cookieConsent/cookiesPage.component.tsx
@@ -26,13 +26,13 @@ const styles = (theme: Theme): StyleRules =>
       backgroundColor: theme.palette.background.default,
       '& a': {
         '&:link': {
-          color: (theme as UKRITheme).link.default,
+          color: (theme as UKRITheme).colours.link.default,
         },
         '&:visited': {
-          color: (theme as UKRITheme).link.visited,
+          color: (theme as UKRITheme).colours.link.visited,
         },
         '&:active': {
-          color: (theme as UKRITheme).link.active,
+          color: (theme as UKRITheme).colours.link.active,
         },
       },
     },

--- a/src/footer/footer.component.tsx
+++ b/src/footer/footer.component.tsx
@@ -25,13 +25,13 @@ const styles = (theme: Theme): StyleRules =>
       backgroundColor: theme.palette.background.default,
       '& a': {
         '&:link': {
-          color: (theme as UKRITheme).link.default,
+          color: (theme as UKRITheme).colours.link.default,
         },
         '&:visited': {
-          color: (theme as UKRITheme).link.visited,
+          color: (theme as UKRITheme).colours.link.visited,
         },
         '&:active': {
-          color: (theme as UKRITheme).link.active,
+          color: (theme as UKRITheme).colours.link.active,
         },
       },
     },

--- a/src/helpPage/__snapshots__/helpPage.component.test.tsx.snap
+++ b/src/helpPage/__snapshots__/helpPage.component.test.tsx.snap
@@ -28,6 +28,7 @@ exports[`Help page component should render correctly 1`] = `
       "colours": Object {
         "background": "#FAFAFA",
         "blue": "#003088",
+        "contrastGrey": "#E0E0E0",
         "darkGreen": "#3E863E",
         "darkOrange": "#C34F00",
         "grey": "#727272",
@@ -64,6 +65,11 @@ exports[`Help page component should render correctly 1`] = `
           "colorPrimary": Object {
             "backgroundColor": "#C34F00",
             "color": "white",
+          },
+        },
+        "MuiChip": Object {
+          "root": Object {
+            "backgroundColor": "#E0E0E0",
           },
         },
         "MuiFormHelperText": Object {

--- a/src/helpPage/__snapshots__/helpPage.component.test.tsx.snap
+++ b/src/helpPage/__snapshots__/helpPage.component.test.tsx.snap
@@ -25,13 +25,28 @@ exports[`Help page component should render correctly 1`] = `
         },
         "width": [Function],
       },
+      "colours": Object {
+        "background": "#FAFAFA",
+        "blue": "#003088",
+        "darkGreen": "#3E863E",
+        "darkOrange": "#C34F00",
+        "grey": "#727272",
+        "information": "#003088",
+        "lightOrange": "#FF6900",
+        "link": Object {
+          "active": "#E94D36",
+          "default": "#1E5DF8",
+          "visited": "#BE2BBB",
+        },
+        "orange": "#C34F00",
+        "paper": "#FFF",
+        "primary": "#003088",
+        "red": "#AC1600",
+        "secondary": "#003088",
+        "warning": "#FFA500",
+      },
       "direction": "ltr",
       "drawerWidth": 300,
-      "link": Object {
-        "active": "#E94D36",
-        "default": "#1E5DF8",
-        "visited": "#BE2BBB",
-      },
       "mixins": Object {
         "gutters": [Function],
         "toolbar": Object {
@@ -47,7 +62,8 @@ exports[`Help page component should render correctly 1`] = `
       "overrides": Object {
         "MuiBadge": Object {
           "colorPrimary": Object {
-            "backgroundColor": "#FF6900",
+            "backgroundColor": "#C34F00",
+            "color": "white",
           },
         },
         "MuiFormHelperText": Object {
@@ -67,6 +83,9 @@ exports[`Help page component should render correctly 1`] = `
             "&$error": Object {
               "color": "#AC1600",
             },
+            "&$focused": Object {
+              "color": "#003088",
+            },
           },
         },
         "MuiInput": Object {
@@ -74,6 +93,14 @@ exports[`Help page component should render correctly 1`] = `
             "&$error:after": Object {
               "borderBottomColor": "#AC1600",
             },
+            "&:after": Object {
+              "borderBottomColor": "#003088",
+            },
+          },
+        },
+        "MuiLink": Object {
+          "root": Object {
+            "color": "#003088",
           },
         },
         "MuiOutlinedInput": Object {
@@ -89,6 +116,9 @@ exports[`Help page component should render correctly 1`] = `
           },
         },
         "MuiPickersDay": Object {
+          "current": Object {
+            "color": "#003088",
+          },
           "dayDisabled": Object {
             "color": "#727272",
           },
@@ -97,6 +127,17 @@ exports[`Help page component should render correctly 1`] = `
           "monthDisabled": Object {
             "color": "#727272",
           },
+          "monthSelected": Object {
+            "color": "#003088",
+          },
+          "root": Object {
+            "&:active": Object {
+              "color": "#003088",
+            },
+            "&:focus": Object {
+              "color": "#003088",
+            },
+          },
         },
         "MuiPickersToolbar": Object {
           "toolbar": Object {
@@ -104,8 +145,25 @@ exports[`Help page component should render correctly 1`] = `
           },
         },
         "MuiPickersYear": Object {
+          "root": Object {
+            "&:active": Object {
+              "color": "#003088",
+            },
+            "&:focus": Object {
+              "color": "#003088",
+            },
+          },
           "yearDisabled": Object {
             "color": "#727272",
+          },
+          "yearSelected": Object {
+            "color": "#003088",
+          },
+        },
+        "MuiTabs": Object {
+          "indicator": Object {
+            "color": "#003088",
+            "textDecoration": "underline",
           },
         },
       },
@@ -125,8 +183,8 @@ exports[`Help page component should render correctly 1`] = `
         },
         "augmentColor": [Function],
         "background": Object {
-          "default": "#fafafa",
-          "paper": "#fff",
+          "default": "#FAFAFA",
+          "paper": "#FFF",
         },
         "common": Object {
           "black": "#000",
@@ -349,30 +407,6 @@ exports[`Help page component should render correctly 1`] = `
           "fontWeight": 500,
           "letterSpacing": "0.00714em",
           "lineHeight": 1.57,
-        },
-      },
-      "ukri": Object {
-        "bright": Object {
-          "blue": "#1E5DF8",
-          "green": "#67C04D",
-          "orange": "#FF6900",
-          "purple": "#BE2BBB",
-          "red": "#E94D36",
-          "yellow": "#FBBB10",
-        },
-        "contrast": Object {
-          "blue": "#003088",
-          "grey": "#727272",
-          "orange": "#C34F00",
-          "red": "#AC1600",
-        },
-        "deep": Object {
-          "blue": "#003088",
-          "green": "#3E863E",
-          "orange": "#C13D33",
-          "purple": "#8A1A9B",
-          "red": "#A91B2E",
-          "yellow": "#F08900",
         },
       },
       "zIndex": Object {

--- a/src/helpPage/helpPage.component.tsx
+++ b/src/helpPage/helpPage.component.tsx
@@ -20,13 +20,13 @@ const styles = (theme: Theme): StyleRules =>
       backgroundColor: theme.palette.background.default,
       '& a': {
         '&:link': {
-          color: (theme as UKRITheme).link.default,
+          color: (theme as UKRITheme).colours.link.default,
         },
         '&:visited': {
-          color: (theme as UKRITheme).link.visited,
+          color: (theme as UKRITheme).colours.link.visited,
         },
         '&:active': {
-          color: (theme as UKRITheme).link.active,
+          color: (theme as UKRITheme).colours.link.active,
         },
       },
     },

--- a/src/homePage/homePage.component.tsx
+++ b/src/homePage/homePage.component.tsx
@@ -51,7 +51,7 @@ const styles = (theme: Theme): StyleRules =>
       alignItems: 'center',
     },
     howItWorksGridItemTitle: {
-      color: (theme as UKRITheme).ukri.bright.orange,
+      color: (theme as UKRITheme).colours.lightOrange,
       fontWeight: 'bold',
       paddingBottom: 10,
     },

--- a/src/homePage/homePage.component.tsx
+++ b/src/homePage/homePage.component.tsx
@@ -51,7 +51,7 @@ const styles = (theme: Theme): StyleRules =>
       alignItems: 'center',
     },
     howItWorksGridItemTitle: {
-      color: (theme as UKRITheme).colours.lightOrange,
+      color: (theme as UKRITheme).colours.orange,
       fontWeight: 'bold',
       paddingBottom: 10,
     },

--- a/src/loginPage/loginPage.component.tsx
+++ b/src/loginPage/loginPage.component.tsx
@@ -38,7 +38,7 @@ const styles = (theme: Theme): StyleRules =>
     },
     avatar: {
       margin: theme.spacing(1),
-      backgroundColor: (theme as UKRITheme).ukri.bright.orange,
+      backgroundColor: (theme as UKRITheme).colours.lightOrange,
     },
     paper: {
       marginTop: theme.spacing(8),
@@ -65,7 +65,7 @@ const styles = (theme: Theme): StyleRules =>
     },
     warning: {
       marginTop: `${theme.spacing(1)}px`,
-      color: (theme as UKRITheme).ukri.contrast.red,
+      color: (theme as UKRITheme).colours.red,
     },
     info: {
       marginTop: `${theme.spacing(1)}px`,

--- a/src/logoutPage/logoutPage.component.tsx
+++ b/src/logoutPage/logoutPage.component.tsx
@@ -33,7 +33,7 @@ const styles = (theme: Theme): StyleRules =>
     },
     avatar: {
       margin: theme.spacing(1),
-      backgroundColor: (theme as UKRITheme).ukri.bright.orange,
+      backgroundColor: (theme as UKRITheme).colours.orange,
     },
     avataUrl: {
       margin: theme.spacing(1),

--- a/src/mainAppBar/__snapshots__/mainAppBar.component.test.tsx.snap
+++ b/src/mainAppBar/__snapshots__/mainAppBar.component.test.tsx.snap
@@ -15,6 +15,7 @@ Object {
   },
   "darkMode": false,
   "drawerOpen": true,
+  "highContrastMode": false,
   "loading": true,
   "loggedIn": true,
   "manageCookies": [Function],
@@ -31,6 +32,7 @@ Object {
   "toggleDarkMode": [Function],
   "toggleDrawer": [Function],
   "toggleHelp": [Function],
+  "toggleHighContrastMode": [Function],
 }
 `;
 
@@ -49,6 +51,7 @@ Object {
   },
   "darkMode": false,
   "drawerOpen": false,
+  "highContrastMode": false,
   "loading": true,
   "loggedIn": true,
   "manageCookies": [Function],
@@ -65,6 +68,7 @@ Object {
   "toggleDarkMode": [Function],
   "toggleDrawer": [Function],
   "toggleHelp": [Function],
+  "toggleHighContrastMode": [Function],
 }
 `;
 
@@ -83,6 +87,7 @@ Object {
   },
   "darkMode": false,
   "drawerOpen": false,
+  "highContrastMode": false,
   "loading": true,
   "loggedIn": true,
   "manageCookies": [Function],
@@ -99,6 +104,7 @@ Object {
   "toggleDarkMode": [Function],
   "toggleDrawer": [Function],
   "toggleHelp": [Function],
+  "toggleHighContrastMode": [Function],
 }
 `;
 
@@ -117,6 +123,7 @@ Object {
   },
   "darkMode": false,
   "drawerOpen": false,
+  "highContrastMode": false,
   "loading": true,
   "loggedIn": true,
   "manageCookies": [Function],
@@ -133,6 +140,7 @@ Object {
   "toggleDarkMode": [Function],
   "toggleDrawer": [Function],
   "toggleHelp": [Function],
+  "toggleHighContrastMode": [Function],
 }
 `;
 
@@ -151,6 +159,7 @@ Object {
   },
   "darkMode": false,
   "drawerOpen": false,
+  "highContrastMode": false,
   "loading": true,
   "loggedIn": true,
   "manageCookies": [Function],
@@ -167,5 +176,6 @@ Object {
   "toggleDarkMode": [Function],
   "toggleDrawer": [Function],
   "toggleHelp": [Function],
+  "toggleHighContrastMode": [Function],
 }
 `;

--- a/src/mainAppBar/mainAppBar.component.test.tsx
+++ b/src/mainAppBar/mainAppBar.component.test.tsx
@@ -6,7 +6,11 @@ import { PluginConfig } from '../state/scigateway.types';
 import configureStore from 'redux-mock-store';
 import { push } from 'connected-react-router';
 import { initialState } from '../state/reducers/scigateway.reducer';
-import { toggleDrawer, toggleHelp } from '../state/actions/scigateway.actions';
+import {
+  loadHighContrastModePreference,
+  toggleDrawer,
+  toggleHelp,
+} from '../state/actions/scigateway.actions';
 import { Provider } from 'react-redux';
 import TestAuthProvider from '../authentication/testAuthProvider';
 import { buildTheme } from '../theming';
@@ -183,6 +187,22 @@ describe('Main app bar component', () => {
 
     expect(testStore.getActions().length).toEqual(1);
     expect(testStore.getActions()[0]).toEqual(loadDarkModePreference(true));
+  });
+
+  it('sends load high contrast mode prefrence action if toggle high contrast mode is clicked', () => {
+    const testStore = mockStore(state);
+    const wrapper = createWrapper(testStore);
+
+    // Click the user menu button and click on the manage cookies menu item.
+    wrapper
+      .find('button[aria-label="Open browser settings"]')
+      .simulate('click');
+    wrapper.find('#item-high-contrast-mode').first().simulate('click');
+
+    expect(testStore.getActions().length).toEqual(1);
+    expect(testStore.getActions()[0]).toEqual(
+      loadHighContrastModePreference(true)
+    );
   });
 
   it('sets plugin logo', () => {

--- a/src/mainAppBar/mainAppBar.component.tsx
+++ b/src/mainAppBar/mainAppBar.component.tsx
@@ -9,6 +9,7 @@ import IconButton from '@material-ui/core/IconButton';
 import HelpIcon from '@material-ui/icons/HelpOutline';
 import MenuIcon from '@material-ui/icons/Menu';
 import BrightnessIcon from '@material-ui/icons/Brightness4';
+import PaletteIcon from '@material-ui/icons/Palette';
 import TuneIcon from '@material-ui/icons/Tune';
 import SettingsIcon from '@material-ui/icons/Settings';
 import { Menu, MenuItem, ListItemIcon, ListItemText } from '@material-ui/core';
@@ -25,6 +26,7 @@ import {
   toggleDrawer,
   toggleHelp,
   loadDarkModePreference,
+  loadHighContrastModePreference,
 } from '../state/actions/scigateway.actions';
 import { AppStrings } from '../state/scigateway.types';
 import { StateType } from '../state/state.types';
@@ -45,6 +47,7 @@ interface MainAppProps {
   singlePluginLogo: boolean;
   loggedIn: boolean;
   darkMode: boolean;
+  highContrastMode: boolean;
   plugins?: PluginConfig[];
   loading: boolean;
 }
@@ -58,6 +61,7 @@ interface MainAppDispatchProps {
   toggleHelp: () => Action;
   manageCookies: () => Action;
   toggleDarkMode: (preference: boolean) => Action;
+  toggleHighContrastMode: (preference: boolean) => Action;
 }
 
 const styles = (theme: Theme): StyleRules =>
@@ -125,6 +129,12 @@ const MainAppBar = (props: CombinedMainAppBarProps): React.ReactElement => {
     const toggledPreference = !props.darkMode;
     localStorage.setItem('darkMode', toggledPreference.toString());
     props.toggleDarkMode(toggledPreference);
+  };
+
+  const toggleHighContrastMode = (): void => {
+    const toggledPreference = !props.highContrastMode;
+    localStorage.setItem('highContrastMode', toggledPreference.toString());
+    props.toggleHighContrastMode(toggledPreference);
   };
 
   const location = useLocation();
@@ -259,6 +269,17 @@ const MainAppBar = (props: CombinedMainAppBarProps): React.ReactElement => {
                 primary={getString(props.res, 'toggle-dark-mode')}
               />
             </MenuItem>
+            <MenuItem
+              id="item-high-contrast-mode"
+              onClick={toggleHighContrastMode}
+            >
+              <ListItemIcon>
+                <PaletteIcon />
+              </ListItemIcon>
+              <ListItemText
+                primary={getString(props.res, 'toggle-high-contrast-mode')}
+              />
+            </MenuItem>
           </Menu>
           {props.loggedIn ? <NotificationBadgeComponent /> : null}
           <UserProfileComponent />
@@ -279,6 +300,7 @@ const mapStateToProps = (state: StateType): MainAppProps => ({
     state.scigateway.authorisation.provider.isAdmin(),
   res: getAppStrings(state, 'main-appbar'),
   darkMode: state.scigateway.darkMode,
+  highContrastMode: state.scigateway.highContrastMode,
   plugins: state.scigateway.plugins,
   loading: state.scigateway.siteLoading,
 });
@@ -293,6 +315,8 @@ const mapDispatchToProps = (dispatch: Dispatch): MainAppDispatchProps => ({
   manageCookies: () => dispatch(push('/cookies')),
   toggleDarkMode: (preference: boolean) =>
     dispatch(loadDarkModePreference(preference)),
+  toggleHighContrastMode: (preference: boolean) =>
+    dispatch(loadHighContrastModePreference(preference)),
 });
 
 export const MainAppBarWithStyles = withStyles(styles)(MainAppBar);

--- a/src/mainAppBar/mainAppBar.component.tsx
+++ b/src/mainAppBar/mainAppBar.component.tsx
@@ -9,7 +9,7 @@ import IconButton from '@material-ui/core/IconButton';
 import HelpIcon from '@material-ui/icons/HelpOutline';
 import MenuIcon from '@material-ui/icons/Menu';
 import BrightnessIcon from '@material-ui/icons/Brightness4';
-import PaletteIcon from '@material-ui/icons/Palette';
+import InvertColorsIcon from '@material-ui/icons/InvertColors';
 import TuneIcon from '@material-ui/icons/Tune';
 import SettingsIcon from '@material-ui/icons/Settings';
 import { Menu, MenuItem, ListItemIcon, ListItemText } from '@material-ui/core';
@@ -274,7 +274,7 @@ const MainAppBar = (props: CombinedMainAppBarProps): React.ReactElement => {
               onClick={toggleHighContrastMode}
             >
               <ListItemIcon>
-                <PaletteIcon />
+                <InvertColorsIcon />
               </ListItemIcon>
               <ListItemText
                 primary={getString(props.res, 'toggle-high-contrast-mode')}

--- a/src/notifications/scigatewayNotification.component.tsx
+++ b/src/notifications/scigatewayNotification.component.tsx
@@ -39,7 +39,7 @@ const styles = (theme: Theme): StyleRules => ({
   },
   warningIcon: {
     ...severityIconStyle,
-    color: (theme as UKRITheme).ukri.bright.orange,
+    color: (theme as UKRITheme).colours.lightOrange,
   },
   errorIcon: {
     ...severityIconStyle,

--- a/src/pageNotFound/pageNotFound.component.tsx
+++ b/src/pageNotFound/pageNotFound.component.tsx
@@ -17,12 +17,12 @@ const styles = (theme: Theme): StyleRules => ({
   bugIcon: {
     width: '10vw',
     height: '10vw',
-    color: (theme as UKRITheme).ukri.contrast.blue,
+    color: (theme as UKRITheme).colours.blue,
   },
   codeText: {
     fontWeight: 'bold',
     fontSize: '10vw',
-    color: (theme as UKRITheme).ukri.contrast.blue,
+    color: (theme as UKRITheme).colours.blue,
   },
   container: {
     display: 'flex',

--- a/src/state/actions/scigateway.actions.test.tsx
+++ b/src/state/actions/scigateway.actions.test.tsx
@@ -21,6 +21,7 @@ import {
   loadScheduledMaintenanceState,
   loadMaintenanceState,
   loadAuthProvider,
+  loadHighContrastModePreference,
 } from './scigateway.actions';
 import {
   ToggleDrawerType,
@@ -574,6 +575,39 @@ describe('scigateway actions', () => {
 
     expect(localStorage.getItem).toBeCalledWith('darkMode');
     expect(actions).toContainEqual(loadDarkModePreference(true));
+  });
+
+  it('should load high contrast mode preference into store', async () => {
+    (mockAxios.get as jest.Mock).mockImplementation(() =>
+      Promise.resolve({
+        data: {
+          'ui-strings': 'res/default.json',
+        },
+      })
+    );
+
+    jest.spyOn(window.localStorage.__proto__, 'getItem');
+    window.localStorage.__proto__.getItem = jest
+      .fn()
+      .mockImplementation((name) =>
+        name === 'highContrastMode' ? 'true' : 'false'
+      );
+
+    const asyncAction = configureSite();
+    const actions: Action[] = [];
+    const dispatch = (action: Action): number => actions.push(action);
+    const getState = (): Partial<StateType> => ({
+      scigateway: initialState,
+      router: {
+        location: { ...createLocation('/'), query: {} },
+        action: 'PUSH',
+      },
+    });
+
+    await asyncAction(dispatch, getState);
+
+    expect(localStorage.getItem).toBeCalledWith('highContrastMode');
+    expect(actions).toContainEqual(loadHighContrastModePreference(true));
   });
 
   it('logs an error if settings.json fails to be loaded', async () => {

--- a/src/state/actions/scigateway.actions.tsx
+++ b/src/state/actions/scigateway.actions.tsx
@@ -47,6 +47,8 @@ import {
   ToggleHelpType,
   RegisterRouteType,
   scigatewayRoutes,
+  LoadHighContrastModePreferenceType,
+  LoadHighContrastModePreferencePayload,
 } from '../scigateway.types';
 import { ActionType, StateType, ThunkResult } from '../state.types';
 import loadMicroFrontends from './loadMicroFrontends';
@@ -320,6 +322,15 @@ export const configureSite = (): ThunkResult<Promise<void>> => {
       const mq = window.matchMedia('(prefers-color-scheme: dark)');
       if (mq) dispatch(loadDarkModePreference(mq.matches));
     }
+    const highContrastModeLocalStorage = localStorage.getItem(
+      'highContrastMode'
+    );
+    if (highContrastModeLocalStorage)
+      dispatch(
+        loadHighContrastModePreference(
+          highContrastModeLocalStorage === 'true' ? true : false
+        )
+      );
 
     const provider = getState().scigateway.authorisation.provider;
     if (provider.fetchScheduledMaintenanceState) {
@@ -491,6 +502,15 @@ export const loadDarkModePreference = (
   type: LoadDarkModePreferenceType,
   payload: {
     darkMode: darkMode,
+  },
+});
+
+export const loadHighContrastModePreference = (
+  highContrastMode: boolean
+): ActionType<LoadHighContrastModePreferencePayload> => ({
+  type: LoadHighContrastModePreferenceType,
+  payload: {
+    highContrastMode: highContrastMode,
   },
 });
 

--- a/src/state/middleware/scigateway.middleware.test.tsx
+++ b/src/state/middleware/scigateway.middleware.test.tsx
@@ -9,6 +9,7 @@ import {
   ToggleDrawerType,
   LoadDarkModePreferenceType,
   SendThemeOptionsType,
+  LoadHighContrastModePreferenceType,
 } from '../scigateway.types';
 import { toastr } from 'react-redux-toastr';
 import { AddHelpTourStepsType } from '../scigateway.types';
@@ -70,6 +71,13 @@ describe('scigateway middleware', () => {
     type: LoadDarkModePreferenceType,
     payload: {
       darkMode: false,
+    },
+  };
+
+  const loadHighContrastModePreferenceAction = {
+    type: LoadHighContrastModePreferenceType,
+    payload: {
+      highContrastMode: false,
     },
   };
 
@@ -192,6 +200,9 @@ describe('scigateway middleware', () => {
   });
 
   it('should send theme options and request plugin rerender actions when LoadDarkModePreferenceType action is sent', () => {
+    store = configureStore()({
+      scigateway: initialState,
+    });
     ScigatewayMiddleware(store)(store.dispatch)(loadDarkModePreferenceAction);
 
     expect(store.getActions().length).toEqual(3);
@@ -202,7 +213,27 @@ describe('scigateway middleware', () => {
     expect(store.getActions()[2]).toEqual(requestPluginRerenderAction);
   });
 
+  it('should send theme options and request plugin rerender actions when LoadHighContrastModePreferenceType action is sent', () => {
+    store = configureStore()({
+      scigateway: initialState,
+    });
+    ScigatewayMiddleware(store)(store.dispatch)(
+      loadHighContrastModePreferenceAction
+    );
+
+    expect(store.getActions().length).toEqual(3);
+    expect(store.getActions()[0]).toEqual(loadHighContrastModePreferenceAction);
+    expect(JSON.stringify(store.getActions()[1])).toEqual(
+      JSON.stringify(sendThemeOptionsAction)
+    );
+    expect(store.getActions()[2]).toEqual(requestPluginRerenderAction);
+  });
+
   it('should send dark theme options when LoadDarkModePreferenceType action is sent and darkmode preference is true', () => {
+    store = configureStore()({
+      scigateway: initialState,
+    });
+
     const loadDarkModePreferenceAction = {
       type: LoadDarkModePreferenceType,
       payload: {
@@ -220,6 +251,37 @@ describe('scigateway middleware', () => {
       },
     };
     ScigatewayMiddleware(store)(store.dispatch)(loadDarkModePreferenceAction);
+
+    expect(store.getActions().length).toEqual(3);
+    expect(JSON.stringify(store.getActions()[1])).toEqual(
+      JSON.stringify(sendThemeOptionsAction)
+    );
+  });
+
+  it('should send high contrast theme options when LoadHighContrastModePreferenceType action is sent and high contrast mode preference is true', () => {
+    store = configureStore()({
+      scigateway: initialState,
+    });
+
+    const loadHighContrastModePreferenceAction = {
+      type: LoadHighContrastModePreferenceType,
+      payload: {
+        highContrastMode: true,
+      },
+    };
+
+    const theme = buildTheme(false, true);
+
+    const sendThemeOptionsAction = {
+      type: SendThemeOptionsType,
+      payload: {
+        theme,
+        broadcast: true,
+      },
+    };
+    ScigatewayMiddleware(store)(store.dispatch)(
+      loadHighContrastModePreferenceAction
+    );
 
     expect(store.getActions().length).toEqual(3);
     expect(JSON.stringify(store.getActions()[1])).toEqual(

--- a/src/state/middleware/scigateway.middleware.tsx
+++ b/src/state/middleware/scigateway.middleware.tsx
@@ -7,6 +7,7 @@ import {
   ToggleDrawerType,
   SendThemeOptionsType,
   LoadDarkModePreferenceType,
+  LoadHighContrastModePreferenceType,
 } from '../scigateway.types';
 import log from 'loglevel';
 import { toastr } from 'react-redux-toastr';
@@ -123,7 +124,13 @@ export const listenToPlugins = (
             const mq = window.matchMedia('(prefers-color-scheme: dark)');
             darkModePreference = mq.matches;
           }
-          const theme = buildTheme(darkModePreference);
+          const highContrastModePreference: boolean =
+            localStorage.getItem('highContrastMode') === 'true' ? true : false;
+
+          const theme = buildTheme(
+            darkModePreference,
+            highContrastModePreference
+          );
           // Send theme options once registered.
           dispatch(sendThemeOptions(theme));
 
@@ -204,7 +211,20 @@ const ScigatewayMiddleware: Middleware = ((
 
   if (action.type === LoadDarkModePreferenceType) {
     next(action);
-    const theme = buildTheme(action.payload.darkMode);
+    const theme = buildTheme(
+      action.payload.darkMode,
+      state.scigateway.highContrastMode
+    );
+    store.dispatch(sendThemeOptions(theme));
+    return store.dispatch(requestPluginRerender());
+  }
+
+  if (action.type === LoadHighContrastModePreferenceType) {
+    next(action);
+    const theme = buildTheme(
+      state.scigateway.darkMode,
+      action.payload.highContrastMode
+    );
     store.dispatch(sendThemeOptions(theme));
     return store.dispatch(requestPluginRerender());
   }

--- a/src/state/reducers/scigateway.reducer.test.tsx
+++ b/src/state/reducers/scigateway.reducer.test.tsx
@@ -19,6 +19,7 @@ import {
   registerHomepageUrl,
   loadScheduledMaintenanceState,
   loadMaintenanceState,
+  loadHighContrastModePreference,
 } from '../actions/scigateway.actions';
 import ScigatewayReducer, {
   initialState,
@@ -369,6 +370,17 @@ describe('scigateway reducer', () => {
     const updatedState = ScigatewayReducer(state, loadDarkModePreference(true));
 
     expect(updatedState.darkMode).toBeTruthy();
+  });
+
+  it('should load hight contrast mode property into store when load high contrast mode action is sent', () => {
+    expect(state.highContrastMode).toBeFalsy();
+
+    const updatedState = ScigatewayReducer(
+      state,
+      loadHighContrastModePreference(true)
+    );
+
+    expect(updatedState.highContrastMode).toBeTruthy();
   });
 
   describe('register route', () => {

--- a/src/state/reducers/scigateway.reducer.tsx
+++ b/src/state/reducers/scigateway.reducer.tsx
@@ -35,6 +35,8 @@ import {
   ScheduledMaintenanceStatePayLoad,
   MaintenanceStatePayLoad,
   LoadMaintenanceStateType,
+  LoadHighContrastModePreferencePayload,
+  LoadHighContrastModePreferenceType,
 } from '../scigateway.types';
 import { ScigatewayState, AuthState } from '../state.types';
 import { buildPluginConfig } from '../pluginhelper';
@@ -66,6 +68,7 @@ export const initialState: ScigatewayState = {
     singlePluginLogo: false,
   },
   darkMode: false,
+  highContrastMode: false,
   scheduledMaintenance: {
     show: false,
     message: '',
@@ -394,6 +397,16 @@ export function handleLoadDarkModePreference(
   };
 }
 
+export function handleLoadHighContrastModePreference(
+  state: ScigatewayState,
+  payload: LoadHighContrastModePreferencePayload
+): ScigatewayState {
+  return {
+    ...state,
+    highContrastMode: payload.highContrastMode,
+  };
+}
+
 const ScigatewayReducer = createReducer(initialState, {
   [NotificationType]: handleNotification,
   [ToggleDrawerType]: handleDrawerToggle,
@@ -416,6 +429,7 @@ const ScigatewayReducer = createReducer(initialState, {
   [ToggleHelpType]: handleToggleHelp,
   [AddHelpTourStepsType]: handleAddHelpTourSteps,
   [LoadDarkModePreferenceType]: handleLoadDarkModePreference,
+  [LoadHighContrastModePreferenceType]: handleLoadHighContrastModePreference,
   [RegisterHomepageUrlType]: handleRegisterHomepageUrl,
 });
 

--- a/src/state/scigateway.types.tsx
+++ b/src/state/scigateway.types.tsx
@@ -18,6 +18,8 @@ export const RequestPluginRerenderType = 'scigateway:api:plugin_rerender';
 export const SendThemeOptionsType = 'scigateway:api:send_themeoptions';
 export const LoadDarkModePreferenceType =
   'scigateway:load_dark_mode_preference';
+export const LoadHighContrastModePreferenceType =
+  'scigateway:load_high_contrast_mode_preference';
 export const SignOutType = 'scigateway:signout';
 export const ToggleDrawerType = 'scigateway:toggledrawer';
 export const DismissNotificationType = 'scigateway:dismissnotification';
@@ -129,6 +131,10 @@ export interface SendThemeOptionsPayload {
 
 export interface LoadDarkModePreferencePayload {
   darkMode: boolean;
+}
+
+export interface LoadHighContrastModePreferencePayload {
+  highContrastMode: boolean;
 }
 
 export interface DismissNotificationPayload {

--- a/src/state/state.types.tsx
+++ b/src/state/state.types.tsx
@@ -34,6 +34,7 @@ export interface ScigatewayState {
   features: FeatureSwitches;
   analytics?: AnalyticsState;
   darkMode: boolean;
+  highContrastMode: boolean;
   homepageUrl?: string;
   scheduledMaintenance: ScheduledMaintenanceState;
   maintenance: MaintenanceState;

--- a/src/theming.tsx
+++ b/src/theming.tsx
@@ -151,6 +151,26 @@ const LIGHT_MODE_COLOURS: ThemeColours = {
     active: '#E94D36',
   },
 };
+
+const LIGHT_MODE_HIGH_CONTRAST_COLOURS: ThemeColours = {
+  primary: '#003088',
+  secondary: '#003088',
+  background: '#FAFAFA',
+  paper: '#FFF',
+  blue: '#003088',
+  orange: '#C34F00',
+  red: '#AC1600',
+  grey: '#727272',
+  lightOrange: '#FF6900',
+  darkGreen: '#3E863E',
+  information: '#003088',
+  warning: '#FFA500',
+  link: {
+    default: '#1E5DF8',
+    visited: '#BE2BBB',
+    active: '#E94D36',
+  },
+};
 export interface UKRIThemeOptions extends ThemeOptions {
   drawerWidth: number;
   colours: ThemeColours;
@@ -169,6 +189,8 @@ export const buildTheme = (
     ? highContrastModePreference
       ? DARK_MODE_HIGH_CONTRAST_COLOURS
       : DARK_MODE_COLOURS
+    : highContrastModePreference
+    ? LIGHT_MODE_HIGH_CONTRAST_COLOURS
     : LIGHT_MODE_COLOURS;
 
   const overrides = {

--- a/src/theming.tsx
+++ b/src/theming.tsx
@@ -73,7 +73,8 @@ export interface UKRITheme extends Theme {
 
 /* Colours that may be used across light/dark modes e.g. the main app bar */
 const STATIC_COLOURS = {
-  darkBlue: '#80ACFF',
+  darkBlue: '#003088',
+  orange: '#FF6900',
 };
 
 /* Main colours used for dark/light modes respectively */
@@ -90,6 +91,19 @@ interface ThemeColours {
 
 const DARK_MODE_COLOURS: ThemeColours = {
   primary: '#003088',
+  secondary: '#80ACFF',
+  background: '#1B1B1B',
+  paper: '#3A3A3A',
+  blue: '#86B4FF',
+  orange: '#C34F00',
+  red: '#FF7F73',
+  grey: '#A4A4A4',
+};
+
+//For experimenting
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const DARK_MODE_COLOURS_HIGH_CONTRAST: ThemeColours = {
+  primary: '#86B4FF',
   secondary: '#80ACFF',
   background: '#1B1B1B',
   paper: '#3A3A3A',
@@ -143,7 +157,7 @@ export const buildTheme = (darkModePreference: boolean): Theme => {
     },
     MuiBadge: {
       colorPrimary: {
-        backgroundColor: colours.orange,
+        backgroundColor: STATIC_COLOURS.orange,
       },
     },
     MuiInput: {
@@ -172,7 +186,7 @@ export const buildTheme = (darkModePreference: boolean): Theme => {
     },
     MuiPickersToolbar: {
       toolbar: {
-        backgroundColor: '#003088',
+        backgroundColor: STATIC_COLOURS.darkBlue,
       },
     },
     MuiPickersCalendarHeader: {

--- a/src/theming.tsx
+++ b/src/theming.tsx
@@ -5,71 +5,26 @@ import React from 'react';
 import { StateType } from './state/state.types';
 import { connect, useSelector } from 'react-redux';
 
-export interface UKRIThemeOptions extends ThemeOptions {
-  ukri: {
-    bright: {
-      orange: string;
-      yellow: string;
-      green: string;
-      blue: string;
-      purple: string;
-      red: string;
-    };
-    contrast: {
-      orange: string;
-      red: string;
-      grey: string;
-      blue: string;
-    };
-    deep: {
-      orange: string;
-      yellow: string;
-      green: string;
-      blue: string;
-      purple: string;
-      red: string;
-    };
-  };
-  drawerWidth: number;
-  link: {
-    default: string;
-    visited: string;
-    active: string;
-  };
-}
-
-export interface UKRITheme extends Theme {
-  ukri: {
-    bright: {
-      orange: string;
-      yellow: string;
-      green: string;
-      blue: string;
-      purple: string;
-      red: string;
-    };
-    contrast: {
-      orange: string;
-      red: string;
-      grey: string;
-      blue: string;
-    };
-    deep: {
-      orange: string;
-      yellow: string;
-      green: string;
-      blue: string;
-      purple: string;
-      red: string;
-    };
-  };
-  drawerWidth: number;
-  link: {
-    default: string;
-    visited: string;
-    active: string;
-  };
-}
+/* UKRI colours */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const UKRI_COLOURS = {
+  bright: {
+    orange: '#FF6900', // pure orange
+    yellow: '#FBBB10', // yellow
+    green: '#67C04D', // light green
+    blue: '#1E5DF8', // blue
+    purple: '#BE2BBB', // bright purple
+    red: '#E94D36', // light red
+  },
+  deep: {
+    orange: '#C13D33', // pure orange
+    yellow: '#F08900', // vivid yellow
+    green: '#3E863E', // green
+    blue: '#003088', // blue
+    purple: '#8A1A9B', // bright purple
+    red: '#A91B2E', // red
+  },
+};
 
 /* Colours that may be used across light/dark modes e.g. the main app bar */
 const STATIC_COLOURS = {
@@ -79,14 +34,38 @@ const STATIC_COLOURS = {
 
 /* Main colours used for dark/light modes respectively */
 interface ThemeColours {
+  /* Primary/secondary colours used for MUI */
   primary: string;
   secondary: string;
+
+  /* Background colours for the page and papers */
   background: string;
   paper: string;
+
+  /* Standard colours used in plugins (change to lighter/darker shades
+    between light and dark modes) - these are meant to give good contrast
+    for text on the chosen paper background colour */
   blue: string;
   orange: string;
   red: string;
   grey: string;
+
+  /* Lighter colours */
+  lightOrange: string; //Used for notifcation icon
+
+  /* Deeper colours */
+  darkGreen: string; //Used for cookie consent message
+
+  /* Informational/Warning colours */
+  information: string; //Used in open data label
+  warning: string; //Used for selection alert banner
+
+  /* Colours for <a> style links */
+  link: {
+    default: string;
+    visited: string;
+    active: string;
+  };
 }
 
 const DARK_MODE_COLOURS: ThemeColours = {
@@ -98,19 +77,37 @@ const DARK_MODE_COLOURS: ThemeColours = {
   orange: '#C34F00',
   red: '#FF7F73',
   grey: '#A4A4A4',
+  lightOrange: '#FF6900',
+  darkGreen: '#3E863E',
+  information: '#003088',
+  warning: '#FFA500',
+  link: {
+    default: '#257fff',
+    visited: '#BE2BBB',
+    active: '#E94D36',
+  },
 };
 
 //For experimenting
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-const DARK_MODE_COLOURS_HIGH_CONTRAST: ThemeColours = {
+const DARK_MODE_HIGH_CONTRAST_COLOURS: ThemeColours = {
   primary: '#86B4FF',
   secondary: '#80ACFF',
   background: '#1B1B1B',
   paper: '#3A3A3A',
-  blue: '#86B4FF',
+  blue: '#B4CCFA', //Joshua's suggestion
   orange: '#C34F00',
   red: '#FF7F73',
   grey: '#A4A4A4',
+  lightOrange: '#FF6900',
+  darkGreen: '#3E863E',
+  information: '#003088',
+  warning: '#FFA500',
+  link: {
+    default: '#257fff',
+    visited: '#BE2BBB',
+    active: '#E94D36',
+  },
 };
 
 const LIGHT_MODE_COLOURS: ThemeColours = {
@@ -122,7 +119,25 @@ const LIGHT_MODE_COLOURS: ThemeColours = {
   orange: '#C34F00',
   red: '#AC1600',
   grey: '#727272',
+  lightOrange: '#FF6900',
+  darkGreen: '#3E863E',
+  information: '#003088',
+  warning: '#FFA500',
+  link: {
+    default: '#1E5DF8',
+    visited: '#BE2BBB',
+    active: '#E94D36',
+  },
 };
+export interface UKRIThemeOptions extends ThemeOptions {
+  drawerWidth: number;
+  colours: ThemeColours;
+}
+
+export interface UKRITheme extends Theme {
+  drawerWidth: number;
+  colours: ThemeColours;
+}
 
 export const buildTheme = (darkModePreference: boolean): Theme => {
   let options: UKRIThemeOptions;
@@ -252,37 +267,9 @@ export const buildTheme = (darkModePreference: boolean): Theme => {
           paper: colours.paper,
         },
       },
-      ukri: {
-        bright: {
-          orange: '#FF6900', // pure orange
-          yellow: '#FBBB10', // yellow
-          green: '#67C04D', // light green
-          blue: '#1E5DF8', // blue
-          purple: '#BE2BBB', // bright purple
-          red: '#E94D36', // light red
-        },
-        contrast: {
-          orange: colours.orange,
-          red: colours.red,
-          grey: colours.grey,
-          blue: colours.blue,
-        },
-        deep: {
-          orange: '#C13D33', // pure orange
-          yellow: '#F08900', // vivid yellow
-          green: '#3E863E', // green
-          blue: '#003088', // blue
-          purple: '#8A1A9B', // bright purple
-          red: '#A91B2E', // red
-        },
-      },
       drawerWidth: 300,
-      link: {
-        default: '#257fff',
-        visited: '#BE2BBB',
-        active: '#E94D36',
-      },
       overrides: overrides,
+      colours: colours,
     };
   } else {
     options = {
@@ -300,37 +287,9 @@ export const buildTheme = (darkModePreference: boolean): Theme => {
           paper: colours.paper,
         },
       },
-      ukri: {
-        bright: {
-          orange: '#FF6900', // pure orange
-          yellow: '#FBBB10', // yellow
-          green: '#67C04D', // light green
-          blue: '#1E5DF8', // blue
-          purple: '#BE2BBB', // bright purple
-          red: '#E94D36', // light red
-        },
-        contrast: {
-          orange: colours.orange,
-          red: colours.red,
-          grey: colours.grey,
-          blue: colours.blue,
-        },
-        deep: {
-          orange: '#C13D33', // pure orange
-          yellow: '#F08900', // vivid yellow
-          green: '#3E863E', // green
-          blue: '#003088', // blue
-          purple: '#8A1A9B', // bright purple
-          red: '#A91B2E', // red
-        },
-      },
       drawerWidth: 300,
-      link: {
-        default: '#1E5DF8',
-        visited: '#BE2BBB',
-        active: '#E94D36',
-      },
       overrides: overrides,
+      colours: colours,
     };
   }
 

--- a/src/theming.tsx
+++ b/src/theming.tsx
@@ -74,7 +74,7 @@ const DARK_MODE_COLOURS: ThemeColours = {
   background: '#1B1B1B',
   paper: '#3A3A3A',
   blue: '#86B4FF',
-  orange: '#C34F00',
+  orange: '#F26300',
   red: '#FF7F73',
   grey: '#A4A4A4',
   lightOrange: '#FF6900',
@@ -90,7 +90,7 @@ const DARK_MODE_COLOURS: ThemeColours = {
 
 //For experimenting
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-const DARK_MODE_HIGH_CONTRAST_COLOURS: ThemeColours = {
+const DARK_MODE_TEST1: ThemeColours = {
   primary: '#86B4FF',
   secondary: '#80ACFF',
   background: '#1B1B1B',
@@ -104,7 +104,29 @@ const DARK_MODE_HIGH_CONTRAST_COLOURS: ThemeColours = {
   information: '#003088',
   warning: '#FFA500',
   link: {
-    default: '#257fff',
+    default: '#B4CCFA',
+    visited: '#BE2BBB',
+    active: '#E94D36',
+  },
+};
+
+//For experimenting
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const DARK_MODE_HIGH_CONTRAST_COLOURS: ThemeColours = {
+  primary: '#86B4FF',
+  secondary: '#80ACFF',
+  background: '#000000',
+  paper: '#1A1A1A',
+  blue: '#B4CCFA', //Joshua's suggestion
+  orange: '#FFC14D',
+  red: '#FF7F73',
+  grey: '#A4A4A4',
+  lightOrange: '#FFC14D',
+  darkGreen: '#3E863E',
+  information: '#003088',
+  warning: '#FFC14D',
+  link: {
+    default: '#B4CCFA',
     visited: '#BE2BBB',
     active: '#E94D36',
   },
@@ -139,9 +161,15 @@ export interface UKRITheme extends Theme {
   colours: ThemeColours;
 }
 
-export const buildTheme = (darkModePreference: boolean): Theme => {
-  let options: UKRIThemeOptions;
-  const colours = darkModePreference ? DARK_MODE_COLOURS : LIGHT_MODE_COLOURS;
+export const buildTheme = (
+  darkModePreference: boolean,
+  highContrastModePreference?: boolean
+): Theme => {
+  const colours = darkModePreference
+    ? highContrastModePreference
+      ? DARK_MODE_HIGH_CONTRAST_COLOURS
+      : DARK_MODE_COLOURS
+    : LIGHT_MODE_COLOURS;
 
   const overrides = {
     MuiLink: {
@@ -250,48 +278,25 @@ export const buildTheme = (darkModePreference: boolean): Theme => {
       },
     },
   };
-
-  if (darkModePreference) {
-    options = {
-      palette: {
-        // Light/dark mode
-        type: 'dark',
-        primary: {
-          main: colours.primary,
-        },
-        secondary: {
-          main: colours.secondary,
-        },
-        background: {
-          default: colours.background,
-          paper: colours.paper,
-        },
+  const options: UKRIThemeOptions = {
+    palette: {
+      // Light/dark mode
+      type: darkModePreference ? 'dark' : 'light',
+      primary: {
+        main: colours.primary,
       },
-      drawerWidth: 300,
-      overrides: overrides,
-      colours: colours,
-    };
-  } else {
-    options = {
-      palette: {
-        // Light/dark mode
-        type: 'light',
-        primary: {
-          main: colours.primary,
-        },
-        secondary: {
-          main: colours.secondary,
-        },
-        background: {
-          default: colours.background,
-          paper: colours.paper,
-        },
+      secondary: {
+        main: colours.secondary,
       },
-      drawerWidth: 300,
-      overrides: overrides,
-      colours: colours,
-    };
-  }
+      background: {
+        default: colours.background,
+        paper: colours.paper,
+      },
+    },
+    drawerWidth: 300,
+    overrides: overrides,
+    colours: colours,
+  };
 
   return createMuiTheme(options);
 };
@@ -312,8 +317,13 @@ const SciGatewayThemeProvider = (props: {
   const darkModePreference: boolean = useSelector(
     (state: StateType) => state.scigateway.darkMode
   );
+  const highContrastModePreference: boolean = useSelector(
+    (state: StateType) => state.scigateway.highContrastMode
+  );
   return (
-    <MuiThemeProvider theme={buildTheme(darkModePreference)}>
+    <MuiThemeProvider
+      theme={buildTheme(darkModePreference, highContrastModePreference)}
+    >
       {props.children}
     </MuiThemeProvider>
   );

--- a/src/theming.tsx
+++ b/src/theming.tsx
@@ -71,6 +71,12 @@ export interface UKRITheme extends Theme {
   };
 }
 
+/* Colours that may be used across light/dark modes e.g. the main app bar */
+const STATIC_COLOURS = {
+  darkBlue: '#80ACFF',
+};
+
+/* Main colours used for dark/light modes respectively */
 interface ThemeColours {
   primary: string;
   secondary: string;
@@ -116,7 +122,7 @@ export const buildTheme = (darkModePreference: boolean): Theme => {
     },
     MuiTabs: {
       indicator: {
-        color: '#80ACFF',
+        color: STATIC_COLOURS.darkBlue,
         textDecoration: 'underline',
       },
     },
@@ -137,7 +143,7 @@ export const buildTheme = (darkModePreference: boolean): Theme => {
     },
     MuiBadge: {
       colorPrimary: {
-        backgroundColor: '#FF6900',
+        backgroundColor: colours.orange,
       },
     },
     MuiInput: {

--- a/src/theming.tsx
+++ b/src/theming.tsx
@@ -57,6 +57,10 @@ interface ThemeColours {
   darkGreen: string; //Used for cookie consent message
   darkOrange: string; //Used for help tour
 
+  /* Contrast colours that need to change significantly between dark
+     and light modes */
+  contrastGrey: string; //Used for chip colours in cards and filters
+
   /* Informational/Warning colours */
   information: string; //Used in open data label
   warning: string; //Used for selection alert banner
@@ -81,6 +85,7 @@ const DARK_MODE_COLOURS: ThemeColours = {
   lightOrange: '#FF6900',
   darkGreen: '#3E863E',
   darkOrange: STATIC_COLOURS.orange,
+  contrastGrey: '#595959',
   information: '#003088',
   warning: '#FFA500',
   link: {
@@ -102,6 +107,7 @@ const DARK_MODE_HIGH_CONTRAST_COLOURS: ThemeColours = {
   lightOrange: '#FFC14D',
   darkGreen: '#3E863E',
   darkOrange: STATIC_COLOURS.orange,
+  contrastGrey: '#3A3A3A',
   information: '#003088',
   warning: '#FFC14D',
   link: {
@@ -123,6 +129,7 @@ const LIGHT_MODE_COLOURS: ThemeColours = {
   lightOrange: '#FF6900',
   darkGreen: '#3E863E',
   darkOrange: STATIC_COLOURS.orange,
+  contrastGrey: '#E0E0E0',
   information: '#003088',
   warning: '#FFA500',
   link: {
@@ -144,6 +151,7 @@ const LIGHT_MODE_HIGH_CONTRAST_COLOURS: ThemeColours = {
   lightOrange: '#FF6900',
   darkGreen: '#3E863E',
   darkOrange: STATIC_COLOURS.orange,
+  contrastGrey: '#E0E0E0',
   information: '#003088',
   warning: '#FFA500',
   link: {
@@ -229,6 +237,11 @@ export const buildTheme = (
         '&$error': {
           color: colours.red,
         },
+      },
+    },
+    MuiChip: {
+      root: {
+        backgroundColor: colours.contrastGrey,
       },
     },
     MuiPickersToolbar: {

--- a/src/theming.tsx
+++ b/src/theming.tsx
@@ -71,18 +71,43 @@ export interface UKRITheme extends Theme {
   };
 }
 
+interface ThemeColours {
+  primary: string;
+  secondary: string;
+  blue: string;
+  red: string;
+  grey: string;
+}
+
+const DARK_MODE_COLOURS: ThemeColours = {
+  primary: '#003088',
+  secondary: '#80ACFF',
+  blue: '#86B4FF',
+  red: '#FF7F73',
+  grey: '#A4A4A4',
+};
+
+const LIGHT_MODE_COLOURS: ThemeColours = {
+  primary: '#003088',
+  secondary: '#003088',
+  blue: '#003088',
+  red: '#AC1600',
+  grey: '#727272',
+};
+
 export const buildTheme = (darkModePreference: boolean): Theme => {
   let options: UKRIThemeOptions;
+  const colours = darkModePreference ? DARK_MODE_COLOURS : LIGHT_MODE_COLOURS;
   if (darkModePreference) {
     options = {
       palette: {
         // Light/dark mode
         type: 'dark',
         primary: {
-          main: '#003088',
+          main: colours.primary,
         },
         secondary: {
-          main: '#80ACFF',
+          main: colours.secondary,
         },
         background: {
           default: '#1B1B1B',
@@ -100,9 +125,9 @@ export const buildTheme = (darkModePreference: boolean): Theme => {
         },
         contrast: {
           orange: '#C34F00',
-          red: '#FF7F73',
-          grey: '#A4A4A4',
-          blue: '#86B4FF',
+          red: colours.red,
+          grey: colours.grey,
+          blue: colours.blue,
         },
         deep: {
           orange: '#C13D33', // pure orange
@@ -122,7 +147,7 @@ export const buildTheme = (darkModePreference: boolean): Theme => {
       overrides: {
         MuiLink: {
           root: {
-            color: '#86B4FF',
+            color: colours.blue,
           },
         },
         MuiTabs: {
@@ -134,15 +159,15 @@ export const buildTheme = (darkModePreference: boolean): Theme => {
         MuiFormLabel: {
           root: {
             '&$error': {
-              color: '#FF7F73',
+              color: colours.red,
             },
             '&$focused': {
-              color: '#86B4FF',
+              color: colours.blue,
             },
           },
           asterisk: {
             '&$error': {
-              color: '#FF7F73',
+              color: colours.red,
             },
           },
         },
@@ -154,24 +179,24 @@ export const buildTheme = (darkModePreference: boolean): Theme => {
         MuiInput: {
           underline: {
             '&$error:after': {
-              borderBottomColor: '#FF7F73',
+              borderBottomColor: colours.red,
             },
             '&:after': {
-              borderBottomColor: '#86B4FF',
+              borderBottomColor: colours.blue,
             },
           },
         },
         MuiOutlinedInput: {
           root: {
             '&$error $notchedOutline': {
-              borderColor: '#FF7F73',
+              borderColor: colours.red,
             },
           },
         },
         MuiFormHelperText: {
           root: {
             '&$error': {
-              color: '#FF7F73',
+              color: colours.red,
             },
           },
         },
@@ -182,47 +207,47 @@ export const buildTheme = (darkModePreference: boolean): Theme => {
         },
         MuiPickersCalendarHeader: {
           dayLabel: {
-            color: 'A4A4A4',
+            color: colours.grey,
           },
         },
         MuiPickersDay: {
           current: {
-            color: '#86B4FF',
+            color: colours.blue,
           },
           dayDisabled: {
-            color: '#A4A4A4',
+            color: colours.grey,
           },
         },
         MuiPickersYear: {
           root: {
             '&:active': {
-              color: '#86B4FF',
+              color: colours.blue,
             },
             '&:focus': {
-              color: '#86B4FF',
+              color: colours.blue,
             },
           },
           yearSelected: {
-            color: '#86B4FF',
+            color: colours.blue,
           },
           yearDisabled: {
-            color: '#A4A4A4',
+            color: colours.grey,
           },
         },
         MuiPickersMonth: {
           root: {
             '&:active': {
-              color: '#86B4FF',
+              color: colours.blue,
             },
             '&:focus': {
-              color: '#86B4FF',
+              color: colours.blue,
             },
           },
           monthSelected: {
             color: '#86B4FF',
           },
           monthDisabled: {
-            color: '#A4A4A4',
+            color: colours.grey,
           },
         },
       },
@@ -233,10 +258,10 @@ export const buildTheme = (darkModePreference: boolean): Theme => {
         // Light/dark mode
         type: 'light',
         primary: {
-          main: '#003088', // blue (deep palette)
+          main: colours.primary, // blue (deep palette)
         },
         secondary: {
-          main: '#003088',
+          main: colours.secondary,
         },
       },
       ukri: {
@@ -250,9 +275,9 @@ export const buildTheme = (darkModePreference: boolean): Theme => {
         },
         contrast: {
           orange: '#C34F00',
-          red: '#AC1600',
-          grey: '#727272',
-          blue: '#003088',
+          red: colours.red,
+          grey: colours.grey,
+          blue: colours.blue,
         },
         deep: {
           orange: '#C13D33', // pure orange
@@ -273,12 +298,12 @@ export const buildTheme = (darkModePreference: boolean): Theme => {
         MuiFormLabel: {
           root: {
             '&$error': {
-              color: '#AC1600',
+              color: colours.red,
             },
           },
           asterisk: {
             '&$error': {
-              color: '#AC1600',
+              color: colours.red,
             },
           },
         },
@@ -295,42 +320,42 @@ export const buildTheme = (darkModePreference: boolean): Theme => {
         MuiInput: {
           underline: {
             '&$error:after': {
-              borderBottomColor: '#AC1600',
+              borderBottomColor: colours.red,
             },
           },
         },
         MuiOutlinedInput: {
           root: {
             '&$error $notchedOutline': {
-              borderColor: '#AC1600',
+              borderColor: colours.red,
             },
           },
         },
         MuiFormHelperText: {
           root: {
             '&$error': {
-              color: '#AC1600',
+              color: colours.red,
             },
           },
         },
         MuiPickersCalendarHeader: {
           dayLabel: {
-            color: '#727272',
+            color: colours.grey,
           },
         },
         MuiPickersDay: {
           dayDisabled: {
-            color: '#727272',
+            color: colours.grey,
           },
         },
         MuiPickersYear: {
           yearDisabled: {
-            color: '#727272',
+            color: colours.grey,
           },
         },
         MuiPickersMonth: {
           monthDisabled: {
-            color: '#727272',
+            color: colours.grey,
           },
         },
       },

--- a/src/theming.tsx
+++ b/src/theming.tsx
@@ -74,7 +74,10 @@ export interface UKRITheme extends Theme {
 interface ThemeColours {
   primary: string;
   secondary: string;
+  background: string;
+  paper: string;
   blue: string;
+  orange: string;
   red: string;
   grey: string;
 }
@@ -82,7 +85,10 @@ interface ThemeColours {
 const DARK_MODE_COLOURS: ThemeColours = {
   primary: '#003088',
   secondary: '#80ACFF',
+  background: '#1B1B1B',
+  paper: '#3A3A3A',
   blue: '#86B4FF',
+  orange: '#C34F00',
   red: '#FF7F73',
   grey: '#A4A4A4',
 };
@@ -90,7 +96,10 @@ const DARK_MODE_COLOURS: ThemeColours = {
 const LIGHT_MODE_COLOURS: ThemeColours = {
   primary: '#003088',
   secondary: '#003088',
+  background: '#FAFAFA',
+  paper: '#FFF',
   blue: '#003088',
+  orange: '#C34F00',
   red: '#AC1600',
   grey: '#727272',
 };
@@ -98,6 +107,115 @@ const LIGHT_MODE_COLOURS: ThemeColours = {
 export const buildTheme = (darkModePreference: boolean): Theme => {
   let options: UKRIThemeOptions;
   const colours = darkModePreference ? DARK_MODE_COLOURS : LIGHT_MODE_COLOURS;
+
+  const overrides = {
+    MuiLink: {
+      root: {
+        color: colours.blue,
+      },
+    },
+    MuiTabs: {
+      indicator: {
+        color: '#80ACFF',
+        textDecoration: 'underline',
+      },
+    },
+    MuiFormLabel: {
+      root: {
+        '&$error': {
+          color: colours.red,
+        },
+        '&$focused': {
+          color: colours.blue,
+        },
+      },
+      asterisk: {
+        '&$error': {
+          color: colours.red,
+        },
+      },
+    },
+    MuiBadge: {
+      colorPrimary: {
+        backgroundColor: '#FF6900',
+      },
+    },
+    MuiInput: {
+      underline: {
+        '&$error:after': {
+          borderBottomColor: colours.red,
+        },
+        '&:after': {
+          borderBottomColor: colours.blue,
+        },
+      },
+    },
+    MuiOutlinedInput: {
+      root: {
+        '&$error $notchedOutline': {
+          borderColor: colours.red,
+        },
+      },
+    },
+    MuiFormHelperText: {
+      root: {
+        '&$error': {
+          color: colours.red,
+        },
+      },
+    },
+    MuiPickersToolbar: {
+      toolbar: {
+        backgroundColor: '#003088',
+      },
+    },
+    MuiPickersCalendarHeader: {
+      dayLabel: {
+        color: colours.grey,
+      },
+    },
+    MuiPickersDay: {
+      current: {
+        color: colours.blue,
+      },
+      dayDisabled: {
+        color: colours.grey,
+      },
+    },
+    MuiPickersYear: {
+      root: {
+        '&:active': {
+          color: colours.blue,
+        },
+        '&:focus': {
+          color: colours.blue,
+        },
+      },
+      yearSelected: {
+        color: colours.blue,
+      },
+      yearDisabled: {
+        color: colours.grey,
+      },
+    },
+    MuiPickersMonth: {
+      root: {
+        '&:active': {
+          color: colours.blue,
+        },
+        '&:focus': {
+          color: colours.blue,
+        },
+      },
+      monthSelected: {
+        color: colours.blue,
+      },
+      monthDisabled: {
+        color: colours.grey,
+      },
+    },
+  };
+
   if (darkModePreference) {
     options = {
       palette: {
@@ -110,8 +228,8 @@ export const buildTheme = (darkModePreference: boolean): Theme => {
           main: colours.secondary,
         },
         background: {
-          default: '#1B1B1B',
-          paper: '#3A3A3A',
+          default: colours.background,
+          paper: colours.paper,
         },
       },
       ukri: {
@@ -124,7 +242,7 @@ export const buildTheme = (darkModePreference: boolean): Theme => {
           red: '#E94D36', // light red
         },
         contrast: {
-          orange: '#C34F00',
+          orange: colours.orange,
           red: colours.red,
           grey: colours.grey,
           blue: colours.blue,
@@ -144,113 +262,7 @@ export const buildTheme = (darkModePreference: boolean): Theme => {
         visited: '#BE2BBB',
         active: '#E94D36',
       },
-      overrides: {
-        MuiLink: {
-          root: {
-            color: colours.blue,
-          },
-        },
-        MuiTabs: {
-          indicator: {
-            color: '#80ACFF',
-            textDecoration: 'underline',
-          },
-        },
-        MuiFormLabel: {
-          root: {
-            '&$error': {
-              color: colours.red,
-            },
-            '&$focused': {
-              color: colours.blue,
-            },
-          },
-          asterisk: {
-            '&$error': {
-              color: colours.red,
-            },
-          },
-        },
-        MuiBadge: {
-          colorPrimary: {
-            backgroundColor: '#FF6900',
-          },
-        },
-        MuiInput: {
-          underline: {
-            '&$error:after': {
-              borderBottomColor: colours.red,
-            },
-            '&:after': {
-              borderBottomColor: colours.blue,
-            },
-          },
-        },
-        MuiOutlinedInput: {
-          root: {
-            '&$error $notchedOutline': {
-              borderColor: colours.red,
-            },
-          },
-        },
-        MuiFormHelperText: {
-          root: {
-            '&$error': {
-              color: colours.red,
-            },
-          },
-        },
-        MuiPickersToolbar: {
-          toolbar: {
-            backgroundColor: '#003088',
-          },
-        },
-        MuiPickersCalendarHeader: {
-          dayLabel: {
-            color: colours.grey,
-          },
-        },
-        MuiPickersDay: {
-          current: {
-            color: colours.blue,
-          },
-          dayDisabled: {
-            color: colours.grey,
-          },
-        },
-        MuiPickersYear: {
-          root: {
-            '&:active': {
-              color: colours.blue,
-            },
-            '&:focus': {
-              color: colours.blue,
-            },
-          },
-          yearSelected: {
-            color: colours.blue,
-          },
-          yearDisabled: {
-            color: colours.grey,
-          },
-        },
-        MuiPickersMonth: {
-          root: {
-            '&:active': {
-              color: colours.blue,
-            },
-            '&:focus': {
-              color: colours.blue,
-            },
-          },
-          monthSelected: {
-            color: '#86B4FF',
-          },
-          monthDisabled: {
-            color: colours.grey,
-          },
-        },
-      },
+      overrides: overrides,
     };
   } else {
     options = {
@@ -258,10 +270,14 @@ export const buildTheme = (darkModePreference: boolean): Theme => {
         // Light/dark mode
         type: 'light',
         primary: {
-          main: colours.primary, // blue (deep palette)
+          main: colours.primary,
         },
         secondary: {
           main: colours.secondary,
+        },
+        background: {
+          default: colours.background,
+          paper: colours.paper,
         },
       },
       ukri: {
@@ -274,7 +290,7 @@ export const buildTheme = (darkModePreference: boolean): Theme => {
           red: '#E94D36', // light red
         },
         contrast: {
-          orange: '#C34F00',
+          orange: colours.orange,
           red: colours.red,
           grey: colours.grey,
           blue: colours.blue,
@@ -294,71 +310,7 @@ export const buildTheme = (darkModePreference: boolean): Theme => {
         visited: '#BE2BBB',
         active: '#E94D36',
       },
-      overrides: {
-        MuiFormLabel: {
-          root: {
-            '&$error': {
-              color: colours.red,
-            },
-          },
-          asterisk: {
-            '&$error': {
-              color: colours.red,
-            },
-          },
-        },
-        MuiBadge: {
-          colorPrimary: {
-            backgroundColor: '#FF6900',
-          },
-        },
-        MuiPickersToolbar: {
-          toolbar: {
-            backgroundColor: '#003088',
-          },
-        },
-        MuiInput: {
-          underline: {
-            '&$error:after': {
-              borderBottomColor: colours.red,
-            },
-          },
-        },
-        MuiOutlinedInput: {
-          root: {
-            '&$error $notchedOutline': {
-              borderColor: colours.red,
-            },
-          },
-        },
-        MuiFormHelperText: {
-          root: {
-            '&$error': {
-              color: colours.red,
-            },
-          },
-        },
-        MuiPickersCalendarHeader: {
-          dayLabel: {
-            color: colours.grey,
-          },
-        },
-        MuiPickersDay: {
-          dayDisabled: {
-            color: colours.grey,
-          },
-        },
-        MuiPickersYear: {
-          yearDisabled: {
-            color: colours.grey,
-          },
-        },
-        MuiPickersMonth: {
-          monthDisabled: {
-            color: colours.grey,
-          },
-        },
-      },
+      overrides: overrides,
     };
   }
 

--- a/src/theming.tsx
+++ b/src/theming.tsx
@@ -29,7 +29,7 @@ const UKRI_COLOURS = {
 /* Colours that may be used across light/dark modes e.g. the main app bar */
 const STATIC_COLOURS = {
   darkBlue: '#003088',
-  orange: '#FF6900',
+  orange: '#C34F00',
 };
 
 /* Main colours used for dark/light modes respectively */
@@ -53,8 +53,9 @@ interface ThemeColours {
   /* Lighter colours */
   lightOrange: string; //Used for notifcation icon
 
-  /* Deeper colours */
+  /* Darker colours */
   darkGreen: string; //Used for cookie consent message
+  darkOrange: string; //Used for help tour
 
   /* Informational/Warning colours */
   information: string; //Used in open data label
@@ -79,39 +80,16 @@ const DARK_MODE_COLOURS: ThemeColours = {
   grey: '#A4A4A4',
   lightOrange: '#FF6900',
   darkGreen: '#3E863E',
+  darkOrange: STATIC_COLOURS.orange,
   information: '#003088',
   warning: '#FFA500',
   link: {
-    default: '#257fff',
+    default: '#86B4FF',
     visited: '#BE2BBB',
     active: '#E94D36',
   },
 };
 
-//For experimenting
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const DARK_MODE_TEST1: ThemeColours = {
-  primary: '#86B4FF',
-  secondary: '#80ACFF',
-  background: '#1B1B1B',
-  paper: '#3A3A3A',
-  blue: '#B4CCFA', //Joshua's suggestion
-  orange: '#C34F00',
-  red: '#FF7F73',
-  grey: '#A4A4A4',
-  lightOrange: '#FF6900',
-  darkGreen: '#3E863E',
-  information: '#003088',
-  warning: '#FFA500',
-  link: {
-    default: '#B4CCFA',
-    visited: '#BE2BBB',
-    active: '#E94D36',
-  },
-};
-
-//For experimenting
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const DARK_MODE_HIGH_CONTRAST_COLOURS: ThemeColours = {
   primary: '#86B4FF',
   secondary: '#80ACFF',
@@ -119,10 +97,11 @@ const DARK_MODE_HIGH_CONTRAST_COLOURS: ThemeColours = {
   paper: '#1A1A1A',
   blue: '#B4CCFA', //Joshua's suggestion
   orange: '#FFC14D',
-  red: '#FF7F73',
+  red: '#FFA198',
   grey: '#A4A4A4',
   lightOrange: '#FFC14D',
   darkGreen: '#3E863E',
+  darkOrange: STATIC_COLOURS.orange,
   information: '#003088',
   warning: '#FFC14D',
   link: {
@@ -143,6 +122,7 @@ const LIGHT_MODE_COLOURS: ThemeColours = {
   grey: '#727272',
   lightOrange: '#FF6900',
   darkGreen: '#3E863E',
+  darkOrange: STATIC_COLOURS.orange,
   information: '#003088',
   warning: '#FFA500',
   link: {
@@ -157,16 +137,17 @@ const LIGHT_MODE_HIGH_CONTRAST_COLOURS: ThemeColours = {
   secondary: '#003088',
   background: '#FAFAFA',
   paper: '#FFF',
-  blue: '#003088',
+  blue: '#002466',
   orange: '#C34F00',
-  red: '#AC1600',
+  red: '#801100',
   grey: '#727272',
   lightOrange: '#FF6900',
   darkGreen: '#3E863E',
+  darkOrange: STATIC_COLOURS.orange,
   information: '#003088',
   warning: '#FFA500',
   link: {
-    default: '#1E5DF8',
+    default: '#052d94',
     visited: '#BE2BBB',
     active: '#E94D36',
   },
@@ -223,6 +204,7 @@ export const buildTheme = (
     MuiBadge: {
       colorPrimary: {
         backgroundColor: STATIC_COLOURS.orange,
+        color: 'white',
       },
     },
     MuiInput: {
@@ -251,7 +233,7 @@ export const buildTheme = (
     },
     MuiPickersToolbar: {
       toolbar: {
-        backgroundColor: STATIC_COLOURS.darkBlue,
+        backgroundColor: colours.primary,
       },
     },
     MuiPickersCalendarHeader: {
@@ -300,25 +282,51 @@ export const buildTheme = (
       },
     },
   };
-  const options: UKRIThemeOptions = {
-    palette: {
-      // Light/dark mode
-      type: darkModePreference ? 'dark' : 'light',
-      primary: {
-        main: colours.primary,
+  let options: UKRIThemeOptions;
+  if (!darkModePreference && highContrastModePreference) {
+    options = {
+      palette: {
+        // Light/dark mode
+        type: darkModePreference ? 'dark' : 'light',
+        primary: {
+          main: colours.primary,
+        },
+        secondary: {
+          main: colours.secondary,
+        },
+        text: {
+          secondary: '#000000',
+        },
+        background: {
+          default: colours.background,
+          paper: colours.paper,
+        },
       },
-      secondary: {
-        main: colours.secondary,
+      drawerWidth: 300,
+      overrides: overrides,
+      colours: colours,
+    };
+  } else {
+    options = {
+      palette: {
+        // Light/dark mode
+        type: darkModePreference ? 'dark' : 'light',
+        primary: {
+          main: colours.primary,
+        },
+        secondary: {
+          main: colours.secondary,
+        },
+        background: {
+          default: colours.background,
+          paper: colours.paper,
+        },
       },
-      background: {
-        default: colours.background,
-        paper: colours.paper,
-      },
-    },
-    drawerWidth: 300,
-    overrides: overrides,
-    colours: colours,
-  };
+      drawerWidth: 300,
+      overrides: overrides,
+      colours: colours,
+    };
+  }
 
   return createMuiTheme(options);
 };

--- a/src/tour/__snapshots__/tour.component.test.tsx.snap
+++ b/src/tour/__snapshots__/tour.component.test.tsx.snap
@@ -41,8 +41,8 @@ exports[`Tour component renders correctly 1`] = `
         "color": "#C34F00",
       },
       "options": Object {
-        "arrowColor": "#fafafa",
-        "backgroundColor": "#fafafa",
+        "arrowColor": "#FAFAFA",
+        "backgroundColor": "#FAFAFA",
         "primaryColor": "#C34F00",
         "textColor": "rgba(0, 0, 0, 0.87)",
         "zIndex": 1500,
@@ -90,7 +90,7 @@ exports[`Tour component renders correctly in dark mode 1`] = `
   styles={
     Object {
       "buttonBack": Object {
-        "color": "rgb(204, 105, 38)",
+        "color": "rgb(243, 122, 38)",
       },
       "options": Object {
         "arrowColor": "#1B1B1B",

--- a/src/tour/tour.component.tsx
+++ b/src/tour/tour.component.tsx
@@ -120,14 +120,14 @@ class Tour extends React.Component<CombinedTourProps, TourState> {
         styles={{
           buttonBack: {
             color:
-              //For WCAG 2.0 contrast, need dark mode colour be slighly lighter as
+              //For WCAG 2.1 contrast, need dark mode colour be slighly lighter as
               //same colour breaks contrast for next button
               theme.palette.type === 'dark'
-                ? lighten((theme as UKRITheme).ukri.contrast.orange, 0.15)
-                : (theme as UKRITheme).ukri.contrast.orange,
+                ? lighten((theme as UKRITheme).colours.orange, 0.15)
+                : (theme as UKRITheme).colours.orange,
           },
           options: {
-            primaryColor: (theme as UKRITheme).ukri.contrast.orange,
+            primaryColor: (theme as UKRITheme).colours.orange,
             backgroundColor: theme.palette.background.default,
             arrowColor: theme.palette.background.default,
             textColor: theme.palette.text.primary,

--- a/src/tour/tour.component.tsx
+++ b/src/tour/tour.component.tsx
@@ -127,7 +127,7 @@ class Tour extends React.Component<CombinedTourProps, TourState> {
                 : (theme as UKRITheme).colours.orange,
           },
           options: {
-            primaryColor: (theme as UKRITheme).colours.orange,
+            primaryColor: (theme as UKRITheme).colours.darkOrange,
             backgroundColor: theme.palette.background.default,
             arrowColor: theme.palette.background.default,
             textColor: theme.palette.text.primary,


### PR DESCRIPTION
## Description
Improves customisability of theme colours and adds high contrast settings that can be toggled using a button under the dark mode toggle. This requires PR https://github.com/ral-facilities/datagateway/pull/926.

![image](https://user-images.githubusercontent.com/90245114/141824626-555509c6-947e-46e7-bcba-efeffb702120.png)

High contrast dark mode example:
![image](https://user-images.githubusercontent.com/90245114/141824706-18ffc675-3e30-4db8-bd53-469cd71b7dc7.png)



## Testing instructions

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
Closes #818