### PR TITLE
Broadcast signout action when user signs out

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,7 +34,7 @@ const history = createBrowserHistory();
 const middleware = [thunk, routerMiddleware(history), ScigatewayMiddleware];
 if (process.env.NODE_ENV === `development`) {
   /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-  const logger = (createLogger as any)();
+  const logger = (createLogger as any)({ collapsed: true });
   middleware.push(logger);
   // const {whyDidYouUpdate} = require('why-did-you-update');
   // whyDidYouUpdate(React);

--- a/src/authentication/baseAuthProvider.tsx
+++ b/src/authentication/baseAuthProvider.tsx
@@ -1,7 +1,7 @@
 import { AuthProvider, User } from '../state/state.types';
 import UserInfo from './user';
 import parseJwt from '../authentication/parseJwt';
-import { SignOutType } from '../state/scigateway.types';
+import { BroadcastSignOutType } from '../state/scigateway.types';
 
 const tokenLocalStorageName = 'scigateway:token';
 
@@ -59,7 +59,7 @@ export default abstract class BaseAuthProvider implements AuthProvider {
     this.token = null;
     this.user = null;
     document.dispatchEvent(
-      new CustomEvent('scigateway', { detail: { type: SignOutType } })
+      new CustomEvent('scigateway', { detail: { type: BroadcastSignOutType } })
     );
   }
 

--- a/src/authentication/baseAuthProvider.tsx
+++ b/src/authentication/baseAuthProvider.tsx
@@ -1,6 +1,7 @@
 import { AuthProvider, User } from '../state/state.types';
 import UserInfo from './user';
 import parseJwt from '../authentication/parseJwt';
+import { SignOutType } from '../state/scigateway.types';
 
 const tokenLocalStorageName = 'scigateway:token';
 
@@ -57,6 +58,9 @@ export default abstract class BaseAuthProvider implements AuthProvider {
     localStorage.removeItem(tokenLocalStorageName);
     this.token = null;
     this.user = null;
+    document.dispatchEvent(
+      new CustomEvent('scigateway', { detail: { type: SignOutType } })
+    );
   }
 
   protected storeToken(token: string): void {

--- a/src/authentication/icatAuthProvider.test.tsx
+++ b/src/authentication/icatAuthProvider.test.tsx
@@ -2,7 +2,7 @@ import mockAxios from 'axios';
 import ICATAuthProvider from './icatAuthProvider';
 import ReactGA from 'react-ga';
 import parseJwt from './parseJwt';
-import { SignOutType } from '../state/scigateway.types';
+import { BroadcastSignOutType } from '../state/scigateway.types';
 
 jest.mock('./parseJwt');
 
@@ -63,7 +63,7 @@ describe('ICAT auth provider', () => {
     expect(
       (document.dispatchEvent as jest.Mock).mock.calls[0][0].detail
     ).toEqual({
-      type: SignOutType,
+      type: BroadcastSignOutType,
     });
   });
 
@@ -96,7 +96,7 @@ describe('ICAT auth provider', () => {
     expect(
       (document.dispatchEvent as jest.Mock).mock.calls[0][0].detail
     ).toEqual({
-      type: SignOutType,
+      type: BroadcastSignOutType,
     });
 
     expect(mockAxios.post).toHaveBeenCalledWith('http://localhost:8000/login', {

--- a/src/authentication/icatAuthProvider.test.tsx
+++ b/src/authentication/icatAuthProvider.test.tsx
@@ -2,6 +2,7 @@ import mockAxios from 'axios';
 import ICATAuthProvider from './icatAuthProvider';
 import ReactGA from 'react-ga';
 import parseJwt from './parseJwt';
+import { SignOutType } from '../state/scigateway.types';
 
 jest.mock('./parseJwt');
 
@@ -34,6 +35,8 @@ describe('ICAT auth provider', () => {
       (token) =>
         `{"sessionId": "${token}", "username": "${token} username", "userIsAdmin": true}`
     );
+
+    document.dispatchEvent = jest.fn();
   });
 
   afterEach(() => {
@@ -51,15 +54,59 @@ describe('ICAT auth provider', () => {
     expect(icatAuthProvider.isLoggedIn()).toBeTruthy();
   });
 
-  it('should clear the token when logging out', () => {
+  it('should clear the token & broadcast signout action when logging out', () => {
     icatAuthProvider.logOut();
 
     expect(localStorage.removeItem).toBeCalledWith('scigateway:token');
     expect(icatAuthProvider.isLoggedIn()).toBeFalsy();
+    expect(document.dispatchEvent).toHaveBeenCalled();
+    expect(
+      (document.dispatchEvent as jest.Mock).mock.calls[0][0].detail
+    ).toEqual({
+      type: SignOutType,
+    });
   });
 
   it('should successfully log in if user is already logged in', () => {
     return icatAuthProvider.logIn('user', 'password');
+  });
+
+  it('should successfully log in if user is already logged in via autoLogin', async () => {
+    (mockAxios.post as jest.Mock).mockImplementation(() =>
+      Promise.resolve({
+        data: testToken,
+      })
+    );
+    window.localStorage.__proto__.getItem = jest
+      .fn()
+      .mockImplementation((name) => {
+        if (name === 'scigateway:token') {
+          return testToken;
+        } else if (name === 'autoLogin') {
+          return 'true';
+        } else {
+          return null;
+        }
+      });
+
+    await icatAuthProvider.logIn('user', 'password');
+
+    // should send sign out action for autologin logout
+    expect(document.dispatchEvent).toHaveBeenCalled();
+    expect(
+      (document.dispatchEvent as jest.Mock).mock.calls[0][0].detail
+    ).toEqual({
+      type: SignOutType,
+    });
+
+    expect(mockAxios.post).toHaveBeenCalledWith('http://localhost:8000/login', {
+      mnemonic: 'mnemonic',
+      credentials: { username: 'user', password: 'password' },
+    });
+    expect(localStorage.setItem).toBeCalledWith('scigateway:token', testToken);
+    expect(localStorage.setItem).toBeCalledWith('autoLogin', 'false');
+
+    expect(icatAuthProvider.isLoggedIn()).toBeTruthy();
   });
 
   it('should call the api to authenticate', async () => {

--- a/src/authentication/icatAuthProvider.tsx
+++ b/src/authentication/icatAuthProvider.tsx
@@ -48,6 +48,9 @@ export default class ICATAuthProvider extends BaseAuthProvider {
           category: 'Login',
           action: 'Successfully logged in via JWT',
         });
+        if (this.isLoggedIn() && localStorage.getItem('autoLogin') === 'true') {
+          this.logOut();
+        }
         this.storeToken(res.data);
         localStorage.setItem('autoLogin', 'false');
         const payload: {

--- a/src/state/middleware/scigateway.middleware.test.tsx
+++ b/src/state/middleware/scigateway.middleware.test.tsx
@@ -9,7 +9,7 @@ import {
   ToggleDrawerType,
   LoadDarkModePreferenceType,
   SendThemeOptionsType,
-  SignOutType,
+  BroadcastSignOutType,
   LoadHighContrastModePreferenceType,
 } from '../scigateway.types';
 import { toastr } from 'react-redux-toastr';
@@ -76,7 +76,7 @@ describe('scigateway middleware', () => {
   };
 
   const signOutAction = {
-    type: SignOutType,
+    type: BroadcastSignOutType,
   };
 
   const loadHighContrastModePreferenceAction = {
@@ -570,9 +570,9 @@ describe('scigateway middleware', () => {
     expect(mockLog.calls.length).toBe(0);
   });
 
-  it('should ignore SignOut broadcasts', () => {
-    log.error = jest.fn();
-    const mockLog = (log.error as jest.Mock).mock;
+  it('should ignore BroadcastSignOut ', () => {
+    log.warn = jest.fn();
+    const mockLog = (log.warn as jest.Mock).mock;
 
     listenToPlugins(store.dispatch, getState);
     expect(document.addEventListener).toHaveBeenCalled();

--- a/src/state/middleware/scigateway.middleware.test.tsx
+++ b/src/state/middleware/scigateway.middleware.test.tsx
@@ -9,6 +9,7 @@ import {
   ToggleDrawerType,
   LoadDarkModePreferenceType,
   SendThemeOptionsType,
+  SignOutType,
 } from '../scigateway.types';
 import { toastr } from 'react-redux-toastr';
 import { AddHelpTourStepsType } from '../scigateway.types';
@@ -71,6 +72,10 @@ describe('scigateway middleware', () => {
     payload: {
       darkMode: false,
     },
+  };
+
+  const signOutAction = {
+    type: SignOutType,
   };
 
   beforeEach(() => {
@@ -500,6 +505,17 @@ describe('scigateway middleware', () => {
     handler(new CustomEvent('test', { detail: requestPluginRerenderAction }));
     expect(document.addEventListener).toHaveBeenCalled();
     expect(store.getActions().length).toEqual(1);
+    expect(mockLog.calls.length).toBe(0);
+  });
+
+  it('should ignore SignOut broadcasts', () => {
+    log.error = jest.fn();
+    const mockLog = (log.error as jest.Mock).mock;
+
+    listenToPlugins(store.dispatch, getState);
+    expect(document.addEventListener).toHaveBeenCalled();
+
+    handler(new CustomEvent('test', { detail: signOutAction }));
     expect(mockLog.calls.length).toBe(0);
   });
 

--- a/src/state/middleware/scigateway.middleware.tsx
+++ b/src/state/middleware/scigateway.middleware.tsx
@@ -7,6 +7,7 @@ import {
   ToggleDrawerType,
   SendThemeOptionsType,
   LoadDarkModePreferenceType,
+  SignOutType,
 } from '../scigateway.types';
 import log from 'loglevel';
 import { toastr } from 'react-redux-toastr';
@@ -70,6 +71,7 @@ export const listenToPlugins = (
   document.addEventListener(microFrontendMessageId, (event) => {
     const pluginMessage = event as microFrontendMessageType;
 
+    if (pluginMessage?.detail?.type === SignOutType) return;
     if (
       pluginMessage.detail &&
       pluginMessage.detail.type &&

--- a/src/state/middleware/scigateway.middleware.tsx
+++ b/src/state/middleware/scigateway.middleware.tsx
@@ -7,7 +7,7 @@ import {
   ToggleDrawerType,
   SendThemeOptionsType,
   LoadDarkModePreferenceType,
-  SignOutType,
+  BroadcastSignOutType,
   LoadHighContrastModePreferenceType,
 } from '../scigateway.types';
 import log from 'loglevel';
@@ -72,7 +72,6 @@ export const listenToPlugins = (
   document.addEventListener(microFrontendMessageId, (event) => {
     const pluginMessage = event as microFrontendMessageType;
 
-    if (pluginMessage?.detail?.type === SignOutType) return;
     if (
       pluginMessage.detail &&
       pluginMessage.detail.type &&
@@ -85,6 +84,9 @@ export const listenToPlugins = (
           break;
 
         case SendThemeOptionsType:
+          break;
+
+        case BroadcastSignOutType:
           break;
 
         case RegisterRouteType:

--- a/src/state/scigateway.types.tsx
+++ b/src/state/scigateway.types.tsx
@@ -21,6 +21,7 @@ export const LoadDarkModePreferenceType =
 export const LoadHighContrastModePreferenceType =
   'scigateway:load_high_contrast_mode_preference';
 export const SignOutType = 'scigateway:signout';
+export const BroadcastSignOutType = 'scigateway:api:signout';
 export const ToggleDrawerType = 'scigateway:toggledrawer';
 export const DismissNotificationType = 'scigateway:dismissnotification';
 export const ConfigureFeatureSwitchesType = 'scigateway:feature_switches';


### PR DESCRIPTION
## Description

This is so plugins can listen to this and perform actions such as cache invalidation.

## Testing instructions
If you want to test this, you need to login as two users with different data. I can show some gifs/do a demo of the different behaviours when using two users on DLS preprod data.

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
This is required by ral-facilities/datagateway#928