### PR TITLE
Use react-router links and remove unnecessary aria labels on homepage

### DIFF
--- a/public/res/default.json
+++ b/public/res/default.json
@@ -31,29 +31,25 @@
       "description1": "SciGateway is a ReactJs based parent application within a micro-front end architecture. It provides access to large facilities science.",
       "description2": "The <0>SciGateway</0> application offers features such as authentication and authorisation functionality, notifications, cookies management.",
       "link": "/browse/investigation",
-      "button": "Browse data",
-      "button_arialabel": "Browse data"
+      "button": "Browse data"
     },
     "search": {
       "title": "Search",
       "description": "Search for the experimental data according to different criteria.",
       "link": "/search",
-      "button": "Search data",
-      "button_arialabel": "Search data"
+      "button": "Search data"
     },
     "download": {
       "title": "Download",
       "description": "Retrieve the experimental data using a variety of download methods.",
       "link": "/download",
-      "button": "Download data",
-      "button_arialabel": "Download data"
+      "button": "Download data"
     },
     "facility": {
       "title": "Facility Title",
       "description": "Facility Description",
       "link": "#",
-      "button": "Read more",
-      "button_arialabel": "Read more"
+      "button": "Read more"
     }
   },
   "contact-page": {

--- a/src/homePage/__snapshots__/homePage.component.test.tsx.snap
+++ b/src/homePage/__snapshots__/homePage.component.test.tsx.snap
@@ -104,9 +104,23 @@ exports[`Home page component homepage renders correctly 1`] = `
               marginTop="auto"
             >
               <WithStyles(ForwardRef(Button))
-                aria-label="home-page.browse.button_arialabel"
                 color="primary"
-                href="home-page.browse.link"
+                component={
+                  Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "displayName": "Link",
+                    "propTypes": Object {
+                      "innerRef": [Function],
+                      "onClick": [Function],
+                      "replace": [Function],
+                      "target": [Function],
+                      "to": [Function],
+                    },
+                    "render": [Function],
+                  }
+                }
+                data-testid="browse-button"
+                to="home-page.browse.link"
                 variant="contained"
               >
                 home-page.browse.button
@@ -167,9 +181,23 @@ exports[`Home page component homepage renders correctly 1`] = `
               marginTop="auto"
             >
               <WithStyles(ForwardRef(Button))
-                aria-label="home-page.search.button_arialabel"
                 color="primary"
-                href="home-page.search.link"
+                component={
+                  Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "displayName": "Link",
+                    "propTypes": Object {
+                      "innerRef": [Function],
+                      "onClick": [Function],
+                      "replace": [Function],
+                      "target": [Function],
+                      "to": [Function],
+                    },
+                    "render": [Function],
+                  }
+                }
+                data-testid="search-button"
+                to="home-page.search.link"
                 variant="contained"
               >
                 home-page.search.button
@@ -213,9 +241,23 @@ exports[`Home page component homepage renders correctly 1`] = `
               marginTop="auto"
             >
               <WithStyles(ForwardRef(Button))
-                aria-label="home-page.download.button_arialabel"
                 color="primary"
-                href="home-page.download.link"
+                component={
+                  Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "displayName": "Link",
+                    "propTypes": Object {
+                      "innerRef": [Function],
+                      "onClick": [Function],
+                      "replace": [Function],
+                      "target": [Function],
+                      "to": [Function],
+                    },
+                    "render": [Function],
+                  }
+                }
+                data-testid="download-button"
+                to="home-page.download.link"
                 variant="contained"
               >
                 home-page.download.button
@@ -255,9 +297,9 @@ exports[`Home page component homepage renders correctly 1`] = `
                 marginTop="auto"
               >
                 <WithStyles(ForwardRef(Button))
-                  aria-label="home-page.facility.button_arialabel"
                   className="makeStyles-lightBlueButton-17"
                   color="primary"
+                  data-testid="facility-button"
                   href="home-page.facility.link"
                   variant="contained"
                 >

--- a/src/homePage/homePage.component.tsx
+++ b/src/homePage/homePage.component.tsx
@@ -24,6 +24,7 @@ import Decal2Image from '../images/decal2.svg';
 import Decal2DarkImage from '../images/decal2-dark.svg';
 import Decal2DarkHCImage from '../images/decal2-darkhc.svg';
 import FacilityImage from '../images/facility.jpg';
+import { Link } from 'react-router-dom';
 
 export interface HomePageProps {
   logo: string;
@@ -235,8 +236,9 @@ const HomePage = (): React.ReactElement => {
                   <Button
                     color="primary"
                     variant="contained"
-                    href={t('home-page.browse.link')}
-                    aria-label={t('home-page.browse.button_arialabel')}
+                    component={Link}
+                    to={t('home-page.browse.link')}
+                    data-testid="browse-button"
                   >
                     {t('home-page.browse.button')}
                   </Button>
@@ -270,8 +272,9 @@ const HomePage = (): React.ReactElement => {
                   <Button
                     color="primary"
                     variant="contained"
-                    href={t('home-page.search.link')}
-                    aria-label={t('home-page.search.button_arialabel')}
+                    component={Link}
+                    to={t('home-page.search.link')}
+                    data-testid="search-button"
                   >
                     {t('home-page.search.button')}
                   </Button>
@@ -298,8 +301,9 @@ const HomePage = (): React.ReactElement => {
                   <Button
                     color="primary"
                     variant="contained"
-                    href={t('home-page.download.link')}
-                    aria-label={t('home-page.download.button_arialabel')}
+                    component={Link}
+                    to={t('home-page.download.link')}
+                    data-testid="download-button"
                   >
                     {t('home-page.download.button')}
                   </Button>
@@ -326,7 +330,7 @@ const HomePage = (): React.ReactElement => {
                       variant="contained"
                       className={classes.lightBlueButton}
                       href={t('home-page.facility.link')}
-                      aria-label={t('home-page.facility.button_arialabel')}
+                      data-testid="facility-button"
                     >
                       {t('home-page.facility.button')}
                     </Button>


### PR DESCRIPTION
## Description
Changes buttons on homepage to use react-router links to avoid unnecessary page reloading. Also removed some unnecessary aria-labels. This is the same as https://github.com/ral-facilities/datagateway/pull/991, but applied to the SciGateway homepage.

## Testing instructions

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
connect to https://github.com/ral-facilities/datagateway/issues/988