### PR TITLE
Modify dependabot config to ignore patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
     timezone: Europe/London
   open-pull-requests-limit: 10
   ignore:
+  - dependency-name: '*'
+    update-types: ['version-update:semver-patch']
   - dependency-name: axios-mock-adapter
     versions:
     - "> 1.18.1, < 1.19"


### PR DESCRIPTION
## Description
Changes dependabot config to ignore patch versions. Corresponding DataGateway PR is here: https://github.com/ral-facilities/datagateway/pull/1026.

## Testing instructions

- [ ] Review changes

## Agile board tracking