### PR TITLE
Homepage redesign tweaks #897

### DIFF
--- a/public/res/default.json
+++ b/public/res/default.json
@@ -122,7 +122,13 @@
     "message": "We're sorry, the page you requested was not found on the server. If you entered the URL manually please check your spelling and try again. Otherwise, return to the <2>homepage</2> or <6>contact support</6>."
   },
   "footer": {
-    "html": "<a href=\"#\">Facility Name</a> | <a href=\"#\">Privacy statement</a> | <a href=\"#\">Data policy</a> | <a href=\"mailto:#\">Contact</a>",
+    "links": {
+      "text": "<0>ISIS Home</0> | <2>Privacy statement</2> | <4>Data policy</4> | <6>Contact</6>",
+      "facility": "#",
+      "privacy-statement": "#",
+      "data-policy": "#",
+      "contact": "#"
+    },
     "website-development-provider": "Built by the <2>Data and Software Engineering Group</2>"
   },
   "navigation-drawer": {

--- a/src/footer/__snapshots__/footer.component.test.tsx.snap
+++ b/src/footer/__snapshots__/footer.component.test.tsx.snap
@@ -4,24 +4,46 @@ exports[`Footer component footer renders correctly 1`] = `
 <div
   className="root-class"
 >
-  <div
-    dangerouslySetInnerHTML={
-      Object {
-        "__html": "html",
-      }
-    }
-  />
+  <div>
+    <Trans
+      i18nKey="footer.links.text"
+    >
+      <WithStyles(ForwardRef(Link))
+        href="footer.links.facility"
+      >
+        Facility Home
+      </WithStyles(ForwardRef(Link))>
+       | 
+      <WithStyles(ForwardRef(Link))
+        href="footer.links.privacy-statement"
+      >
+        Privacy statement
+      </WithStyles(ForwardRef(Link))>
+       | 
+      <WithStyles(ForwardRef(Link))
+        href="footer.links.data-policy"
+      >
+        Data policy
+      </WithStyles(ForwardRef(Link))>
+       | 
+      <WithStyles(ForwardRef(Link))
+        href="footer.links.contact"
+      >
+        Contact
+      </WithStyles(ForwardRef(Link))>
+    </Trans>
+  </div>
   <div>
     <Trans
       i18nKey="footer.website-development-provider"
     >
       Built by the
        
-      <a
+      <WithStyles(ForwardRef(Link))
         href="https://www.scd.stfc.ac.uk/Pages/Software-Engineering-Group.aspx"
       >
         Data and Software Engineering Group
-      </a>
+      </WithStyles(ForwardRef(Link))>
     </Trans>
   </div>
 </div>

--- a/src/footer/footer.component.tsx
+++ b/src/footer/footer.component.tsx
@@ -6,12 +6,13 @@ import {
   withStyles,
   WithStyles,
 } from '@material-ui/core/styles';
-import { getAppStrings, getString } from '../state/strings';
+import { getAppStrings } from '../state/strings';
 import { connect } from 'react-redux';
 import { StateType } from '../state/state.types';
 import { AppStrings } from '../state/scigateway.types';
 import { UKRITheme } from '../theming';
-import { Trans } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
+import Link from '@material-ui/core/Link';
 
 const styles = (theme: Theme): StyleRules =>
   createStyles({
@@ -41,14 +42,14 @@ const styles = (theme: Theme): StyleRules =>
       textAlign: 'left',
       fontWeight: 'bold',
       fontSize: 14,
-      textIndent: '24px',
+      textIndent: '16px',
       display: 'inline-block',
     },
     rightText: {
       textAlign: 'right',
       fontSize: 14,
       right: 0,
-      paddingRight: 24,
+      paddingRight: '16px',
       marginLeft: 'auto',
     },
     bold: {
@@ -64,23 +65,47 @@ interface FooterProps {
 export type CombinedFooterProps = FooterProps & WithStyles<typeof styles>;
 
 const Footer = (props: CombinedFooterProps): React.ReactElement => {
+  const [t] = useTranslation();
+
   return (
     <div className={props.classes.root}>
-      <div
-        className={props.classes.leftText}
-        dangerouslySetInnerHTML={{
-          __html: getString(props.res, 'html'),
-        }}
-      />
+      <div className={props.classes.leftText}>
+        <Trans i18nKey="footer.links.text">
+          <Link
+            className={props.classes.bold}
+            href={t('footer.links.facility')}
+          >
+            Facility Home
+          </Link>
+          {' | '}
+          <Link
+            className={props.classes.bold}
+            href={t('footer.links.privacy-statement')}
+          >
+            Privacy statement
+          </Link>
+          {' | '}
+          <Link
+            className={props.classes.bold}
+            href={t('footer.links.data-policy')}
+          >
+            Data policy
+          </Link>
+          {' | '}
+          <Link className={props.classes.bold} href={t('footer.links.contact')}>
+            Contact
+          </Link>
+        </Trans>
+      </div>
       <div className={props.classes.rightText}>
         <Trans i18nKey="footer.website-development-provider">
           Built by the{' '}
-          <a
+          <Link
             className={props.classes.bold}
             href="https://www.scd.stfc.ac.uk/Pages/Software-Engineering-Group.aspx"
           >
             Data and Software Engineering Group
-          </a>
+          </Link>
         </Trans>
       </div>
     </div>

--- a/src/helpPage/__snapshots__/helpPage.component.test.tsx.snap
+++ b/src/helpPage/__snapshots__/helpPage.component.test.tsx.snap
@@ -39,7 +39,7 @@ exports[`Help page component should render correctly 1`] = `
         "grey": "#727272",
         "homePage": Object {
           "blueButton": "#1E5DF8",
-          "blueDescription": "#E6E6E6",
+          "blueDescription": "#FFFFFF",
           "heading": "#333333",
         },
         "information": "#003088",
@@ -62,8 +62,8 @@ exports[`Help page component should render correctly 1`] = `
       "direction": "ltr",
       "drawerWidth": 220,
       "footerHeight": "20px",
-      "footerPaddingBottom": "14px",
-      "footerPaddingTop": "14px",
+      "footerPaddingBottom": "8px",
+      "footerPaddingTop": "8px",
       "mainAppBarHeight": "64px",
       "mixins": Object {
         "gutters": [Function],
@@ -355,7 +355,7 @@ exports[`Help page component should render correctly 1`] = `
           "fontWeight": 500,
           "letterSpacing": "0.02857em",
           "lineHeight": 1.75,
-          "textTransform": "uppercase",
+          "textTransform": "none",
         },
         "caption": Object {
           "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",

--- a/src/homePage/__snapshots__/homePage.component.test.tsx.snap
+++ b/src/homePage/__snapshots__/homePage.component.test.tsx.snap
@@ -101,7 +101,7 @@ exports[`Home page component homepage renders correctly 1`] = `
               </Trans>
             </WithStyles(ForwardRef(Typography))>
             <Styled(MuiBox)
-              marginTop="auto"
+              marginTop="16px"
             >
               <WithStyles(ForwardRef(Button))
                 color="primary"

--- a/src/homePage/homePage.component.tsx
+++ b/src/homePage/homePage.component.tsx
@@ -241,7 +241,7 @@ const HomePage = (): React.ReactElement => {
                     discovery and data access functionality to the data.
                   </Trans>
                 </Typography>
-                <Box marginTop="auto">
+                <Box marginTop="16px">
                   <Button
                     color="primary"
                     variant="contained"

--- a/src/loginPage/loginPage.component.tsx
+++ b/src/loginPage/loginPage.component.tsx
@@ -350,7 +350,14 @@ export const LoginSelector = (
   }
 ): React.ReactElement => {
   return (
-    <FormControl style={{ minWidth: 120, paddingTop: '8px', fontSize: 14 }}>
+    <FormControl
+      style={{
+        minWidth: 120,
+        paddingTop: '8px',
+        paddingBottom: '16px',
+        fontSize: 14,
+      }}
+    >
       <InputLabel htmlFor="mnemonic-select" color="secondary">
         Authenticator
       </InputLabel>

--- a/src/mainAppBar/__snapshots__/userProfile.component.test.tsx.snap
+++ b/src/mainAppBar/__snapshots__/userProfile.component.test.tsx.snap
@@ -49,13 +49,16 @@ exports[`User profile component renders sign in button if not signed in 1`] = `
 >
   <WithStyles(ForwardRef(Button))
     className="button-class"
+    color="primary"
     onClick={[Function]}
+    variant="contained"
   >
     <WithStyles(ForwardRef(Typography))
       color="inherit"
       noWrap={true}
       style={
         Object {
+          "fontWeight": 500,
           "marginTop": 3,
         }
       }
@@ -72,13 +75,16 @@ exports[`User profile component renders sign in button if user signed in via aut
 >
   <WithStyles(ForwardRef(Button))
     className="button-class"
+    color="primary"
     onClick={[Function]}
+    variant="contained"
   >
     <WithStyles(ForwardRef(Typography))
       color="inherit"
       noWrap={true}
       style={
         Object {
+          "fontWeight": 500,
           "marginTop": 3,
         }
       }

--- a/src/mainAppBar/mainAppBar.component.tsx
+++ b/src/mainAppBar/mainAppBar.component.tsx
@@ -210,6 +210,7 @@ const MainAppBar = (props: CombinedMainAppBarProps): React.ReactElement => {
           <Button
             className={classNames(props.classes.titleButton, 'tour-title')}
             onClick={props.navigateToHome}
+            aria-label={getString(props.res, 'home-page')}
           >
             <img
               src={props.logo ? props.logo : defaultLogo}

--- a/src/mainAppBar/mainAppBar.component.tsx
+++ b/src/mainAppBar/mainAppBar.component.tsx
@@ -91,17 +91,17 @@ const styles = (theme: Theme): StyleRules =>
     },
     menuButton: {
       marginLeft: -12,
-      marginRight: 20,
+      marginRight: 0,
       color: theme.palette.primary.contrastText,
     },
     menuButtonPlaceholder: {
       marginLeft: -12,
-      marginRight: 20,
+      marginRight: 0,
       width: 48,
     },
     menuButtonOpen: {
       marginLeft: -12,
-      marginRight: 20,
+      marginRight: 0,
       color: theme.palette.primary.contrastText,
     },
   });
@@ -207,7 +207,6 @@ const MainAppBar = (props: CombinedMainAppBarProps): React.ReactElement => {
           <Button
             className={classNames(props.classes.titleButton, 'tour-title')}
             onClick={props.navigateToHome}
-            aria-label={getString(props.res, 'home-page')}
           >
             <img
               src={props.logo ? props.logo : defaultLogo}
@@ -217,11 +216,14 @@ const MainAppBar = (props: CombinedMainAppBarProps): React.ReactElement => {
           {props.showHelpPageButton ? (
             <Button
               className={classNames(props.classes.button, 'tour-help')}
-              style={{ paddingTop: 3 }}
               onClick={props.navigateToHelpPage}
               aria-label={getString(props.res, 'help-page')}
             >
-              <Typography color="inherit" noWrap style={{ marginTop: 3 }}>
+              <Typography
+                color="inherit"
+                noWrap
+                style={{ fontWeight: 500, marginTop: 3 }}
+              >
                 {getString(props.res, 'help')}
               </Typography>
             </Button>
@@ -229,11 +231,14 @@ const MainAppBar = (props: CombinedMainAppBarProps): React.ReactElement => {
           {props.showAdminPageButton ? (
             <Button
               className={classNames(props.classes.button, 'tour-admin')}
-              style={{ paddingTop: 3 }}
               onClick={props.navigateToAdminPage}
               aria-label={getString(props.res, 'admin-page')}
             >
-              <Typography color="inherit" noWrap style={{ marginTop: 3 }}>
+              <Typography
+                color="inherit"
+                noWrap
+                style={{ fontWeight: 500, marginTop: 3 }}
+              >
                 {getString(props.res, 'admin')}
               </Typography>
             </Button>

--- a/src/mainAppBar/mainAppBar.component.tsx
+++ b/src/mainAppBar/mainAppBar.component.tsx
@@ -173,7 +173,10 @@ const MainAppBar = (props: CombinedMainAppBarProps): React.ReactElement => {
   return (
     <div className={props.classes.root}>
       <AppBar position="static" className={props.classes.appBar}>
-        <Toolbar>
+        <Toolbar
+          disableGutters
+          style={{ marginLeft: '16px', marginRight: '16px' }}
+        >
           {props.loggedIn ? (
             props.drawerOpen === false ? (
               <IconButton

--- a/src/mainAppBar/userProfile.component.tsx
+++ b/src/mainAppBar/userProfile.component.tsx
@@ -124,13 +124,19 @@ const UserProfileComponent = (
         </div>
       ) : (
         <Button
+          color="primary"
+          variant="contained"
           className={props.classes.button}
           onClick={() => {
             props.signIn();
             log.debug('signing in');
           }}
         >
-          <Typography color="inherit" noWrap style={{ marginTop: 3 }}>
+          <Typography
+            color="inherit"
+            noWrap
+            style={{ fontWeight: 500, marginTop: 3 }}
+          >
             {getString(props.res, 'login-button')}
           </Typography>
         </Button>

--- a/src/navigationDrawer/navigationDrawer.component.tsx
+++ b/src/navigationDrawer/navigationDrawer.component.tsx
@@ -47,7 +47,7 @@ const styles = (theme: Theme): StyleRules =>
     },
     sectionTitle: {
       textAlign: 'left',
-      paddingTop: theme.spacing(1),
+      paddingTop: theme.spacing(2),
       paddingBottom: 0,
       color: (theme as UKRITheme).colours.contrastGrey,
       paddingLeft: theme.spacing(2),
@@ -58,8 +58,8 @@ const styles = (theme: Theme): StyleRules =>
       color: (theme as UKRITheme).colours.blue,
     },
     menuLogo: {
-      paddingRight: 25,
-      paddingLeft: 25,
+      paddingRight: theme.spacing(2),
+      paddingLeft: theme.spacing(2),
       height: 40,
       paddingBottom: 24,
       color: theme.palette.text.secondary,

--- a/src/notifications/notificationBadge.component.tsx
+++ b/src/notifications/notificationBadge.component.tsx
@@ -33,6 +33,7 @@ interface BadgeDispatchProps {
 const styles = (theme: Theme): StyleRules =>
   createStyles({
     button: {
+      margin: theme.spacing(1),
       color: theme.palette.primary.contrastText,
     },
     menuItem: {

--- a/src/theming.tsx
+++ b/src/theming.tsx
@@ -125,7 +125,7 @@ const DARK_MODE_COLOURS: ThemeColours = {
   chip: '#595959',
   homePage: {
     heading: '#FFFFFF',
-    blueDescription: '#E6E6E6',
+    blueDescription: '#FFFFFF',
     blueButton: UKRI_COLOURS.bright.blue,
   },
 };
@@ -195,7 +195,7 @@ const LIGHT_MODE_COLOURS: ThemeColours = {
   chip: '#E0E0E0',
   homePage: {
     heading: '#333333',
-    blueDescription: '#E6E6E6',
+    blueDescription: '#FFFFFF',
     blueButton: UKRI_COLOURS.bright.blue,
   },
 };
@@ -404,12 +404,17 @@ export const buildTheme = (
       },
     },
     drawerWidth: 220,
-    footerPaddingTop: '14px',
-    footerPaddingBottom: '14px',
+    footerPaddingTop: '8px',
+    footerPaddingBottom: '8px',
     footerHeight: '20px',
     mainAppBarHeight: '64px',
     overrides: overrides,
     colours: colours,
+    typography: {
+      button: {
+        textTransform: 'none',
+      },
+    },
   };
 
   return createMuiTheme(options);


### PR DESCRIPTION
## Description
Applies the tweaks described in https://github.com/ral-facilities/datagateway/issues/1048.

![image](https://user-images.githubusercontent.com/90245114/148749039-9041da07-ea7d-49a8-92a5-db956af1964a.png)

Also adds padding on the login page:
![image](https://user-images.githubusercontent.com/90245114/148808141-f68cc862-d851-4601-acbe-ffa8b5b7fabf.png)
as previously this looked like:
![image](https://user-images.githubusercontent.com/90245114/148807028-f8ab3122-f3fa-4d70-901b-276b7d241003.png)
on diamond.

## Testing instructions

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
Connect to ral-facilities/datagateway#1048