### PR TITLE
Changing the min-width to work correctly with card view #965

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -7,7 +7,7 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  min-width: fit-content;
+  min-width: 560px;
 }
 
 code {


### PR DESCRIPTION
## Description
- Changing the min-width to a same size as the main app bar.

- To avoid getting this weird behaviour when "fit-content" is using
<br><br>
![image](https://user-images.githubusercontent.com/83226114/155509269-9f41b962-7bca-484c-a217-162c43aca7ec.png)
<br><br>
## Testing instructions
Add a set up instructions describing how the reviewer should test the code

Check if the black bar (on the right-hand side) exist at maximum of the browser zoom (e.g. %500) 
 
- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] {more steps here}

## Agile board tracking
closes #965 