### PR TITLE
Navigation drawer logo is defined by width instead of the height #964

### DIFF
--- a/src/navigationDrawer/navigationDrawer.component.tsx
+++ b/src/navigationDrawer/navigationDrawer.component.tsx
@@ -61,7 +61,7 @@ const styles = (theme: Theme): StyleRules =>
     menuLogo: {
       paddingRight: theme.spacing(2),
       paddingLeft: theme.spacing(2),
-      height: 40,
+      width: '188px',
       paddingBottom: 24,
       color: theme.palette.text.secondary,
     },


### PR DESCRIPTION
## Description
The navigation drawer logo should be set by the width of the of navigation bar 

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] {more steps here}

## Agile board tracking
closes #964 