### PR TITLE
Fix plugin loading bug

### DIFF
--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -11,7 +11,12 @@
 // This function is called when a project is opened or re-opened (e.g. due to
 // the project's config changing)
 
-module.exports = () => {
+// eslint-disable-next-line
+module.exports = (on, config) => {
   // `on` is used to hook into various events Cypress emits
   // `config` is the resolved Cypress config
+  on('task', {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    failed: require('cypress-failed-log/src/failed')(),
+  });
 };

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -18,3 +18,5 @@ import './commands';
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
+
+require('cypress-failed-log');

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "connected-react-router": "^6.9.1",
     "cookie-parser": "^1.4.5",
     "custom-event-polyfill": "^1.0.7",
+    "cypress-failed-log": "^2.9.4",
     "express": "^4.17.1",
     "i18next": "^21.6.11",
     "i18next-browser-languagedetector": "^6.0.0",

--- a/src/adminPage/adminPage.component.tsx
+++ b/src/adminPage/adminPage.component.tsx
@@ -72,30 +72,16 @@ export type CombinedAdminPageProps = AdminPageProps & WithStyles<typeof styles>;
 export const AdminPage = (props: CombinedAdminPageProps): ReactElement => {
   const pluginRoutes = getPluginRoutes(props.plugins, true);
 
-  const [tabValue, setTabValue] = React.useState<'maintenance' | 'download'>(
-    props.adminPageDefaultTab ?? 'maintenance'
-  );
-
   const location = useLocation();
 
-  React.useEffect(() => {
-    // Allows direct access to the download page when maintenance page is default
-    if (
-      location.pathname === adminRoutes['download'] &&
-      tabValue !== 'download'
-    ) {
-      setTabValue('download');
-    }
-    // Allows direct access to the maintenance page when download page is default
-    else if (
-      location.pathname === adminRoutes['maintenance'] &&
-      tabValue !== 'maintenance'
-    ) {
-      setTabValue('maintenance');
-    }
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [location.pathname]);
+  const [tabValue, setTabValue] = React.useState<'maintenance' | 'download'>(
+    // allows direct access to a tab when another tab is the default
+    (Object.keys(adminRoutes) as Array<keyof typeof adminRoutes>).find(
+      (key) => adminRoutes[key] === location.pathname
+    ) ??
+      props.adminPageDefaultTab ??
+      'maintenance'
+  );
 
   const [t] = useTranslation();
 

--- a/src/preloader/__snapshots__/preloader.component.test.tsx.snap
+++ b/src/preloader/__snapshots__/preloader.component.test.tsx.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Preloader component does not render when on the login page 1`] = `
-<div>
+<div
+  id="preloader"
+>
   <div
     className="makeStyles-container-3 makeStyles-container-10"
   >
@@ -147,10 +149,16 @@ exports[`Preloader component does not render when on the login page 1`] = `
 </div>
 `;
 
-exports[`Preloader component does not render when the site stops loading 1`] = `<div />`;
+exports[`Preloader component does not render when the site stops loading 1`] = `
+<div
+  id="preloader"
+/>
+`;
 
 exports[`Preloader component renders fullscreen correctly 1`] = `
-<div>
+<div
+  id="preloader"
+>
   <div
     className="makeStyles-container-3 makeStyles-container-6"
   >
@@ -297,7 +305,9 @@ exports[`Preloader component renders fullscreen correctly 1`] = `
 `;
 
 exports[`Preloader component renders not fullscreen correctly 1`] = `
-<div>
+<div
+  id="preloader"
+>
   <div
     className="makeStyles-container-3 makeStyles-container-8"
   >

--- a/src/preloader/__snapshots__/preloader.component.test.tsx.snap
+++ b/src/preloader/__snapshots__/preloader.component.test.tsx.snap
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Preloader component does not render when on the login page 1`] = `
-<div
-  id="preloader"
->
+<div>
   <div
     className="makeStyles-container-3 makeStyles-container-10"
   >
@@ -149,16 +147,10 @@ exports[`Preloader component does not render when on the login page 1`] = `
 </div>
 `;
 
-exports[`Preloader component does not render when the site stops loading 1`] = `
-<div
-  id="preloader"
-/>
-`;
+exports[`Preloader component does not render when the site stops loading 1`] = `<div />`;
 
 exports[`Preloader component renders fullscreen correctly 1`] = `
-<div
-  id="preloader"
->
+<div>
   <div
     className="makeStyles-container-3 makeStyles-container-6"
   >
@@ -305,9 +297,7 @@ exports[`Preloader component renders fullscreen correctly 1`] = `
 `;
 
 exports[`Preloader component renders not fullscreen correctly 1`] = `
-<div
-  id="preloader"
->
+<div>
   <div
     className="makeStyles-container-3 makeStyles-container-8"
   >

--- a/src/preloader/preloader.component.tsx
+++ b/src/preloader/preloader.component.tsx
@@ -49,6 +49,7 @@ interface PreloaderStateProps {
 
 interface PreloaderProps {
   fullScreen: boolean;
+  id?: string;
 }
 
 type PreloaderCombinedProps = PreloaderStateProps & PreloaderProps;
@@ -89,7 +90,7 @@ export const Preloader = (
 ): React.ReactElement => {
   const classes = useStyles(props);
   return (
-    <div id="preloader">
+    <div id={props.id}>
       {props.loading ? (
         <div className={classes.container}>
           <div className={classes.wrapper}>

--- a/src/preloader/preloader.component.tsx
+++ b/src/preloader/preloader.component.tsx
@@ -89,7 +89,7 @@ export const Preloader = (
 ): React.ReactElement => {
   const classes = useStyles(props);
   return (
-    <div>
+    <div id="preloader">
       {props.loading ? (
         <div className={classes.container}>
           <div className={classes.wrapper}>

--- a/src/routing/__snapshots__/routing.component.test.tsx.snap
+++ b/src/routing/__snapshots__/routing.component.test.tsx.snap
@@ -301,6 +301,7 @@ exports[`Routing component renders a route for a plugin when site is under maint
                         >
                           <Preloader
                             fullScreen={false}
+                            id="plugin-preloader"
                             loading={true}
                           >
                             Mocked Preloader
@@ -818,6 +819,7 @@ exports[`Routing component renders placeholder for a plugin 1`] = `
 >
   <Preloader
     fullScreen={false}
+    id="plugin-preloader"
     loading={true}
   />
 </div>

--- a/src/routing/routing.component.test.tsx
+++ b/src/routing/routing.component.test.tsx
@@ -54,6 +54,7 @@ describe('Routing component', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
+    jest.useRealTimers();
   });
 
   it('renders component with no plugin routes', () => {
@@ -270,5 +271,42 @@ describe('Routing component', () => {
     expect(singleSpa.unloadApplication).toHaveBeenCalledWith(
       'test_plugin_name'
     );
+  });
+
+  it("single-spa reloads a plugin when it hasn't loaded for some reason", () => {
+    jest.useFakeTimers();
+    state.scigateway.authorisation.provider = new TestAuthProvider('logged in');
+    state.scigateway.siteLoading = false;
+    state.scigateway.plugins = [
+      {
+        section: 'test section',
+        link: '/test_link',
+        plugin: 'test_plugin_name',
+        displayName: 'Test Plugin',
+        order: 1,
+      },
+    ];
+    state.router.location = createLocation('/test_link');
+
+    jest.spyOn(document, 'getElementById').mockImplementation(() => {
+      return document.createElement('div');
+    });
+
+    const clearIntervalSpy = jest.spyOn(window, 'clearInterval');
+
+    mount(
+      <Provider store={mockStore(state)}>
+        <MemoryRouter initialEntries={['/test_link']}>
+          <Routing classes={classes} />
+        </MemoryRouter>
+      </Provider>
+    );
+    jest.runAllTimers();
+
+    expect(singleSpa.unloadApplication).toHaveBeenCalledWith(
+      'test_plugin_name'
+    );
+
+    expect(clearIntervalSpy).toHaveBeenCalledWith(expect.any(Number));
   });
 });

--- a/src/routing/routing.component.tsx
+++ b/src/routing/routing.component.tsx
@@ -70,7 +70,7 @@ export class PluginPlaceHolder extends React.PureComponent<{
       <div id={id}>
         {/* display a loading indicator whilst the plugin is mounting
             the loading indicator is replaced when the plugin itself mounts */}
-        <Preloader loading={true} fullScreen={false} />
+        <Preloader id="plugin-preloader" loading={true} fullScreen={false} />
       </div>
     );
   }
@@ -129,7 +129,7 @@ const Routing: React.FC<RoutingProps & WithStyles<typeof styles>> = (
         // & that the site has loaded, so the plugin should have been loaded already
         // and if it hasn't we need to manually load it
         if (pluginConf && document.getElementById(pluginConf.plugin)) {
-          if (document.getElementById('preloader')) {
+          if (document.getElementById('plugin-preloader')) {
             singleSpa.unloadApplication(pluginConf.plugin);
           }
           manuallyLoadedPluginRef.current = true;

--- a/src/state/actions/loadMicroFrontends.tsx
+++ b/src/state/actions/loadMicroFrontends.tsx
@@ -83,8 +83,6 @@ async function init(plugins: Plugin[]): Promise<void> {
 
   // wait until all stores are loaded and all apps are registered with singleSpa
   await Promise.all(loadingPromises);
-
-  singleSpa.start();
 }
 
 const exports = { init };

--- a/src/state/actions/scigateway.actions.test.tsx
+++ b/src/state/actions/scigateway.actions.test.tsx
@@ -580,9 +580,9 @@ describe('scigateway actions', () => {
       },
     });
 
-    await asyncAction(dispatch, getState);
-
     const eventListenerSpy = jest.spyOn(document, 'addEventListener');
+
+    await asyncAction(dispatch, getState);
 
     expect(eventListenerSpy).not.toHaveBeenCalled();
     expect(actions).toContainEqual(siteLoadingUpdate(false));

--- a/src/state/actions/scigateway.actions.test.tsx
+++ b/src/state/actions/scigateway.actions.test.tsx
@@ -542,6 +542,52 @@ describe('scigateway actions', () => {
     expect(actions).toContainEqual(siteLoadingUpdate(false));
   });
 
+  it("dispatches a site loading update but doesn't wait for register route event if it's already been recieved", async () => {
+    (mockAxios.get as jest.Mock).mockImplementation(() =>
+      Promise.resolve({
+        data: {
+          'ui-strings': 'res/default.json',
+        },
+      })
+    );
+
+    const asyncAction = configureSite();
+    const actions: Action[] = [];
+    const dispatch = (action: Action): void | Promise<void> => {
+      if (typeof action === 'function') {
+        action(dispatch);
+        return Promise.resolve();
+      } else {
+        actions.push(action);
+      }
+    };
+
+    const state = JSON.parse(JSON.stringify(initialState));
+    state.authorisation.provider = new TestAuthProvider('token');
+    state.plugins = [
+      {
+        section: 'Analysis',
+        link: '/test',
+        plugin: 'demo_plugin',
+        displayName: 'Demo Plugin Analysis',
+      },
+    ];
+    const getState = (): Partial<StateType> => ({
+      scigateway: state,
+      router: {
+        location: { ...createLocation('/test'), query: {} },
+        action: 'PUSH',
+      },
+    });
+
+    await asyncAction(dispatch, getState);
+
+    const eventListenerSpy = jest.spyOn(document, 'addEventListener');
+
+    expect(eventListenerSpy).not.toHaveBeenCalled();
+    expect(actions).toContainEqual(siteLoadingUpdate(false));
+  });
+
   it("given an authenticator that supports autologin, autologin is attempted when user isn't logged in", async () => {
     (mockAxios.get as jest.Mock).mockImplementation(() =>
       Promise.resolve({

--- a/src/state/actions/scigateway.actions.tsx
+++ b/src/state/actions/scigateway.actions.tsx
@@ -348,8 +348,8 @@ export const configureSite = (): ThunkResult<Promise<void>> => {
                   dispatch(siteLoadingUpdate(false));
                   eventFired = true;
                   document.removeEventListener('scigateway', handler);
+                  singleSpa.start();
                   resolve();
-                  singleSpa.triggerAppChange();
                 }
               };
 
@@ -358,13 +358,14 @@ export const configureSite = (): ThunkResult<Promise<void>> => {
                   dispatch(siteLoadingUpdate(false));
                 }
                 document.removeEventListener('scigateway', handler);
+                singleSpa.start();
                 resolve();
-                singleSpa.triggerAppChange();
               }, 3000);
 
               document.addEventListener('scigateway', handler);
             } else {
               dispatch(siteLoadingUpdate(false));
+              singleSpa.start();
               resolve();
             }
           });

--- a/src/state/actions/scigateway.actions.tsx
+++ b/src/state/actions/scigateway.actions.tsx
@@ -57,6 +57,7 @@ import {
   CustomNavigationDrawerLogoType,
   CustomAdminPageDefaultTabPayload,
   CustomAdminPageDefaultTabType,
+  adminRoutes,
 } from '../scigateway.types';
 import { ActionType, LogoState, StateType, ThunkResult } from '../state.types';
 import loadMicroFrontends from './loadMicroFrontends';
@@ -339,6 +340,7 @@ export const configureSite = (): ThunkResult<Promise<void>> => {
             const currUrl = getState().router.location.pathname;
             if (
               !Object.values(scigatewayRoutes).includes(currUrl) &&
+              currUrl !== adminRoutes.maintenance &&
               !getState().scigateway.plugins.find((p) =>
                 currUrl.startsWith(p.link)
               )

--- a/src/state/actions/scigateway.actions.tsx
+++ b/src/state/actions/scigateway.actions.tsx
@@ -333,11 +333,16 @@ export const configureSite = (): ThunkResult<Promise<void>> => {
         }
 
         return Promise.all(loadingPromises).then(() => {
-          // if we're on a non-scigateway url, attempt to wait for matching register route event
+          // if we're on a non-scigateway url that isn't in plugins yet, attempt to wait for matching register route event
           // to help prevent showing a 404 page before the right route has been registered
           return new Promise<void>((resolve) => {
             const currUrl = getState().router.location.pathname;
-            if (!Object.values(scigatewayRoutes).includes(currUrl)) {
+            if (
+              !Object.values(scigatewayRoutes).includes(currUrl) &&
+              !getState().scigateway.plugins.find((p) =>
+                currUrl.startsWith(p.link)
+              )
+            ) {
               let eventFired = false;
               const handler = (event: Event): void => {
                 const pluginMessage = event as CustomEvent<AnyAction>;

--- a/src/state/middleware/scigateway.middleware.test.tsx
+++ b/src/state/middleware/scigateway.middleware.test.tsx
@@ -29,6 +29,9 @@ import { authState, initialState } from '../reducers/scigateway.reducer';
 import { buildTheme } from '../../theming';
 import thunk from 'redux-thunk';
 import { autoLoginAuthorised } from '../actions/scigateway.actions';
+import * as singleSpa from 'single-spa';
+
+jest.mock('single-spa');
 
 describe('scigateway middleware', () => {
   let events: CustomEvent<AnyAction>[] = [];
@@ -560,6 +563,28 @@ describe('scigateway middleware', () => {
     expect(JSON.stringify(store.getActions()[2])).toEqual(
       JSON.stringify(sendThemeOptionsAction)
     );
+  });
+
+  it("should listen for events and fire registerroute action and call singleSpa.triggerAppChange if url matches plugin route and it's not loaded", () => {
+    const getState: () => StateType = () => ({
+      scigateway: { ...initialState },
+      router: {
+        action: 'POP',
+        location: createLocation('/plugin1/analysis2'),
+      },
+    });
+
+    (singleSpa.getAppStatus as jest.Mock).mockReturnValue('NOT_LOADED');
+
+    listenToPlugins(store.dispatch, getState);
+
+    handler(
+      new CustomEvent('test', {
+        detail: registerRouteAction,
+      })
+    );
+
+    expect(singleSpa.triggerAppChange).toHaveBeenCalled();
   });
 
   describe('notifications', () => {

--- a/src/state/middleware/scigateway.middleware.tsx
+++ b/src/state/middleware/scigateway.middleware.tsx
@@ -25,6 +25,7 @@ import { StateType } from '../state.types';
 import { buildTheme } from '../../theming';
 import { push } from 'connected-react-router';
 import { ThunkDispatch } from 'redux-thunk';
+import * as singleSpa from 'single-spa';
 
 const trackPage = (page: string): void => {
   ReactGA.set({
@@ -122,6 +123,16 @@ export const listenToPlugins = (
                 scigateway: { homepageUrl: pluginMessage.detail.payload.link },
               })
             );
+          }
+
+          // this helps prevent problems if the plugin settings files and thus routes are loaded particularly slowly
+          if (
+            getState().router.location.pathname ===
+              pluginMessage.detail.payload.link &&
+            singleSpa.getAppStatus(pluginMessage.detail.payload.plugin) ===
+              'NOT_LOADED'
+          ) {
+            singleSpa.triggerAppChange();
           }
 
           let darkModePreference: boolean;

--- a/src/state/middleware/scigateway.middleware.tsx
+++ b/src/state/middleware/scigateway.middleware.tsx
@@ -130,7 +130,7 @@ export const listenToPlugins = (
             getState().router.location.pathname ===
               pluginMessage.detail.payload.link &&
             singleSpa.getAppStatus(pluginMessage.detail.payload.plugin) ===
-              'NOT_LOADED'
+              singleSpa.NOT_LOADED
           ) {
             singleSpa.triggerAppChange();
           }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4010,7 +4010,7 @@ chalk@2.4.1:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^2.0.0, chalk@^2.4.1, chalk@^2.4.2:
+chalk@^2.0.0, chalk@^2.3.0, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -4728,6 +4728,14 @@ custom-event-polyfill@^1.0.7:
   resolved "https://registry.yarnpkg.com/custom-event-polyfill/-/custom-event-polyfill-1.0.7.tgz#9bc993ddda937c1a30ccd335614c6c58c4f87aee"
   integrity sha512-TDDkd5DkaZxZFM8p+1I3yAlvM3rSr1wbrOliG4yJiwinMZN8z/iGL7BTlDkrJcYTmgUSb4ywVCc3ZaUtOtC76w==
 
+cypress-failed-log@^2.9.4:
+  version "2.9.4"
+  resolved "https://registry.yarnpkg.com/cypress-failed-log/-/cypress-failed-log-2.9.4.tgz#340d4112392ae13847a7768a7eddb8fb4900718a"
+  integrity sha512-y6QKAacs+lxP5XfbWyCsconpJf7Oa6iffXgm2w5CzRBklamzIm8znzC5KSQoVFD5h05Lm+5cOonhlUcTb855BQ==
+  dependencies:
+    debug "4.3.3"
+    logdown "3.3.1"
+
 cypress@^9.5.0:
   version "9.5.0"
   resolved "https://registry.yarnpkg.com/cypress/-/cypress-9.5.0.tgz#704a79f0d3d4e775f433334eb8f5ae065e3bea31"
@@ -4814,7 +4822,7 @@ debug@2.6.9, debug@^2.6.0, debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.3:
+debug@4, debug@4.3.3, debug@^4.1.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.3:
   version "4.3.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.3.tgz#04266e0b70a98d4462e6e288e38259213332b664"
   integrity sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==
@@ -8206,6 +8214,13 @@ log-update@^4.0.0:
     cli-cursor "^3.1.0"
     slice-ansi "^4.0.0"
     wrap-ansi "^6.2.0"
+
+logdown@3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/logdown/-/logdown-3.3.1.tgz#836d5a195b5949c6db631ccc9fecce0492e01d10"
+  integrity sha512-pjX0vlIJsYQlgVzFba2amXI1wZZnhrEorL68MdLI7B0/sN1TNUozBNFaHfcPHMM3A+INZ0OXFDxtnoaEgOmGjQ==
+  dependencies:
+    chalk "^2.3.0"
 
 loglevel@^1.8.0:
   version "1.8.0"


### PR DESCRIPTION
## Description
After a lot of debugging and page refreshing to try and trigger the bug with logging, I think it was caused by `singleSpa.start()` being called before plugins had a chance to send their routes and thus make single-spa aware of them. Fixed by moving the `singleSpa.start()` call in the attempt to wait for plugins to send their routes section of `configureSite`.

Also, if the plugins are really slow I've added in a `triggerAppChange` call in the middleware.

EDIT: After noticing the bug still sometimes occurred, and a bug in that when the admin download table was directly accessed it loaded infinitely, I have added a "general" fix i.e. a setInterval that basically polls until the plugin routes has loaded, and checks if the preloader exists and if it does it calls `singleSpa.unloadApplication` (which forces a reload). I'd expect that this should cover all other cases of the bug happening but let me know if you still see it!

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] I've put these changes on DG ISIS prod, but didn't find a way to reliably recreate the bug. I basically just refreshed the page on my phone a bunch until the preloader takes a while to disappear. So either trust me or have fun refreshing the page 😅