### PR TITLE
accessibility page minor tweaks #986

### DIFF
--- a/public/res/default.json
+++ b/public/res/default.json
@@ -175,7 +175,7 @@
       "Some of the pages have unreadable ARIA labels. This fails WCAG 2.1 success criterion 4.1.2 (A): Name, Role, and Value",
       "The advanced filters, filters automatically without requiring user input. This fails WCAG 2.1 success criterion 3.2.2 On Input"
     ],
-    "non-compliance-with-the-accessibility-regulations-text": "We will make sure that all the non-compliances above are addressed in September 2022.",
+    "non-compliance-with-the-accessibility-regulations-text": "We will make sure that all the non-compliances above are addressed before the next release, likely to be in September 2022.",
     "disproportionate-burden": {
       "title": "Disproportionate burden",
       "table-view": "Table view",
@@ -192,6 +192,6 @@
       "link": "https://www.legislation.gov.uk/uksi/2018/952/regulation/7/made"
     },
     "preparation-of-this-accessibility-statement": "Preparation of this accessibility statement ",
-    "preparation-of-this-accessibility-statement-text": "This statement was prepared on the <2>14th of February 2022</2>. It was last reviewed on the <5>8th of March 2022</5>. This website was last tested on <9>30th of November 2021</9>. The test was carried out by the <12>Data & Software Engineering Group</12>."
+    "preparation-of-this-accessibility-statement-text": "This statement was prepared on the <2>14th of February 2022</2>. It was last reviewed on the <5>11th of March 2022</5>. This website was last tested on <9>30th of November 2021</9>. The test was carried out by the <12>Data & Software Engineering Group</12>."
   }
 }

--- a/src/accessibilityPage/accessibilityPage.component.tsx
+++ b/src/accessibilityPage/accessibilityPage.component.tsx
@@ -121,7 +121,9 @@ const AccessibiiltyPage = (
 
         <Typography component="ul" className={props.classes.description}>
           {datagatewayDomains.map((item) => (
-            <li key={item}>{item}</li>
+            <li key={item}>
+              <Link href={item}>{item}</Link>
+            </li>
           ))}
         </Typography>
 

--- a/src/accessibilityPage/accessibilityPage.component.tsx
+++ b/src/accessibilityPage/accessibilityPage.component.tsx
@@ -249,7 +249,9 @@ const AccessibiiltyPage = (
       </div>
 
       <Typography variant="h5" className={props.classes.titleText}>
-        {t('accessibility-page.non-accessible-content')}
+        {t(
+          'accessibility-page.non-compliance-with-the-accessibility-regulations'
+        )}
       </Typography>
 
       <div className={props.classes.container}>

--- a/src/accessibilityPage/accessibilityPage.component.tsx
+++ b/src/accessibilityPage/accessibilityPage.component.tsx
@@ -182,10 +182,13 @@ const AccessibiiltyPage = (
         <Typography className={props.classes.description}>
           {t('accessibility-page.contact-us-about-accessibility-text')}
         </Typography>
+
         {/* Here will be Comments box */}
 
         <Typography className={props.classes.description}>
-          {t('accessibility-page.contact-info')}
+          <Link href={`mailto:${t('accessibility-page.contact-info')}`}>
+            {t('accessibility-page.contact-info')}
+          </Link>
         </Typography>
       </div>
 
@@ -320,7 +323,7 @@ const AccessibiiltyPage = (
           >
             This statement was prepared on the{' '}
             <strong>14th of February 2022</strong> It was last reviewed on the{' '}
-            <strong>8th of March 2022</strong>. <br /> This website was last
+            <strong>11th of March 2022</strong>. <br /> This website was last
             tested on <strong> 30th of November 2021 </strong>. The test was
             carried out by the{' '}
             <strong> Data &#38; Software Engineering Group. </strong>


### PR DESCRIPTION
## Description
Addressing minor accessibility tweaks
-  updating the date (last reviewed)
- making the email render as a mailto link 
- removing duplicate of non-accessible content title and changed with the correct header 
- using rough time for "non-compliance with the accessibility regulations"
- rendering the domains URLs  as links 


## Testing instructions
Add a set up instructions describing how the reviewer should test the code
- [ ] it should match this document [https://stfc365.sharepoint.com/:w:/r/sites/TopcatRedevelopment/_layouts/15/Doc.aspx?sour[…]ent%202nd%20draft.docx&action=default&mobileredirect=true](https://stfc365.sharepoint.com/:w:/r/sites/TopcatRedevelopment/_layouts/15/Doc.aspx?sourcedoc=%7B25B17094-151A-4396-A72D-5AE6D36FB1E3%7D&file=DataGateway%20Accessibility%20Statement%202nd%20draft.docx&action=default&mobileredirect=true)
- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] {more steps here}

## Agile board tracking
closes #986