### PR TITLE
Adding Contact Us form for accessibility enquiries #990

### DIFF
--- a/public/settings.example.json
+++ b/public/settings.example.json
@@ -52,5 +52,6 @@
   "ui-strings": "res/default.json",
   "auth-provider": "jwt",
   "authUrl": "http://localhost:3000",
-  "ga-tracking-id": "UA-XXXX-Y"
+  "ga-tracking-id": "UA-XXXX-Y",
+  "contactUsAccessibilityFormUrl": ""
 }

--- a/src/accessibilityPage/__snapshots__/contactUs.component.test.tsx.snap
+++ b/src/accessibilityPage/__snapshots__/contactUs.component.test.tsx.snap
@@ -1,0 +1,39 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Contact us component renders iframe correctly if form url set 1`] = `
+<div
+  id="contact-us"
+>
+  <div
+    id="contact-us-form"
+  >
+    <iframe
+      allowFullScreen={true}
+      height="840px"
+      src="test-url"
+      title="Contact Us"
+      width="740px"
+    />
+  </div>
+</div>
+`;
+
+exports[`Contact us component renders mailto link correctly if form url not set 1`] = `
+<div
+  id="contact-us"
+>
+  <div
+    id="contact-info"
+  >
+    <WithStyles(ForwardRef(Typography))
+      className="description-class"
+    >
+      <WithStyles(ForwardRef(Link))
+        href="mailto:accessibility-page.contact-info"
+      >
+        accessibility-page.contact-info
+      </WithStyles(ForwardRef(Link))>
+    </WithStyles(ForwardRef(Typography))>
+  </div>
+</div>
+`;

--- a/src/accessibilityPage/accessibilityPage.component.test.tsx
+++ b/src/accessibilityPage/accessibilityPage.component.test.tsx
@@ -41,7 +41,7 @@ describe('Accessibility page component', () => {
 
   const theme = buildTheme(false);
 
-  it('should render correctly', () => {
+  it('should render correctly and display contact us component', () => {
     const testStore = mockStore(state);
 
     const wrapper = mount(
@@ -53,19 +53,6 @@ describe('Accessibility page component', () => {
     );
 
     expect(wrapper.find('#accessibility-page')).toBeTruthy();
-  });
-
-  it('should render contact us component correctly', () => {
-    const testStore = mockStore(state);
-
-    const wrapper = mount(
-      <Provider store={testStore}>
-        <MuiThemeProvider theme={theme}>
-          <AccessibiiltyPageWithStyles {...props} />
-        </MuiThemeProvider>
-      </Provider>
-    );
-
     expect(wrapper.find('#contact-us')).toBeTruthy();
   });
 });

--- a/src/accessibilityPage/accessibilityPage.component.test.tsx
+++ b/src/accessibilityPage/accessibilityPage.component.test.tsx
@@ -6,6 +6,12 @@ import {
 } from './accessibilityPage.component';
 import { MuiThemeProvider } from '@material-ui/core';
 import { buildTheme } from '../theming';
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import { StateType } from '../state/state.types';
+import { authState, initialState } from '../state/reducers/scigateway.reducer';
+import { createLocation } from 'history';
+import { Provider } from 'react-redux';
 
 const dummyClasses = {
   root: 'root-class',
@@ -16,25 +22,50 @@ const dummyClasses = {
 
 describe('Accessibility page component', () => {
   let mount;
+  let mockStore;
   let props: CombinedAccessibiiltyPageProps;
+  let state: StateType;
 
   beforeEach(() => {
     mount = createMount();
-
+    mockStore = configureStore([thunk]);
     props = {
       classes: dummyClasses,
+    };
+
+    state = {
+      scigateway: { ...initialState, authorisation: { ...authState } },
+      router: { location: createLocation('/') },
     };
   });
 
   const theme = buildTheme(false);
 
   it('should render correctly', () => {
+    const testStore = mockStore(state);
+
     const wrapper = mount(
-      <MuiThemeProvider theme={theme}>
-        <AccessibiiltyPageWithStyles {...props} />
-      </MuiThemeProvider>
+      <Provider store={testStore}>
+        <MuiThemeProvider theme={theme}>
+          <AccessibiiltyPageWithStyles {...props} />
+        </MuiThemeProvider>
+      </Provider>
     );
 
     expect(wrapper.find('#accessibility-page')).toBeTruthy();
+  });
+
+  it('should render contact us component correctly', () => {
+    const testStore = mockStore(state);
+
+    const wrapper = mount(
+      <Provider store={testStore}>
+        <MuiThemeProvider theme={theme}>
+          <AccessibiiltyPageWithStyles {...props} />
+        </MuiThemeProvider>
+      </Provider>
+    );
+
+    expect(wrapper.find('#contact-us')).toBeTruthy();
   });
 });

--- a/src/accessibilityPage/accessibilityPage.component.tsx
+++ b/src/accessibilityPage/accessibilityPage.component.tsx
@@ -10,6 +10,7 @@ import {
 } from '@material-ui/core';
 import { UKRITheme } from '../theming';
 import { Trans, useTranslation } from 'react-i18next';
+import ContactUs from './contactUs.component';
 
 const styles = (theme: Theme): StyleRules =>
   createStyles({
@@ -185,13 +186,7 @@ const AccessibiiltyPage = (
           {t('accessibility-page.contact-us-about-accessibility-text')}
         </Typography>
 
-        {/* Here will be Comments box */}
-
-        <Typography className={props.classes.description}>
-          <Link href={`mailto:${t('accessibility-page.contact-info')}`}>
-            {t('accessibility-page.contact-info')}
-          </Link>
-        </Typography>
+        <ContactUs />
       </div>
 
       <Typography variant="h4" className={props.classes.titleText}>

--- a/src/accessibilityPage/contactUs.component.test.tsx
+++ b/src/accessibilityPage/contactUs.component.test.tsx
@@ -30,7 +30,7 @@ describe('Contact us component', () => {
 
   it('renders mailto link correctly if form url not set', () => {
     props = {
-      contactUsAccessibilityFormUrl: '',
+      contactUsAccessibilityFormUrl: undefined,
       classes: dummyClasses,
     };
 

--- a/src/accessibilityPage/contactUs.component.test.tsx
+++ b/src/accessibilityPage/contactUs.component.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { createShallow } from '@material-ui/core/test-utils';
+import {
+  ContactUsWithoutStyles,
+  CombinedContactUsProps,
+} from './contactUs.component';
+
+describe('Contact us component', () => {
+  let shallow;
+  let props: CombinedContactUsProps;
+
+  const dummyClasses = {
+    description: 'description-class',
+  };
+
+  beforeEach(() => {
+    shallow = createShallow({ untilSelector: 'ContactUs' });
+  });
+
+  it('renders iframe correctly if form url set', () => {
+    props = {
+      contactUsAccessibilityFormUrl: 'test-url',
+      classes: dummyClasses,
+    };
+
+    const wrapper = shallow(<ContactUsWithoutStyles {...props} />);
+    expect(wrapper).toMatchSnapshot();
+    expect(wrapper.find('#contact-us-form')).toBeTruthy();
+  });
+
+  it('renders mailto link correctly if form url not set', () => {
+    props = {
+      contactUsAccessibilityFormUrl: undefined,
+      classes: dummyClasses,
+    };
+
+    const wrapper = shallow(<ContactUsWithoutStyles {...props} />);
+    expect(wrapper).toMatchSnapshot();
+    expect(wrapper.find('#contact-info')).toBeTruthy();
+  });
+});

--- a/src/accessibilityPage/contactUs.component.test.tsx
+++ b/src/accessibilityPage/contactUs.component.test.tsx
@@ -30,7 +30,7 @@ describe('Contact us component', () => {
 
   it('renders mailto link correctly if form url not set', () => {
     props = {
-      contactUsAccessibilityFormUrl: undefined,
+      contactUsAccessibilityFormUrl: '',
       classes: dummyClasses,
     };
 

--- a/src/accessibilityPage/contactUs.component.tsx
+++ b/src/accessibilityPage/contactUs.component.tsx
@@ -22,7 +22,7 @@ const styles = (theme: Theme): StyleRules =>
   });
 
 interface ContactUsProps {
-  contactUsAccessibilityFormUrl: string | undefined;
+  contactUsAccessibilityFormUrl: string;
 }
 
 export type CombinedContactUsProps = WithStyles<typeof styles> & ContactUsProps;
@@ -32,7 +32,8 @@ const ContactUs = (props: CombinedContactUsProps): React.ReactElement => {
 
   return (
     <div id="contact-us">
-      {props.contactUsAccessibilityFormUrl ? (
+      {/* If we have a contact us form link properly defined in the settings */}
+      {props.contactUsAccessibilityFormUrl !== '' ? (
         <div id="contact-us-form">
           <iframe
             title="Contact Us"
@@ -44,6 +45,8 @@ const ContactUs = (props: CombinedContactUsProps): React.ReactElement => {
         </div>
       ) : (
         <div id="contact-info">
+          {/* Otherwise, we have no contact us form to link to. Display an email
+          address for the user to email support themselves */}
           <Typography className={props.classes.description}>
             <Link href={`mailto:${t('accessibility-page.contact-info')}`}>
               {t('accessibility-page.contact-info')}

--- a/src/accessibilityPage/contactUs.component.tsx
+++ b/src/accessibilityPage/contactUs.component.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { StateType } from '../state/state.types';
+import Typography from '@material-ui/core/Typography';
+import {
+  Theme,
+  StyleRules,
+  createStyles,
+  WithStyles,
+  withStyles,
+  Link,
+} from '@material-ui/core';
+import { connect } from 'react-redux';
+import { useTranslation } from 'react-i18next';
+
+const styles = (theme: Theme): StyleRules =>
+  createStyles({
+    description: {
+      marginTop: theme.spacing(2),
+      marginBottom: theme.spacing(2),
+      color: theme.palette.text.primary,
+    },
+  });
+
+interface ContactUsProps {
+  contactUsAccessibilityFormUrl: string | undefined;
+}
+
+export type CombinedContactUsProps = WithStyles<typeof styles> & ContactUsProps;
+
+const ContactUs = (props: CombinedContactUsProps): React.ReactElement => {
+  const [t] = useTranslation();
+
+  return (
+    <div id="contact-us">
+      {props.contactUsAccessibilityFormUrl ? (
+        <div id="contact-us-form">
+          <iframe
+            title="Contact Us"
+            width="740px"
+            height="840px"
+            src={props.contactUsAccessibilityFormUrl}
+            allowFullScreen
+          ></iframe>
+        </div>
+      ) : (
+        <div id="contact-info">
+          <Typography className={props.classes.description}>
+            <Link href={`mailto:${t('accessibility-page.contact-info')}`}>
+              {t('accessibility-page.contact-info')}
+            </Link>
+          </Typography>
+        </div>
+      )}
+    </div>
+  );
+};
+
+const mapStateToProps = (state: StateType): ContactUsProps => ({
+  contactUsAccessibilityFormUrl: state.scigateway.contactUsAccessibilityFormUrl,
+});
+export const ContactUsWithStyles = withStyles(styles)(ContactUs);
+export const ContactUsWithoutStyles = ContactUs;
+
+export default connect(mapStateToProps)(ContactUsWithStyles);

--- a/src/accessibilityPage/contactUs.component.tsx
+++ b/src/accessibilityPage/contactUs.component.tsx
@@ -22,7 +22,7 @@ const styles = (theme: Theme): StyleRules =>
   });
 
 interface ContactUsProps {
-  contactUsAccessibilityFormUrl: string;
+  contactUsAccessibilityFormUrl: string | undefined;
 }
 
 export type CombinedContactUsProps = WithStyles<typeof styles> & ContactUsProps;
@@ -32,8 +32,9 @@ const ContactUs = (props: CombinedContactUsProps): React.ReactElement => {
 
   return (
     <div id="contact-us">
-      {/* If we have a contact us form link properly defined in the settings */}
-      {props.contactUsAccessibilityFormUrl !== '' ? (
+      {/* If we have a contact us form link defined in the settings, display the form */}
+      {props.contactUsAccessibilityFormUrl &&
+      props.contactUsAccessibilityFormUrl !== '' ? (
         <div id="contact-us-form">
           <iframe
             title="Contact Us"

--- a/src/state/actions/scigateway.actions.test.tsx
+++ b/src/state/actions/scigateway.actions.test.tsx
@@ -26,6 +26,7 @@ import {
   resetAuthState,
   customNavigationDrawerLogo,
   customAdminPageDefaultTab,
+  registerContactUsAccessibilityFormUrl,
 } from './scigateway.actions';
 import {
   ToggleDrawerType,
@@ -949,5 +950,32 @@ describe('scigateway actions', () => {
         instant: false,
       },
     });
+  });
+
+  it('given a contactUsAccessibilityFormUrl, registration is run', async () => {
+    (mockAxios.get as jest.Mock).mockImplementation(() =>
+      Promise.resolve({
+        data: {
+          contactUsAccessibilityFormUrl: '/test',
+        },
+      })
+    );
+
+    const asyncAction = configureSite();
+    const actions: Action[] = [];
+    const dispatch = (action: Action): number => actions.push(action);
+    const getState = (): Partial<StateType> => ({
+      scigateway: initialState,
+      router: {
+        location: { ...createLocation('/'), query: {} },
+        action: 'PUSH',
+      },
+    });
+
+    await asyncAction(dispatch, getState);
+
+    expect(actions).toContainEqual(
+      registerContactUsAccessibilityFormUrl('/test')
+    );
   });
 });

--- a/src/state/actions/scigateway.actions.tsx
+++ b/src/state/actions/scigateway.actions.tsx
@@ -57,6 +57,8 @@ import {
   CustomNavigationDrawerLogoType,
   CustomAdminPageDefaultTabPayload,
   CustomAdminPageDefaultTabType,
+  RegisterContactUsAccessibilityFormUrlType,
+  ContactUsAccessibilityFormUrlPayload,
 } from '../scigateway.types';
 import { ActionType, LogoState, StateType, ThunkResult } from '../state.types';
 import loadMicroFrontends from './loadMicroFrontends';
@@ -294,6 +296,14 @@ export const configureSite = (): ThunkResult<Promise<void>> => {
 
         if (settings['homepageUrl']) {
           dispatch(registerHomepageUrl(settings['homepageUrl']));
+        }
+
+        if (settings['contactUsAccessibilityFormUrl']) {
+          dispatch(
+            registerContactUsAccessibilityFormUrl(
+              settings['contactUsAccessibilityFormUrl']
+            )
+          );
         }
 
         if (settings['logo']) {
@@ -589,3 +599,12 @@ export const dismissMenuItem = (
     },
   };
 };
+
+export const registerContactUsAccessibilityFormUrl = (
+  contactUsAccessibilityFormUrl: string
+): ActionType<ContactUsAccessibilityFormUrlPayload> => ({
+  type: RegisterContactUsAccessibilityFormUrlType,
+  payload: {
+    contactUsAccessibilityFormUrl: contactUsAccessibilityFormUrl,
+  },
+});

--- a/src/state/reducers/scigateway.reducer.test.tsx
+++ b/src/state/reducers/scigateway.reducer.test.tsx
@@ -591,7 +591,7 @@ describe('scigateway reducer', () => {
   });
 
   it('should register the contactUsAccessibilityFormUrl when provided', () => {
-    expect(state.contactUsAccessibilityFormUrl).toEqual('');
+    expect(state.contactUsAccessibilityFormUrl).toBeFalsy();
 
     const updatedState = ScigatewayReducer(
       state,

--- a/src/state/reducers/scigateway.reducer.test.tsx
+++ b/src/state/reducers/scigateway.reducer.test.tsx
@@ -591,7 +591,7 @@ describe('scigateway reducer', () => {
   });
 
   it('should register the contactUsAccessibilityFormUrl when provided', () => {
-    expect(state.contactUsAccessibilityFormUrl).toBeFalsy();
+    expect(state.contactUsAccessibilityFormUrl).toEqual('');
 
     const updatedState = ScigatewayReducer(
       state,

--- a/src/state/reducers/scigateway.reducer.test.tsx
+++ b/src/state/reducers/scigateway.reducer.test.tsx
@@ -25,6 +25,7 @@ import {
   customAdminPageDefaultTab,
   autoLoginAuthorised,
   resetAuthState,
+  registerContactUsAccessibilityFormUrl,
 } from '../actions/scigateway.actions';
 import ScigatewayReducer, {
   initialState,
@@ -587,5 +588,16 @@ describe('scigateway reducer', () => {
     expect(call)
       .toEqual(`Attempted to initialise analytics without analytics configuration -
       configureAnalytics needs to be performed before initialising`);
+  });
+
+  it('should register the contactUsAccessibilityFormUrl when provided', () => {
+    expect(state.contactUsAccessibilityFormUrl).toBeFalsy();
+
+    const updatedState = ScigatewayReducer(
+      state,
+      registerContactUsAccessibilityFormUrl('/test')
+    );
+
+    expect(updatedState.contactUsAccessibilityFormUrl).toEqual('/test');
   });
 });

--- a/src/state/reducers/scigateway.reducer.tsx
+++ b/src/state/reducers/scigateway.reducer.tsx
@@ -87,7 +87,6 @@ export const initialState: ScigatewayState = {
     show: false,
     message: '',
   },
-  contactUsAccessibilityFormUrl: '',
 };
 
 export function handleNotification(

--- a/src/state/reducers/scigateway.reducer.tsx
+++ b/src/state/reducers/scigateway.reducer.tsx
@@ -46,6 +46,8 @@ import {
   CustomNavigationDrawerLogoType,
   CustomAdminPageDefaultTabPayload,
   CustomAdminPageDefaultTabType,
+  RegisterContactUsAccessibilityFormUrlType,
+  ContactUsAccessibilityFormUrlPayload,
 } from '../scigateway.types';
 import { ScigatewayState, AuthState } from '../state.types';
 import { buildPluginConfig } from '../pluginhelper';
@@ -474,6 +476,16 @@ export function handleLoadHighContrastModePreference(
   };
 }
 
+export function handleRegisterContactUsAccessibilityFormUrl(
+  state: ScigatewayState,
+  payload: ContactUsAccessibilityFormUrlPayload
+): ScigatewayState {
+  return {
+    ...state,
+    contactUsAccessibilityFormUrl: payload.contactUsAccessibilityFormUrl,
+  };
+}
+
 const ScigatewayReducer = createReducer(initialState, {
   [NotificationType]: handleNotification,
   [ToggleDrawerType]: handleDrawerToggle,
@@ -503,6 +515,8 @@ const ScigatewayReducer = createReducer(initialState, {
   [CustomLogoType]: handleCustomLogo,
   [CustomNavigationDrawerLogoType]: handleCustomNavigationDrawerLogo,
   [CustomAdminPageDefaultTabType]: handleCustomAdminPageDefaultTab,
+  [RegisterContactUsAccessibilityFormUrlType]:
+    handleRegisterContactUsAccessibilityFormUrl,
 });
 
 export default ScigatewayReducer;

--- a/src/state/reducers/scigateway.reducer.tsx
+++ b/src/state/reducers/scigateway.reducer.tsx
@@ -87,6 +87,7 @@ export const initialState: ScigatewayState = {
     show: false,
     message: '',
   },
+  contactUsAccessibilityFormUrl: '',
 };
 
 export function handleNotification(

--- a/src/state/scigateway.types.tsx
+++ b/src/state/scigateway.types.tsx
@@ -40,6 +40,8 @@ export const CustomNavigationDrawerLogoType =
   'scigateway:custom_navigation_drawer_logo';
 export const CustomAdminPageDefaultTabType =
   'scigateway:custom_admin_default_tab';
+export const RegisterContactUsAccessibilityFormUrlType =
+  'scigateway:contact_us_accessibility_form_url';
 
 export const scigatewayRoutes = {
   home: '/',
@@ -199,4 +201,8 @@ export interface ConfigureAnalyticsPayload {
 
 export interface AddHelpTourStepsPayload {
   steps: Step[];
+}
+
+export interface ContactUsAccessibilityFormUrlPayload {
+  contactUsAccessibilityFormUrl: string;
 }

--- a/src/state/state.types.tsx
+++ b/src/state/state.types.tsx
@@ -41,7 +41,7 @@ export interface ScigatewayState {
   maintenance: MaintenanceState;
   navigationDrawerLogo?: LogoState;
   adminPageDefaultTab?: 'maintenance' | 'download';
-  contactUsAccessibilityFormUrl: string;
+  contactUsAccessibilityFormUrl?: string;
 }
 
 export interface StateType {

--- a/src/state/state.types.tsx
+++ b/src/state/state.types.tsx
@@ -41,6 +41,7 @@ export interface ScigatewayState {
   maintenance: MaintenanceState;
   navigationDrawerLogo?: LogoState;
   adminPageDefaultTab?: 'maintenance' | 'download';
+  contactUsAccessibilityFormUrl?: string;
 }
 
 export interface StateType {

--- a/src/state/state.types.tsx
+++ b/src/state/state.types.tsx
@@ -41,7 +41,7 @@ export interface ScigatewayState {
   maintenance: MaintenanceState;
   navigationDrawerLogo?: LogoState;
   adminPageDefaultTab?: 'maintenance' | 'download';
-  contactUsAccessibilityFormUrl?: string;
+  contactUsAccessibilityFormUrl: string;
 }
 
 export interface StateType {


### PR DESCRIPTION
## Description
I have successfully created two separate Contact Us forms for the accessibility page using Microsoft Forms, one for ISIS and one for Diamond. However, it comes with a lot of external reliance. These are the biggest problems and we'll need to think about whether we want to fix these somehow or just work with them as they are:

- The form is an embedded Microsoft Form, owned and managed by **my** Microsoft account. If the form is ever deleted or access to it is lost for whatever reason, this would invalidate the `src` for the `<iframe>` form object, which creates an `<iframe>` with a 404 Not Found DataGateway page
- Only the form owner receives the responses from the form, meaning by default I receive the responses at sam.glendenning@stfc.ac.uk. To bypass this, I've created two flows in **Microsoft Power Automate** to forward the response to an email of my choice instead. _Currently, for testing purposes, the responses get forwarded to my personal email address_. When SciGateway goes into production, I will need to change the Power Automate flows to forward to the ISIS and DLS support emails.

The `src` value for the Contact Us form is added in SciGateway's `public/settings.json` as a field called `"contactUsAccessibilityFormUrl"`. Each form reports to separate email addresses, i.e. the ISIS form reports to the ISIS support email and the DLS form reports to the DLS support email. We'd need to make note of the exact URLs for the forms so that we don't lose them. Not sure where we'd store these. These are the links to the forms (add these into the `settings.json` file:

- ISIS: "https://forms.office.com/Pages/ResponsePage.aspx?id=HDZmP36oWEGPYZnoLbPKyO8uU1PmT5xLp0L7-EJWMzBUMUw3WjNJSzY1M09DUFo0VlNHN0w0M1M5My4u&embed=true"
- DLS: "https://forms.office.com/Pages/ResponsePage.aspx?id=HDZmP36oWEGPYZnoLbPKyO8uU1PmT5xLp0L7-EJWMzBUQzFBWDdDNzNGQzhJWDBBRk5CODZBODBNMS4u&embed=true"

I've tried my best to avert the problems I've listed above. If `"contactUsAccessibilityFormUrl"` does not exist in the settings, the form is replaced by a `mailto` email address. This email address is whatever value is set in `accessibility-page.contact-info` in `res/default.json`. This should be an ISIS email for ISIS deployment and DLS email for DLS deployment. However, this does nothing to address the problem where an invalid form URL will break the `<iframe>` entirely (any ideas for this are welcome).

If anyone could give some ideas on this functionality being improved and how to bypass some of the problems, that would be valuable.

## Screenshots
Form submission in action
![Form submission compressed](https://user-images.githubusercontent.com/71134574/158610602-5e45ebec-d80a-467b-87f0-6444c17a6ce6.gif)

The received email response
![Received email](https://user-images.githubusercontent.com/71134574/158610633-bc406cc7-bd41-4100-a24f-95633276ef26.PNG)

The ISIS Power Automate flow
![Power Automate flow](https://user-images.githubusercontent.com/71134574/158612352-7f4056f0-0970-4395-89a5-f140bedb9d72.PNG)

## Testing instructions
- [x] Review code
- [x] Check Actions build
- [x] Review changes to test coverage
- [x] Set the `"contactUsAccessibilityFormUrl"` field in `public/settings.json` to either the ISIS or DLS URL. Load SciGateway and navigate to `/accessibility` to see the form in action. You are welcome to test that the form submission works but remember that the responses are currently being forwarded to my personal email address (can ask me to see if I received the response)
- [x] Test that the `mailto` email address for support appears in place of the form if `"contactUsAccessibilityFormUrl"` is ~~not defined~~ equal to '' (empty string) in `public/settings.json`

## Agile board tracking
Closes #990