### PR TITLE
Hide plugin routes from menu

### DIFF
--- a/src/navigationDrawer/__snapshots__/navigationDrawer.component.test.tsx.snap
+++ b/src/navigationDrawer/__snapshots__/navigationDrawer.component.test.tsx.snap
@@ -165,7 +165,7 @@ exports[`Navigation drawer component does not display link to homepage if a home
 </div>
 `;
 
-exports[`Navigation drawer component does not render admin plugins in list 1`] = `
+exports[`Navigation drawer component does not render admin plugins or plugins that ask to hide in list 1`] = `
 <div
   className="MuiDrawer-root MuiDrawer-docked drawer-1"
 >

--- a/src/navigationDrawer/navigationDrawer.component.test.tsx
+++ b/src/navigationDrawer/navigationDrawer.component.test.tsx
@@ -104,7 +104,7 @@ describe('Navigation drawer component', () => {
     expect(wrapper.find('[to="plugin_link"]').first()).toMatchSnapshot();
   });
 
-  it('does not render admin plugins in list', () => {
+  it('does not render admin plugins or plugins that ask to hide in list', () => {
     const dummyPlugins: PluginConfig[] = [
       {
         order: 0,
@@ -113,6 +113,14 @@ describe('Navigation drawer component', () => {
         section: 'DATA',
         displayName: 'display name',
         admin: true,
+      },
+      {
+        order: 1,
+        plugin: 'data-plugin-2',
+        link: 'plugin_link_2',
+        section: 'DATA',
+        displayName: 'display name 2',
+        hideFromMenu: true,
       },
     ];
 

--- a/src/navigationDrawer/navigationDrawer.component.tsx
+++ b/src/navigationDrawer/navigationDrawer.component.tsx
@@ -138,9 +138,9 @@ class NavigationDrawer extends Component<CombinedNavigationProps> {
         (plugin) => plugin.link !== this.props.homepageUrl
       );
     }
-    // Do not include non admin plugins in the drawer list
+    // Do not include admin plugins or plugins that explicitly ask to hide in the drawer list
     const sectionPlugins = structureMenuData(
-      plugins.filter((plugin) => !plugin.admin)
+      plugins.filter((plugin) => !plugin.admin && !plugin.hideFromMenu)
     );
 
     return (

--- a/src/state/scigateway.types.tsx
+++ b/src/state/scigateway.types.tsx
@@ -109,6 +109,7 @@ export interface RegisterRoutePayload {
   link: string;
   plugin: string;
   displayName: string;
+  hideFromMenu?: boolean;
   admin?: boolean;
   order: number;
   helpText?: string;
@@ -123,6 +124,7 @@ export interface PluginConfig {
   link: string;
   plugin: string;
   displayName: string;
+  hideFromMenu?: boolean;
   admin?: boolean;
   order: number;
   helpText?: string;


### PR DESCRIPTION
## Description
DOI redirect is a route that needs to not be in the nav drawer, so parse a boolean from the register route config to add that functionality

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [x] Try with DOI redirect branch

Connects to https://github.com/ral-facilities/datagateway/issues/1198