### PR TITLE
Create Actions workflow for uploading container image to Harbor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -141,3 +141,11 @@ updates:
           - 4.19.0
           - 4.20.0
           - 4.21.0
+
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "00:00"
+      timezone: Europe/London

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -13,3 +13,9 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
+      - name: Log in to Harbor
+        uses: docker/login-action@v1
+        with:
+          registry: harbor.stfc.ac.uk/datagateway
+          username: ${{ secrets.HARBOR_USERNAME }}
+          password: ${{ secrets.HARBOR_TOKEN }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -19,3 +19,8 @@ jobs:
           registry: harbor.stfc.ac.uk/datagateway
           username: ${{ secrets.HARBOR_USERNAME }}
           password: ${{ secrets.HARBOR_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: harbor.stfc.ac.uk/datagateway/scigateway

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,3 +1,8 @@
+# This workflow file builds and pushes the Dockerfile
+# located in this repo, to the SCD harbor Docker registry.
+# It uses a harbor robot account, who's credentials are 
+# stored as secrets in this repo.
+
 name: Build & Push Docker Image
 
 on:
@@ -24,3 +29,10 @@ jobs:
         uses: docker/metadata-action@v3
         with:
           images: harbor.stfc.ac.uk/datagateway/scigateway
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,6 +1,6 @@
 # This workflow file builds and pushes the Dockerfile
 # located in this repo, to the SCD harbor Docker registry.
-# It uses a harbor robot account, who's credentials are 
+# It uses a harbor robot account, whose credentials are 
 # stored as secrets in this repo.
 
 name: Build & Push Docker Image

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,15 @@
+name: Build & Push Docker Image
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - deployment/push-docker-image-to-harbor-#1030
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to Harbor
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - deployment/push-docker-image-to-harbor-#1030
+      - k8s-deployment
 
 jobs:
   push_to_registry:


### PR DESCRIPTION
## Description
Creates a [GitHub Actions workflow](https://github.com/ral-facilities/scigateway/actions/workflows/docker-build.yml) for building and pushing the `Dockerfile` to the SCD Harbor Docker registry. It uses a Harbor robot account whose credentials are stored as secrets in this repo.

## Testing instructions
- [x] Review code
- [x] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
closes #1030 