### PR TITLE
Homepage accessible regardless of login status #1049

### DIFF
--- a/cypress/integration/login.spec.ts
+++ b/cypress/integration/login.spec.ts
@@ -92,7 +92,7 @@ describe('Login', () => {
   it('should login given correct credentials', () => {
     cy.visit('/login');
     cy.contains('Sign in').should('be.visible');
-    cy.get('button[aria-label="Open navigation menu"]').should('not.exist');
+    cy.get('button[aria-label="Open navigation menu"]').should('exist');
 
     cy.contains('Username*').parent().find('input').type('username');
     cy.contains('Password*').parent().find('input').type('password');
@@ -115,7 +115,7 @@ describe('Login', () => {
   it('should login given username with leading or trailing whitespace', () => {
     cy.visit('/login');
     cy.contains('Sign in').should('be.visible');
-    cy.get('button[aria-label="Open navigation menu"]').should('not.exist');
+    cy.get('button[aria-label="Open navigation menu"]').should('exist');
 
     cy.contains('Username*').parent().find('input').type(' username ');
     cy.contains('Password*').parent().find('input').type('password');
@@ -138,7 +138,7 @@ describe('Login', () => {
   it('should remain logged in following page refresh or redirect', () => {
     cy.visit('/login');
     cy.contains('Sign in').should('be.visible');
-    cy.get('button[aria-label="Open navigation menu"]').should('not.exist');
+    cy.get('button[aria-label="Open navigation menu"]').should('exist');
 
     cy.contains('Username*').parent().find('input').type(' username');
     cy.contains('Password*').parent().find('input').type('password');
@@ -357,7 +357,7 @@ describe('Login', () => {
       verifyResponse = verifySuccess;
 
       cy.contains('Sign in').should('be.visible');
-      cy.get('button[aria-label="Open navigation menu"]').should('not.exist');
+      cy.get('button[aria-label="Open navigation menu"]').should('exist');
 
       // test that autologin fails after token validation + refresh fail
       verifyResponse = failure;
@@ -367,7 +367,7 @@ describe('Login', () => {
       );
       cy.reload();
       cy.contains('Sign in').should('be.visible');
-      cy.get('button[aria-label="Open navigation menu"]').should('not.exist');
+      cy.get('button[aria-label="Open navigation menu"]').should('exist');
     });
 
     it('should be able to directly view a plugin route without signing in', () => {

--- a/src/mainAppBar/mainAppBar.component.tsx
+++ b/src/mainAppBar/mainAppBar.component.tsx
@@ -177,35 +177,31 @@ const MainAppBar = (props: CombinedMainAppBarProps): React.ReactElement => {
           disableGutters
           style={{ marginLeft: '16px', marginRight: '16px' }}
         >
-          {props.loggedIn ? (
-            props.drawerOpen === false ? (
-              <IconButton
-                className={classNames(
-                  props.classes.menuButton,
-                  props.drawerOpen && props.classes.menuButtonOpen
-                )}
-                color="inherit"
-                onClick={props.toggleDrawer}
-                aria-label={getString(props.res, 'open-navigation-menu')}
-              >
-                <MenuIcon />
-              </IconButton>
-            ) : (
-              <IconButton
-                className={classNames(
-                  props.classes.menuButtonOpen,
-                  props.drawerOpen && props.classes.menuButton,
-                  'tour-nav-menu'
-                )}
-                color="inherit"
-                onClick={props.toggleDrawer}
-                aria-label={getString(props.res, 'close-navigation-menu')}
-              >
-                <MenuOpenIcon />
-              </IconButton>
-            )
+          {!props.drawerOpen ? (
+            <IconButton
+              className={classNames(
+                props.classes.menuButton,
+                props.drawerOpen && props.classes.menuButtonOpen
+              )}
+              color="inherit"
+              onClick={props.toggleDrawer}
+              aria-label={getString(props.res, 'open-navigation-menu')}
+            >
+              <MenuIcon />
+            </IconButton>
           ) : (
-            <div className={props.classes.menuButtonPlaceholder} />
+            <IconButton
+              className={classNames(
+                props.classes.menuButtonOpen,
+                props.drawerOpen && props.classes.menuButton,
+                'tour-nav-menu'
+              )}
+              color="inherit"
+              onClick={props.toggleDrawer}
+              aria-label={getString(props.res, 'close-navigation-menu')}
+            >
+              <MenuOpenIcon />
+            </IconButton>
           )}
           <Button
             className={classNames(props.classes.titleButton, 'tour-title')}

--- a/src/routing/__snapshots__/authorisedRoute.component.test.tsx.snap
+++ b/src/routing/__snapshots__/authorisedRoute.component.test.tsx.snap
@@ -92,12 +92,15 @@ exports[`AuthorisedRoute component renders non admin component when non admin us
 </div>
 `;
 
-exports[`AuthorisedRoute component renders redirect when user not logged in 1`] = `
+exports[`AuthorisedRoute component renders redirect when user not logged in and stores referrer in router state 1`] = `
 <div>
   <Redirect
     to={
       Object {
         "pathname": "/login",
+        "state": Object {
+          "referrer": "/",
+        },
       }
     }
   />

--- a/src/routing/__snapshots__/authorisedRoute.component.test.tsx.snap
+++ b/src/routing/__snapshots__/authorisedRoute.component.test.tsx.snap
@@ -41,6 +41,23 @@ exports[`AuthorisedRoute component renders admin component when admin user acces
 </div>
 `;
 
+exports[`AuthorisedRoute component renders homepage component when homepageUrl is configured and logged in 1`] = `
+<div>
+  <HomepageComponent
+    store={
+      Object {
+        "clearActions": [Function],
+        "dispatch": [Function],
+        "getActions": [Function],
+        "getState": [Function],
+        "replaceReducer": [Function],
+        "subscribe": [Function],
+      }
+    }
+  />
+</div>
+`;
+
 exports[`AuthorisedRoute component renders non admin component when admin user accesses it 1`] = `
 <div>
   <ComponentToProtect
@@ -75,32 +92,14 @@ exports[`AuthorisedRoute component renders non admin component when non admin us
 </div>
 `;
 
-exports[`AuthorisedRoute component renders redirect when homepageUrl is configured and logged in 1`] = `
-<div>
-  <Redirect
-    push={true}
-    to={
-      Object {
-        "pathname": "/test",
-      }
-    }
-  />
-</div>
-`;
-
 exports[`AuthorisedRoute component renders redirect when user not logged in 1`] = `
 <div>
   <Redirect
-    push={true}
     to={
       Object {
         "pathname": "/login",
-        "state": Object {
-          "referrer": "/",
-        },
       }
     }
   />
-  <WithStyles(PageNotFoundComponent) />
 </div>
 `;

--- a/src/routing/__snapshots__/authorisedRoute.component.test.tsx.snap
+++ b/src/routing/__snapshots__/authorisedRoute.component.test.tsx.snap
@@ -41,7 +41,7 @@ exports[`AuthorisedRoute component renders admin component when admin user acces
 </div>
 `;
 
-exports[`AuthorisedRoute component renders homepage component when homepageUrl is configured and logged in 1`] = `
+exports[`AuthorisedRoute component renders homepage component when homepageUrl is configured 1`] = `
 <div>
   <HomepageComponent
     store={

--- a/src/routing/authorisedRoute.component.test.tsx
+++ b/src/routing/authorisedRoute.component.test.tsx
@@ -35,6 +35,10 @@ describe('AuthorisedRoute component', () => {
     mockStore = configureStore();
   });
 
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('renders non admin component when admin user accesses it', () => {
     state.scigateway.siteLoading = false;
     state.scigateway.authorisation.loading = false;
@@ -201,24 +205,28 @@ describe('AuthorisedRoute component', () => {
     );
   });
 
-  it('does not set referrer in localStorage if logged in or if referrer is homepage', () => {
+  it('does not set referrer in localStorage if logged in', () => {
     window.localStorage.__proto__.setItem = jest.fn();
     state.scigateway.authorisation.provider = new TestAuthProvider(
       'test-token'
     );
     state.router.location.pathname = '/destination/after/login';
 
-    let testStore = mockStore(state);
+    const testStore = mockStore(state);
     const AuthorisedComponent = withAuth(false)(ComponentToProtect);
     shallow(<AuthorisedComponent store={testStore} />);
 
     expect(localStorage.setItem).not.toHaveBeenCalled();
+  });
 
+  it('does not set referrer in localStorage if referrer is homepage', () => {
+    window.localStorage.__proto__.setItem = jest.fn();
     state.scigateway.authorisation.provider = new TestAuthProvider(null);
     state.scigateway.homepageUrl = '/homepage';
     state.router.location.pathname = '/homepage';
 
-    testStore = mockStore(state);
+    const testStore = mockStore(state);
+    const AuthorisedComponent = withAuth(false)(ComponentToProtect);
     shallow(<AuthorisedComponent store={testStore} />);
 
     expect(localStorage.setItem).not.toHaveBeenCalled();

--- a/src/routing/authorisedRoute.component.test.tsx
+++ b/src/routing/authorisedRoute.component.test.tsx
@@ -35,10 +35,6 @@ describe('AuthorisedRoute component', () => {
     mockStore = configureStore();
   });
 
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
-
   it('renders non admin component when admin user accesses it', () => {
     state.scigateway.siteLoading = false;
     state.scigateway.authorisation.loading = false;
@@ -107,7 +103,7 @@ describe('AuthorisedRoute component', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
-  it('renders redirect when user not logged in', () => {
+  it('renders redirect when user not logged in and stores referrer in router state', () => {
     state.scigateway.siteLoading = false;
     state.scigateway.authorisation.loading = false;
     state.scigateway.authorisation.provider = new TestAuthProvider(null);
@@ -186,49 +182,5 @@ describe('AuthorisedRoute component', () => {
 
     expect(testStore.getActions().length).toEqual(1);
     expect(testStore.getActions()[0]).toEqual(invalidToken());
-  });
-
-  it('sets referrer in localStorage if not logged in', () => {
-    window.localStorage.__proto__.setItem = jest.fn();
-    state.scigateway.siteLoading = false;
-    state.scigateway.authorisation.loading = false;
-    state.scigateway.authorisation.provider = new TestAuthProvider(null);
-    state.router.location.pathname = '/destination/after/login';
-
-    const testStore = mockStore(state);
-    const AuthorisedComponent = withAuth(false)(ComponentToProtect);
-    shallow(<AuthorisedComponent store={testStore} />);
-
-    expect(localStorage.setItem).toHaveBeenCalledWith(
-      'referrer',
-      '/destination/after/login'
-    );
-  });
-
-  it('does not set referrer in localStorage if logged in', () => {
-    window.localStorage.__proto__.setItem = jest.fn();
-    state.scigateway.authorisation.provider = new TestAuthProvider(
-      'test-token'
-    );
-    state.router.location.pathname = '/destination/after/login';
-
-    const testStore = mockStore(state);
-    const AuthorisedComponent = withAuth(false)(ComponentToProtect);
-    shallow(<AuthorisedComponent store={testStore} />);
-
-    expect(localStorage.setItem).not.toHaveBeenCalled();
-  });
-
-  it('does not set referrer in localStorage if referrer is homepage', () => {
-    window.localStorage.__proto__.setItem = jest.fn();
-    state.scigateway.authorisation.provider = new TestAuthProvider(null);
-    state.scigateway.homepageUrl = '/homepage';
-    state.router.location.pathname = '/homepage';
-
-    const testStore = mockStore(state);
-    const AuthorisedComponent = withAuth(false)(ComponentToProtect);
-    shallow(<AuthorisedComponent store={testStore} />);
-
-    expect(localStorage.setItem).not.toHaveBeenCalled();
   });
 });

--- a/src/routing/authorisedRoute.component.test.tsx
+++ b/src/routing/authorisedRoute.component.test.tsx
@@ -87,7 +87,7 @@ describe('AuthorisedRoute component', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
-  it('renders redirect when homepageUrl is configured and logged in', () => {
+  it('renders homepage component when homepageUrl is configured and logged in', () => {
     state.scigateway.siteLoading = false;
     state.scigateway.authorisation.loading = false;
     state.scigateway.authorisation.provider = new TestAuthProvider(
@@ -95,7 +95,11 @@ describe('AuthorisedRoute component', () => {
     );
     state.router.location.state = { scigateway: { homepageUrl: '/test' } };
 
-    const AuthorisedComponent = withAuth(false)(ComponentToProtect);
+    const HomepageComponent = (): React.ReactElement => (
+      <div>homepage component</div>
+    );
+
+    const AuthorisedComponent = withAuth(false)(HomepageComponent);
     const wrapper = shallow(<AuthorisedComponent store={mockStore(state)} />);
 
     expect(wrapper).toMatchSnapshot();

--- a/src/routing/authorisedRoute.component.tsx
+++ b/src/routing/authorisedRoute.component.tsx
@@ -88,8 +88,8 @@ const withAuth =
 
         return (
           <div>
-            {!loading &&
-              (!loggedIn ? (
+            {!loading ? (
+              !loggedIn ? (
                 homepageUrl && location === homepageUrl ? (
                   <ComponentToProtect {...(componentProps as T)} />
                 ) : (
@@ -104,7 +104,10 @@ const withAuth =
                 <ComponentToProtect {...(componentProps as T)} />
               ) : (
                 <PageNotFound />
-              ))}
+              )
+            ) : (
+              <PageNotFound />
+            )}
           </div>
         );
       }

--- a/src/routing/authorisedRoute.component.tsx
+++ b/src/routing/authorisedRoute.component.tsx
@@ -59,18 +59,6 @@ const withAuth =
         }
       }
 
-      private setReferrer(): void {
-        if (
-          !this.props.loggedIn &&
-          this.props.location !== '/' &&
-          !(
-            this.props.homepageUrl &&
-            this.props.location === this.props.homepageUrl
-          )
-        )
-          localStorage.setItem('referrer', this.props.location);
-      }
-
       public render(): React.ReactElement {
         const {
           loading,
@@ -84,8 +72,6 @@ const withAuth =
           ...componentProps
         } = this.props;
 
-        this.setReferrer();
-
         return (
           <div>
             {!loading ? (
@@ -96,6 +82,7 @@ const withAuth =
                   <Redirect
                     to={{
                       pathname: '/login',
+                      state: { referrer: location },
                     }}
                   />
                 )

--- a/src/routing/authorisedRoute.component.tsx
+++ b/src/routing/authorisedRoute.component.tsx
@@ -59,6 +59,18 @@ const withAuth =
         }
       }
 
+      private setReferrer(): void {
+        if (
+          !this.props.loggedIn &&
+          this.props.location !== '/' &&
+          !(
+            this.props.homepageUrl &&
+            this.props.location === this.props.homepageUrl
+          )
+        )
+          localStorage.setItem('referrer', this.props.location);
+      }
+
       public render(): React.ReactElement {
         const {
           loading,
@@ -72,6 +84,8 @@ const withAuth =
           ...componentProps
         } = this.props;
 
+        this.setReferrer();
+
         return (
           <div>
             {!loading &&
@@ -79,15 +93,11 @@ const withAuth =
                 homepageUrl && location === homepageUrl ? (
                   <ComponentToProtect {...(componentProps as T)} />
                 ) : (
-                  <div>
-                    <Redirect
-                      push
-                      to={{
-                        pathname: '/login',
-                        state: { referrer: location },
-                      }}
-                    />
-                  </div>
+                  <Redirect
+                    to={{
+                      pathname: '/login',
+                    }}
+                  />
                 )
               ) : /* If using a plugin as the start page, redirect here so the plugin renders with the redirected url */
               !adminSection || (adminSection && userIsAdmin) ? (

--- a/src/routing/authorisedRoute.component.tsx
+++ b/src/routing/authorisedRoute.component.tsx
@@ -87,7 +87,6 @@ const withAuth =
                         state: { referrer: location },
                       }}
                     />
-                    <ComponentToProtect {...(componentProps as T)} />
                   </div>
                 )
               ) : /* If using a plugin as the start page, redirect here so the plugin renders with the redirected url */

--- a/src/routing/authorisedRoute.component.tsx
+++ b/src/routing/authorisedRoute.component.tsx
@@ -16,7 +16,7 @@ interface WithAuthStateProps {
   userIsAdmin: boolean;
   provider: AuthProvider;
   location: string;
-  homepageUrlState?: StateType;
+  homepageUrl?: string;
 }
 
 interface WithAuthDispatchProps {
@@ -37,7 +37,7 @@ const mapStateToProps = (state: StateType): WithAuthStateProps => ({
   userIsAdmin: state.scigateway.authorisation.provider.isAdmin(),
   provider: state.scigateway.authorisation.provider,
   location: state.router.location.pathname,
-  homepageUrlState: state.router.location.state,
+  homepageUrl: state.scigateway.homepageUrl,
 });
 
 const mapDispatchToProps = (dispatch: Dispatch): WithAuthDispatchProps => ({
@@ -66,7 +66,7 @@ const withAuth =
           userIsAdmin,
           location,
           provider,
-          homepageUrlState,
+          homepageUrl,
           requestPluginRerender,
           invalidToken,
           ...componentProps
@@ -74,30 +74,28 @@ const withAuth =
 
         return (
           <div>
-            {!loading && !loggedIn ? (
-              <Redirect
-                push
-                to={{
-                  pathname: '/login',
-                  state: { referrer: location },
-                }}
-              />
-            ) : null}
-            {/* If using a plugin as the start page, redirect here so the plugin renders with the redirected url */}
             {!loading &&
-            loggedIn &&
-            (!adminSection || (adminSection && userIsAdmin)) ? (
-              homepageUrlState && homepageUrlState.scigateway.homepageUrl ? (
-                <Redirect
-                  push
-                  to={{ pathname: homepageUrlState.scigateway.homepageUrl }}
-                />
-              ) : (
+              (!loggedIn ? (
+                homepageUrl && location === homepageUrl ? (
+                  <ComponentToProtect {...(componentProps as T)} />
+                ) : (
+                  <div>
+                    <Redirect
+                      push
+                      to={{
+                        pathname: '/login',
+                        state: { referrer: location },
+                      }}
+                    />
+                    <ComponentToProtect {...(componentProps as T)} />
+                  </div>
+                )
+              ) : /* If using a plugin as the start page, redirect here so the plugin renders with the redirected url */
+              !adminSection || (adminSection && userIsAdmin) ? (
                 <ComponentToProtect {...(componentProps as T)} />
-              )
-            ) : (
-              <PageNotFound />
-            )}
+              ) : (
+                <PageNotFound />
+              ))}
           </div>
         );
       }

--- a/src/state/actions/scigateway.actions.test.tsx
+++ b/src/state/actions/scigateway.actions.test.tsx
@@ -91,6 +91,15 @@ describe('scigateway actions', () => {
       'this will be replaced by an API call to get access token'
     );
 
+    jest.spyOn(window.localStorage.__proto__, 'getItem');
+    window.localStorage.__proto__.getItem = jest
+      .fn()
+      .mockImplementation((name) =>
+        name === 'referrer' ? '/destination/after/login' : null
+      );
+    window.localStorage.__proto__.removeItem = jest.fn();
+    window.localStorage.__proto__.setItem = jest.fn();
+
     const mnemonic = 'anon';
     const authUrl = 'http://example.com';
 
@@ -108,13 +117,6 @@ describe('scigateway actions', () => {
     /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
     const getState = (): any => ({
       scigateway: state,
-      router: {
-        location: {
-          state: {
-            referrer: '/destination/after/login',
-          },
-        },
-      },
     });
 
     const action = asyncAction(dispatch, getState);

--- a/src/state/actions/scigateway.actions.test.tsx
+++ b/src/state/actions/scigateway.actions.test.tsx
@@ -91,15 +91,6 @@ describe('scigateway actions', () => {
       'this will be replaced by an API call to get access token'
     );
 
-    jest.spyOn(window.localStorage.__proto__, 'getItem');
-    window.localStorage.__proto__.getItem = jest
-      .fn()
-      .mockImplementation((name) =>
-        name === 'referrer' ? '/destination/after/login' : null
-      );
-    window.localStorage.__proto__.removeItem = jest.fn();
-    window.localStorage.__proto__.setItem = jest.fn();
-
     const mnemonic = 'anon';
     const authUrl = 'http://example.com';
 
@@ -117,6 +108,13 @@ describe('scigateway actions', () => {
     /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
     const getState = (): any => ({
       scigateway: state,
+      router: {
+        location: {
+          state: {
+            referrer: '/destination/after/login',
+          },
+        },
+      },
     });
 
     const action = asyncAction(dispatch, getState);

--- a/src/state/actions/scigateway.actions.tsx
+++ b/src/state/actions/scigateway.actions.tsx
@@ -490,15 +490,10 @@ export const verifyUsernameAndPassword = (
         dispatch(authorised());
 
         // redirect the user to the original page they were trying to get to
-        // the referrer is added by the redirect in routing.component.tsx
-        const previousRouteState = getState().router.location.state;
-        dispatch(
-          push(
-            previousRouteState && previousRouteState.referrer
-              ? previousRouteState.referrer
-              : '/'
-          )
-        );
+        // the referrer is set in localStorage in authorisedRoute.component.tsx
+        const referrer = localStorage.getItem('referrer');
+        localStorage.removeItem('referrer');
+        dispatch(push(referrer ?? '/'));
       })
       .catch(() => {
         // probably want to do something smarter with

--- a/src/state/actions/scigateway.actions.tsx
+++ b/src/state/actions/scigateway.actions.tsx
@@ -485,14 +485,14 @@ export const verifyUsernameAndPassword = (
     await authProvider
       .logIn(username, password)
       .then(() => {
+        const referrer = getState().router.location.state?.referrer;
+
         if (newMnemonic)
           dispatch(loadAuthProvider(`icat.${newMnemonic}`, `${authUrl}`));
         dispatch(authorised());
 
         // redirect the user to the original page they were trying to get to
-        // the referrer is set in localStorage in authorisedRoute.component.tsx
-        const referrer = localStorage.getItem('referrer');
-        localStorage.removeItem('referrer');
+        // the referrer is added by the redirect in authorisedRoute.component.tsx
         dispatch(push(referrer ?? '/'));
       })
       .catch(() => {


### PR DESCRIPTION
## Description
The user's login state now has no effect on access to the homepage or display of the navigation drawer. This means that, like ISIS, DLS now allows access to the homepage at the web root and the navigation drawer shows all web app routes (but no access allowed while not logged in). This is in comparison to how things used to work on DLS, whereby all nav drawer routes including the homepage were inaccessible until the user logged in.

This PR also includes a fix to a problem where the user would not be redirected to their original request following a successful login, instead being redirected to the homepage. This took a lot of trial and error but I came to the conclusion that this was because the current method detailed below no longer works:

- User tries to navigate to `/protected/domain`
- Router redirects to /login while storing `/protected/domain` in router state
- User successfully logs in
- A router location change is triggered to `/logout`, clearing the router state in the process (still not sure why this location change happens)
- Router state is gone at the crucial stage, therefore default redirect to web root occurs

The state is cleared between page refreshes/redirects because this is what `react-router-dom` does. But I'm unsure as to why a router `REPLACE` to `/logout` happens.

To get around this, I made a new method whereby the referral URL is stored in `localStorage` instead. It is then fetched, changed and deleted as required.

## Testing instructions
Run this with at least one other plugin loaded so that the navigation drawer can be populated. Set the `"authUrl"` in settings.json to be `"https://datagateway-preprod.diamond.ac.uk/api"` to mimic DLS DG environment (no auto login).
When navigating to the web root, you should be directed to the homepage instead of `/login`. Also, the navigation bar should be accessible but you should be redirected to `/login` upon trying to navigate to any of the routes.

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
Closes #1049