### PR TITLE
#1061 - have menu open by default no matter if you're logged in or not

### DIFF
--- a/cypress/integration/login.spec.ts
+++ b/cypress/integration/login.spec.ts
@@ -92,7 +92,6 @@ describe('Login', () => {
   it('should login given correct credentials', () => {
     cy.visit('/login');
     cy.contains('Sign in').should('be.visible');
-    cy.get('button[aria-label="Open navigation menu"]').should('exist');
 
     cy.contains('Username*').parent().find('input').type('username');
     cy.contains('Password*').parent().find('input').type('password');
@@ -114,7 +113,6 @@ describe('Login', () => {
   it('should login given username with leading or trailing whitespace', () => {
     cy.visit('/login');
     cy.contains('Sign in').should('be.visible');
-    cy.get('button[aria-label="Open navigation menu"]').should('exist');
 
     cy.contains('Username*').parent().find('input').type(' username ');
     cy.contains('Password*').parent().find('input').type('password');
@@ -136,7 +134,6 @@ describe('Login', () => {
   it('should remain logged in following page refresh or redirect', () => {
     cy.visit('/login');
     cy.contains('Sign in').should('be.visible');
-    cy.get('button[aria-label="Open navigation menu"]').should('exist');
 
     cy.contains('Username*').parent().find('input').type(' username');
     cy.contains('Password*').parent().find('input').type('password');
@@ -326,33 +323,34 @@ describe('Login', () => {
       });
     });
 
-    it('should show the sidebar and yet still show the Sign in button', () => {
+    it('should allow access to plugins and yet still show the Sign in button', () => {
       verifyResponse = verifySuccess;
       loginResponse = loginSuccess;
-      cy.visit('/');
+      cy.visit('/plugin1');
 
-      cy.get('button[aria-label="Close navigation menu"]').should('be.visible');
+      cy.get('#demo_plugin').contains('Demo Plugin').should('be.visible');
       cy.contains('Sign in').should('be.visible');
 
       // test that token verification also works with autologin
       cy.reload();
-      cy.get('button[aria-label="Close navigation menu"]').should('be.visible');
+      cy.get('#demo_plugin').contains('Demo Plugin').should('be.visible');
       cy.contains('Sign in').should('be.visible');
 
       // test that autologin works after token validation + refresh fail
       verifyResponse = failure;
       cy.intercept('POST', '/refresh', { statusCode: 403 });
       cy.reload();
-      cy.get('button[aria-label="Close navigation menu"]').should('be.visible');
+      cy.get('#demo_plugin').contains('Demo Plugin').should('be.visible');
       cy.contains('Sign in').should('be.visible');
     });
 
-    it('should not display as logged in if autologin requests fail', () => {
+    it('should not be logged in if autologin requests fail', () => {
       loginResponse = failure;
       verifyResponse = verifySuccess;
 
-      cy.contains('Sign in').should('be.visible');
-      cy.get('button[aria-label="Open navigation menu"]').should('exist');
+      cy.visit('/plugin1');
+      cy.get('#demo_plugin').should('not.exist');
+      cy.contains('h1', 'Sign in').should('be.visible');
 
       // test that autologin fails after token validation + refresh fail
       verifyResponse = failure;
@@ -361,8 +359,8 @@ describe('Login', () => {
         $window.localStorage.setItem('scigateway:token', 'invalidtoken')
       );
       cy.reload();
-      cy.contains('Sign in').should('be.visible');
-      cy.get('button[aria-label="Open navigation menu"]').should('exist');
+      cy.get('#demo_plugin').should('not.exist');
+      cy.contains('h1', 'Sign in').should('be.visible');
     });
 
     it('should be able to directly view a plugin route without signing in', () => {

--- a/cypress/integration/scigateway_frontend_spec.tsx
+++ b/cypress/integration/scigateway_frontend_spec.tsx
@@ -54,12 +54,12 @@ describe('Scigateway', () => {
 
     cy.url().should('eq', 'http://127.0.0.1:3000/');
 
-    cy.get('button[aria-label="Open navigation menu"]').should('exist');
+    cy.get('button[aria-label="Close navigation menu"]').should('exist');
     cy.get('button[aria-label="Help page"]').click();
+    cy.get('button[aria-label="Close navigation menu"]').should('exist');
+    cy.get('button[aria-label="Close navigation menu"]').click();
     cy.get('button[aria-label="Open navigation menu"]').should('exist');
-    cy.get('button[aria-label="Open navigation menu"]').click();
-    cy.get('button[aria-label="Close navigation menu"]').should('exist');
     cy.get('button[aria-label="Home page"]').click();
-    cy.get('button[aria-label="Close navigation menu"]').should('exist');
+    cy.get('button[aria-label="Open navigation menu"]').should('exist');
   });
 });

--- a/src/mainAppBar/mainAppBar.component.tsx
+++ b/src/mainAppBar/mainAppBar.component.tsx
@@ -165,16 +165,13 @@ const MainAppBar = (props: CombinedMainAppBarProps): React.ReactElement => {
     }
   }, [props.plugins, location, props.loading, props.singlePluginLogo]);
 
+  // have menu open by default after page loads
   React.useEffect(() => {
-    if (
-      !props.loading &&
-      props.loggedIn &&
-      !props.drawerOpen &&
-      props.pathname !== '/login'
-    )
+    if (!props.loading && !props.drawerOpen) {
       props.toggleDrawer();
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [props.loading, props.loggedIn]);
+  }, [props.loading]);
 
   return (
     <div className={props.classes.root}>

--- a/src/state/reducers/scigateway.reducer.tsx
+++ b/src/state/reducers/scigateway.reducer.tsx
@@ -246,7 +246,6 @@ export function handleTokenExpiration(state: ScigatewayState): ScigatewayState {
   state.authorisation.provider.logOut();
   return {
     ...state,
-    drawerOpen: false,
     authorisation: {
       ...resetAuth(state.authorisation),
       signedOutDueToTokenInvalidation: true,


### PR DESCRIPTION
## Description
Basically I just removed the check for logged in users (and also for the login page as I figured we can just have the menu open everywhere by default for simplicity). Also stopped the drawer from closing on token invalidation.

## Testing instructions
- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] Use server with no autoLogin (e.g. DLS preprod) and the menu is visible by default when logged out

## Agile board tracking
Closes #1061 