### PR TITLE
Fix token refresh error

### DIFF
--- a/public/res/default.json
+++ b/public/res/default.json
@@ -67,35 +67,6 @@
       "button": "Read more"
     }
   },
-  "home_page": {
-    "title_line1": "<0>Data discovery</0> and <2>access</2>",
-    "title_line2": "for <1>large-scale</1> science facilities",
-    "browse": {
-      "title": "Browse, explore and visualise experimental data",
-      "description1": "Large scale facilities, such as synchrotrons, neutron and muon sources, lasers and accelerators, generate vast amounts of data that need to be managed in an efficient way, supporting data ingestion for long-term storage and archival, as well as data analysis and data publication workflows.",
-      "description2": "<0>DataGateway</0> focuses on providing data discovery and data access functionality to the data.",
-      "link": "/browse/investigation",
-      "button": "Browse data"
-    },
-    "search": {
-      "title": "Search",
-      "description": "Search for the experimental data according to different criteria.",
-      "link": "/search/data",
-      "button": "Search data"
-    },
-    "download": {
-      "title": "Download",
-      "description": "Retrieve the experimental data using a variety of download methods.",
-      "link": "/download",
-      "button": "Download data"
-    },
-    "facility": {
-      "title": "ISIS Neutron and Muon Source",
-      "description": "World-leading centre for research giving unique insights into the properties of materials on the atomic scale.",
-      "link": "https://www.isis.stfc.ac.uk/Pages/About.aspx",
-      "button": "Read more"
-    }
-  },
   "contact-page": {
     "title": "Contact",
     "contact-details-description": "For problems with SciGateway, please contact <a href='mailto:example@email.com?subject=Feedback From SciGateway'>example@email.com</a>"

--- a/public/res/default.json
+++ b/public/res/default.json
@@ -35,7 +35,8 @@
     "need-help-signing-in": "Need help signing in?",
     "need-help-signing-in-link": "https://www.isis.stfc.ac.uk/Pages/Troubleshoot-Login.aspx",
     "dont-have-an-account-sign-up-now": "Don't have an account? <2>Sign up now</2>",
-    "dont-have-an-account-sign-up-now-link": "https://users.facilities.rl.ac.uk/auth/CreateAccount.aspx"
+    "dont-have-an-account-sign-up-now-link": "https://users.facilities.rl.ac.uk/auth/CreateAccount.aspx",
+    "auto-login-error-msg": "Unable to create anonymous session - please reload the page. If the error persists please contact support"
   },
   "home-page": {
     "title_line1": "<0>Data discovery</0> and <2>access</2>",
@@ -63,6 +64,35 @@
       "title": "Facility Title",
       "description": "Facility Description",
       "link": "#",
+      "button": "Read more"
+    }
+  },
+  "home_page": {
+    "title_line1": "<0>Data discovery</0> and <2>access</2>",
+    "title_line2": "for <1>large-scale</1> science facilities",
+    "browse": {
+      "title": "Browse, explore and visualise experimental data",
+      "description1": "Large scale facilities, such as synchrotrons, neutron and muon sources, lasers and accelerators, generate vast amounts of data that need to be managed in an efficient way, supporting data ingestion for long-term storage and archival, as well as data analysis and data publication workflows.",
+      "description2": "<0>DataGateway</0> focuses on providing data discovery and data access functionality to the data.",
+      "link": "/browse/investigation",
+      "button": "Browse data"
+    },
+    "search": {
+      "title": "Search",
+      "description": "Search for the experimental data according to different criteria.",
+      "link": "/search/data",
+      "button": "Search data"
+    },
+    "download": {
+      "title": "Download",
+      "description": "Retrieve the experimental data using a variety of download methods.",
+      "link": "/download",
+      "button": "Download data"
+    },
+    "facility": {
+      "title": "ISIS Neutron and Muon Source",
+      "description": "World-leading centre for research giving unique insights into the properties of materials on the atomic scale.",
+      "link": "https://www.isis.stfc.ac.uk/Pages/About.aspx",
       "button": "Read more"
     }
   },

--- a/src/state/middleware/scigateway.middleware.test.tsx
+++ b/src/state/middleware/scigateway.middleware.test.tsx
@@ -19,6 +19,7 @@ import {
   LoadHighContrastModePreferenceType,
   SignOutType,
   AuthFailureType,
+  NotificationType,
 } from '../scigateway.types';
 import { toastr } from 'react-redux-toastr';
 import { AddHelpTourStepsType } from '../scigateway.types';
@@ -445,16 +446,33 @@ describe('scigateway middleware', () => {
     expect(refreshSpy).toHaveBeenCalled();
   });
 
-  it('should listen for events and fire invalidateToken action on invalidateToken message', async () => {
+  it('should listen for events and fires invalidateToken action & notification event on invalidateToken message & failed refresh', async () => {
     listenToPlugins(store.dispatch, getState);
 
-    handler(new CustomEvent('test', { detail: { type: InvalidateTokenType } }));
+    const notificationPayload = { severity: 'error', message: 'Token error' };
+
+    handler(
+      new CustomEvent('test', {
+        detail: {
+          type: InvalidateTokenType,
+          payload: notificationPayload,
+        },
+      })
+    );
 
     await flushPromises();
 
     expect(document.addEventListener).toHaveBeenCalled();
     expect(store.getActions().length).toEqual(1);
-    expect(store.getActions()[0]).toEqual({ type: InvalidateTokenType });
+    expect(store.getActions()[0]).toEqual({
+      type: InvalidateTokenType,
+      payload: notificationPayload,
+    });
+    expect(events.length).toEqual(1);
+    expect(events[0].detail).toEqual({
+      type: NotificationType,
+      payload: notificationPayload,
+    });
   });
 
   it('should listen for events and fire registerroute action and addHelpTourStep action when helpText present', () => {
@@ -592,7 +610,7 @@ describe('scigateway middleware', () => {
       listenToPlugins(store.dispatch, getState);
 
       const notificationAction = {
-        type: 'scigateway:api:notification',
+        type: NotificationType,
         payload: {
           message: 'test notification',
         },
@@ -609,7 +627,7 @@ describe('scigateway middleware', () => {
       listenToPlugins(store.dispatch, getState);
 
       const notificationAction = {
-        type: 'scigateway:api:notification',
+        type: NotificationType,
         payload: {
           message: 'test notification',
           severity: 'success',
@@ -628,7 +646,7 @@ describe('scigateway middleware', () => {
       listenToPlugins(store.dispatch, getState);
 
       const notificationAction = {
-        type: 'scigateway:api:notification',
+        type: NotificationType,
         payload: {
           message: 'test notification',
           severity: 'error',
@@ -648,7 +666,7 @@ describe('scigateway middleware', () => {
       listenToPlugins(store.dispatch, getState);
 
       const notificationAction = {
-        type: 'scigateway:api:notification',
+        type: NotificationType,
         payload: {
           message: 'test notification',
           severity: 'warning',

--- a/src/state/middleware/scigateway.middleware.tsx
+++ b/src/state/middleware/scigateway.middleware.tsx
@@ -181,7 +181,20 @@ export const listenToPlugins = (
         case InvalidateTokenType:
           getState()
             .scigateway.authorisation.provider.refresh()
-            .catch(() => dispatch(pluginMessage.detail));
+            .catch(() => {
+              dispatch(pluginMessage.detail);
+              // if there's an error message in the token invalidation event then broadcast it
+              if (pluginMessage.detail.payload) {
+                document.dispatchEvent(
+                  new CustomEvent(microFrontendMessageId, {
+                    detail: {
+                      type: NotificationType,
+                      payload: pluginMessage.detail.payload,
+                    },
+                  })
+                );
+              }
+            });
           break;
         default:
           // log and ignore


### PR DESCRIPTION
## Description
Goes with ral-facilities/datagateway#1262

Allow plugins to send a notification payload alongside their token invalidation request event, which we then only display after the token refresh has failed.

## Testing instructions
- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] Get me to lower the ICAT session length (or mock that yourself) and test with PR ral-facilities/datagateway#1262

## Agile board tracking
Part of the fix for ral-facilities/datagateway#1257