### PR TITLE
Implement best practices in Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+/.github
+/.husky
+/cypress
+/demos
+.eslintrc.js
+.gitignore
+.prettierrc
+codecov.yml
+CODEOWNERS
+cypress.json
+Jenkinsfile
+LICENSE.md
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,9 @@ COPY --from=build /scigateway/build/. .
 RUN apk --no-cache add libcap \
   # Privileged ports are permitted to root only by default.
   # setcap to bind to privileged ports (80) as non-root.
-  && setcap 'cap_net_bind_service=+ep' /usr/local/apache2/bin/httpd
+  && setcap 'cap_net_bind_service=+ep' /usr/local/apache2/bin/httpd \
+  # Change access righs for logs from root to www-data
+  && chown www-data:www-data /usr/local/apache2/logs
 
 # Switch to non-root user defined in httpd image
 USER www-data

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # Multipart build dockerfile to build and serve scigateway
 
 FROM node:16.14-alpine3.15 as build
+
 WORKDIR /scigateway
-ENV PATH /scigateway/node_modules/.bin:$PATH
 
 # Set Yarn version
 # TODO - Use Yarn 2 when project is upgraded

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,3 +20,6 @@ RUN yarn build
 FROM httpd:2.4-alpine3.15
 WORKDIR /usr/local/apache2/htdocs
 COPY --from=build /scigateway/build/. .
+
+# Switch to non-root user defined in httpd image
+USER www-data

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,15 +4,16 @@ FROM node:16.14-alpine3.15 as build
 
 WORKDIR /scigateway
 
-# Set Yarn version
-# TODO - Use Yarn 2 when project is upgraded
-RUN yarn set version 1.22
+COPY package.json tsconfig.json yarn.lock ./
 
-# Install dependancies
-# TODO: use yarn install --production:
-# https://github.com/ral-facilities/scigateway/issues/1025
+# TODO - Use Yarn 2 when project is upgraded
+RUN yarn set version 1.22 \
+  # TODO: use yarn install --production: 
+  # https://github.com/ral-facilities/scigateway/issues/1025
+  && yarn install
+
 COPY . .
-RUN yarn install
+
 RUN yarn build
 
 # Put the output of the build into an apache server

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,5 +21,10 @@ FROM httpd:2.4-alpine3.15
 WORKDIR /usr/local/apache2/htdocs
 COPY --from=build /scigateway/build/. .
 
+RUN apk --no-cache add libcap \
+  # Privileged ports are permitted to root only by default.
+  # setcap to bind to privileged ports (80) as non-root.
+  && setcap 'cap_net_bind_service=+ep' /usr/local/apache2/bin/httpd
+
 # Switch to non-root user defined in httpd image
 USER www-data


### PR DESCRIPTION
## Description
This PR implements best practices in the Docker image.

In summary, the changes do the following:
- Removes the lines that sets the `PATH` because the image builds and the container works fine without it.
- Build cache is leveraged in the build stage to reduce the build time when changes are made to the source code over and over again. This is accomplished by copying the `package.json`, `tsconfig.json` and `yarn.lock` files and installing the dependencies first, and then copying the source code and building the app. Because each `COPY` and `RUN` command is a new layer, this ensures that the layers for copying and installing the dependencies are cached when changes are made to the source code.
- Configures the image so that containers run using the non-root `www-data` user account that the `httpd` image defines.
- Uses `setcap` to allow non-root user accounts to bind to privileged ports (port 80 in this case) as these ports are only permitted to `root` by default.
- Changes the access rights for the Apache's `logs` directory from `root` to `www-data` user account.

## Testing instructions
- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] Image builds successfully
- [ ] Container starts successfully