### PR TITLE
Customisable primary colour

### DIFF
--- a/public/settings.example.json
+++ b/public/settings.example.json
@@ -6,6 +6,7 @@
     "dark": "",
     "altTxt": ""
   },
+  "primaryColour": "",
   "adminPageDefaultTab": "maintenance",
   "features": {
     "showHelpPageButton": true,

--- a/src/state/actions/scigateway.actions.test.tsx
+++ b/src/state/actions/scigateway.actions.test.tsx
@@ -27,6 +27,7 @@ import {
   customNavigationDrawerLogo,
   customAdminPageDefaultTab,
   registerContactUsAccessibilityFormUrl,
+  customPrimaryColour,
 } from './scigateway.actions';
 import {
   ToggleDrawerType,
@@ -399,6 +400,32 @@ describe('scigateway actions', () => {
     await asyncAction(dispatch, getState);
 
     expect(actions).toContainEqual(configureAnalytics('test-tracking-id'));
+  });
+
+  it('given a custom primary colour it is loading from the settings', async () => {
+    (mockAxios.get as jest.Mock).mockImplementation(() =>
+      Promise.resolve({
+        data: {
+          primaryColour: '#ABCDEF',
+          'ui-strings': '/res/default.json',
+        },
+      })
+    );
+
+    const asyncAction = configureSite();
+    const actions: Action[] = [];
+    const dispatch = (action: Action): number => actions.push(action);
+    const getState = (): Partial<StateType> => ({
+      scigateway: initialState,
+      router: {
+        location: { ...createLocation('/'), query: {} },
+        action: 'PUSH',
+      },
+    });
+
+    await asyncAction(dispatch, getState);
+
+    expect(actions).toContainEqual(customPrimaryColour('#ABCDEF'));
   });
 
   it('dispatches a site loading update after settings are loaded', async () => {

--- a/src/state/actions/scigateway.actions.tsx
+++ b/src/state/actions/scigateway.actions.tsx
@@ -60,6 +60,8 @@ import {
   RegisterContactUsAccessibilityFormUrlType,
   ContactUsAccessibilityFormUrlPayload,
   adminRoutes,
+  CustomPrimaryColourType,
+  CustomPrimaryColourPayload,
 } from '../scigateway.types';
 import { ActionType, LogoState, StateType, ThunkResult } from '../state.types';
 import loadMicroFrontends from './loadMicroFrontends';
@@ -127,6 +129,15 @@ export const customAdminPageDefaultTab = (
   type: CustomAdminPageDefaultTabType,
   payload: {
     adminPageDefaultTab: adminPageDefaultTab,
+  },
+});
+
+export const customPrimaryColour = (
+  primaryColour: string
+): ActionType<CustomPrimaryColourPayload> => ({
+  type: CustomPrimaryColourType,
+  payload: {
+    primaryColour: primaryColour,
   },
 });
 
@@ -325,6 +336,10 @@ export const configureSite = (): ThunkResult<Promise<void>> => {
           dispatch(
             customNavigationDrawerLogo(settings['navigationDrawerLogo'])
           );
+        }
+
+        if (settings['primaryColour']) {
+          dispatch(customPrimaryColour(settings['primaryColour']));
         }
 
         if (

--- a/src/state/middleware/scigateway.middleware.test.tsx
+++ b/src/state/middleware/scigateway.middleware.test.tsx
@@ -390,10 +390,6 @@ describe('scigateway middleware', () => {
   });
 
   it('should send high contrast theme options when LoadHighContrastModePreferenceType action is sent and high contrast mode preference is true', () => {
-    store = mockStore({
-      scigateway: initialState,
-    });
-
     const loadHighContrastModePreferenceAction = {
       type: LoadHighContrastModePreferenceType,
       payload: {
@@ -420,10 +416,21 @@ describe('scigateway middleware', () => {
     );
   });
 
-  it('should extract dark mode value from user preferences', () => {
+  it('should extract dark mode value from user preferences & custom primary colour from store', () => {
+    const getState: () => StateType = () => ({
+      scigateway: {
+        ...initialState,
+        authorisation: { ...authState },
+        primaryColour: '#654321',
+      },
+      router: {
+        action: 'POP',
+        location: createLocation('/'),
+      },
+    });
     Storage.prototype.getItem = jest.fn().mockReturnValueOnce(undefined);
     window.matchMedia = jest.fn().mockReturnValueOnce({ matches: true });
-    const theme = buildTheme(true);
+    const theme = buildTheme(true, false, '#654321');
     const sendThemeOptionsAction = {
       type: SendThemeOptionsType,
       payload: {

--- a/src/state/middleware/scigateway.middleware.tsx
+++ b/src/state/middleware/scigateway.middleware.tsx
@@ -149,7 +149,8 @@ export const listenToPlugins = (
 
           const theme = buildTheme(
             darkModePreference,
-            highContrastModePreference
+            highContrastModePreference,
+            getState().scigateway.primaryColour
           );
           // Send theme options once registered.
           dispatch(sendThemeOptions(theme));
@@ -248,7 +249,8 @@ const ScigatewayMiddleware: Middleware = ((
       next(action);
       const theme = buildTheme(
         action.payload.darkMode,
-        state.scigateway.highContrastMode
+        state.scigateway.highContrastMode,
+        state.scigateway.primaryColour
       );
       store.dispatch(sendThemeOptions(theme));
       return store.dispatch(requestPluginRerender());
@@ -258,7 +260,8 @@ const ScigatewayMiddleware: Middleware = ((
       next(action);
       const theme = buildTheme(
         state.scigateway.darkMode,
-        action.payload.highContrastMode
+        action.payload.highContrastMode,
+        state.scigateway.primaryColour
       );
       store.dispatch(sendThemeOptions(theme));
       return store.dispatch(requestPluginRerender());

--- a/src/state/reducers/scigateway.reducer.test.tsx
+++ b/src/state/reducers/scigateway.reducer.test.tsx
@@ -26,6 +26,7 @@ import {
   autoLoginAuthorised,
   resetAuthState,
   registerContactUsAccessibilityFormUrl,
+  customPrimaryColour,
 } from '../actions/scigateway.actions';
 import ScigatewayReducer, {
   initialState,
@@ -418,6 +419,17 @@ describe('scigateway reducer', () => {
     );
 
     expect(updatedState.adminPageDefaultTab).toEqual('maintenance');
+  });
+
+  it('should update the primaryColour property when customPrimaryColour action is sent', () => {
+    expect(state.primaryColour).toBeFalsy();
+
+    const updatedState = ScigatewayReducer(
+      state,
+      customPrimaryColour('#AB3210')
+    );
+
+    expect(updatedState.primaryColour).toEqual('#AB3210');
   });
 
   it('dismissNotification should remove the referenced notification from the notifications list in State', () => {

--- a/src/state/reducers/scigateway.reducer.tsx
+++ b/src/state/reducers/scigateway.reducer.tsx
@@ -48,6 +48,8 @@ import {
   CustomAdminPageDefaultTabType,
   RegisterContactUsAccessibilityFormUrlType,
   ContactUsAccessibilityFormUrlPayload,
+  CustomPrimaryColourType,
+  CustomPrimaryColourPayload,
 } from '../scigateway.types';
 import { ScigatewayState, AuthState } from '../state.types';
 import { buildPluginConfig } from '../pluginhelper';
@@ -323,6 +325,16 @@ export function handleCustomAdminPageDefaultTab(
   };
 }
 
+export function handleCustomPrimaryColour(
+  state: ScigatewayState,
+  payload: CustomPrimaryColourPayload
+): ScigatewayState {
+  return {
+    ...state,
+    primaryColour: payload.primaryColour,
+  };
+}
+
 export function handleDismissNotification(
   state: ScigatewayState,
   payload: { index: number }
@@ -516,6 +528,7 @@ const ScigatewayReducer = createReducer(initialState, {
   [CustomAdminPageDefaultTabType]: handleCustomAdminPageDefaultTab,
   [RegisterContactUsAccessibilityFormUrlType]:
     handleRegisterContactUsAccessibilityFormUrl,
+  [CustomPrimaryColourType]: handleCustomPrimaryColour,
 });
 
 export default ScigatewayReducer;

--- a/src/state/scigateway.types.tsx
+++ b/src/state/scigateway.types.tsx
@@ -42,6 +42,7 @@ export const CustomAdminPageDefaultTabType =
   'scigateway:custom_admin_default_tab';
 export const RegisterContactUsAccessibilityFormUrlType =
   'scigateway:contact_us_accessibility_form_url';
+export const CustomPrimaryColourType = 'scigateway:custom_primary_colour';
 
 export const scigatewayRoutes = {
   home: '/',
@@ -102,6 +103,10 @@ export interface CustomNavigationDrawerLogoPayload {
 
 export interface CustomAdminPageDefaultTabPayload {
   adminPageDefaultTab: 'maintenance' | 'download';
+}
+
+export interface CustomPrimaryColourPayload {
+  primaryColour: string;
 }
 
 export interface RegisterRoutePayload {

--- a/src/state/state.types.tsx
+++ b/src/state/state.types.tsx
@@ -42,6 +42,7 @@ export interface ScigatewayState {
   navigationDrawerLogo?: LogoState;
   adminPageDefaultTab?: 'maintenance' | 'download';
   contactUsAccessibilityFormUrl?: string;
+  primaryColour?: string;
 }
 
 export interface StateType {

--- a/src/theming.tsx
+++ b/src/theming.tsx
@@ -261,8 +261,14 @@ export interface UKRITheme extends Theme {
 
 export const buildTheme = (
   darkModePreference: boolean,
-  highContrastModePreference?: boolean
+  highContrastModePreference?: boolean,
+  primaryColour?: string
 ): Theme => {
+  if (primaryColour) {
+    DARK_MODE_COLOURS.primary = primaryColour;
+    LIGHT_MODE_COLOURS.primary = primaryColour;
+    LIGHT_MODE_HIGH_CONTRAST_COLOURS.primary = primaryColour;
+  }
   const colours = darkModePreference
     ? highContrastModePreference
       ? DARK_MODE_HIGH_CONTRAST_COLOURS
@@ -444,15 +450,22 @@ const SciGatewayThemeProvider = (props: {
 }): React.ReactElement<{
   children: React.ReactNode;
 }> => {
-  const darkModePreference: boolean = useSelector(
+  const darkModePreference = useSelector(
     (state: StateType) => state.scigateway.darkMode
   );
-  const highContrastModePreference: boolean = useSelector(
+  const highContrastModePreference = useSelector(
     (state: StateType) => state.scigateway.highContrastMode
+  );
+  const primaryColour = useSelector(
+    (state: StateType) => state.scigateway.primaryColour
   );
   return (
     <MuiThemeProvider
-      theme={buildTheme(darkModePreference, highContrastModePreference)}
+      theme={buildTheme(
+        darkModePreference,
+        highContrastModePreference,
+        primaryColour
+      )}
     >
       {props.children}
     </MuiThemeProvider>

--- a/src/theming.tsx
+++ b/src/theming.tsx
@@ -264,11 +264,6 @@ export const buildTheme = (
   highContrastModePreference?: boolean,
   primaryColour?: string
 ): Theme => {
-  if (primaryColour) {
-    DARK_MODE_COLOURS.primary = primaryColour;
-    LIGHT_MODE_COLOURS.primary = primaryColour;
-    LIGHT_MODE_HIGH_CONTRAST_COLOURS.primary = primaryColour;
-  }
   const colours = darkModePreference
     ? highContrastModePreference
       ? DARK_MODE_HIGH_CONTRAST_COLOURS
@@ -276,6 +271,10 @@ export const buildTheme = (
     : highContrastModePreference
     ? LIGHT_MODE_HIGH_CONTRAST_COLOURS
     : LIGHT_MODE_COLOURS;
+
+  if (primaryColour && !(darkModePreference && highContrastModePreference)) {
+    colours.primary = primaryColour;
+  }
 
   const overrides = {
     MuiLink: {


### PR DESCRIPTION
## Description
Add the ability to specify a custom primary colour that is used on the app bar etc.

Note, I didn't override the dark mode high contrast mode colour, as the use case for this is DLS which they want a darker blue than we currently use `#072B5D` but if in the future we'd expect more colours then we'd need to separate out so we can customise the high contrast colours separately.

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] Add custom colour to your settings and see that the main app bar & footer change colour

## Agile board tracking
Closes #1085