### PR TITLE
#1086 - enable custom logos to be larger than 24px

### DIFF
--- a/src/mainAppBar/mainAppBar.component.tsx
+++ b/src/mainAppBar/mainAppBar.component.tsx
@@ -84,7 +84,9 @@ const styles = (theme: Theme): StyleRules =>
       padding: 4,
       margin: theme.spacing(1),
       '& img': {
-        height: 24,
+        maxHeight: `calc(${
+          (theme as UKRITheme).mainAppBarHeight
+        } - 2 * 4px - 2 * ${theme.spacing(1)}px)`,
       },
     },
     button: {
@@ -213,6 +215,9 @@ const MainAppBar = (props: CombinedMainAppBarProps): React.ReactElement => {
           >
             <img
               src={props.logo ? props.logo : defaultLogo}
+              // if using default logo use 24px, if using custom logo then don't set height
+              // custom logos must be sized to fit or will default to the max-height set in the top styling
+              style={props.logo ? {} : { height: '24px' }}
               alt={getString(props.res, 'title')}
             />
           </Button>

--- a/src/mainAppBar/mainAppBar.component.tsx
+++ b/src/mainAppBar/mainAppBar.component.tsx
@@ -84,6 +84,7 @@ const styles = (theme: Theme): StyleRules =>
       padding: 4,
       margin: theme.spacing(1),
       '& img': {
+        // logo maxHeight = mainAppBar height - 2 * padding - 2 * margin
         maxHeight: `calc(${
           (theme as UKRITheme).mainAppBarHeight
         } - 2 * 4px - 2 * ${theme.spacing(1)}px)`,


### PR DESCRIPTION
## Description
Instead, we just set a sensible max height based off of the app bar height. Default logos I set to be 24px height instead so we don't have to modify the SVGs to be smaller.

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
Closes #1086