### PR TITLE
Downgrading @testing-library/react to v12.1.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
   ],
   "devDependencies": {
     "@testing-library/jest-dom": "5.16.5",
-    "@testing-library/react": "13.4.0",
+    "@testing-library/react": "12.1.5",
     "@testing-library/user-event": "14.4.2",
     "@types/history": "4.7.3",
     "@types/jsonwebtoken": "8.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2817,9 +2817,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@testing-library/dom@npm:^8.5.0":
-  version: 8.16.1
-  resolution: "@testing-library/dom@npm:8.16.1"
+"@testing-library/dom@npm:^8.0.0":
+  version: 8.17.1
+  resolution: "@testing-library/dom@npm:8.17.1"
   dependencies:
     "@babel/code-frame": ^7.10.4
     "@babel/runtime": ^7.12.5
@@ -2829,7 +2829,7 @@ __metadata:
     dom-accessibility-api: ^0.5.9
     lz-string: ^1.4.4
     pretty-format: ^27.0.2
-  checksum: eca86b69f28cdab7226209075b3ca54f87fc0fc92a41440bbfa41e14ed0815aac4a63b1d9a08230e0dbd0de3a54c61cd90a3a423695e6840124e2473c8149e99
+  checksum: e4df091fcf84c9eac4a6ee4c76674c1d562bf98732f0ac8820972d7718ab10397b672b9f082aace3cacd1f610fc77de6e1b6094e67afe1df0443bf22eb9deab2
   languageName: node
   linkType: hard
 
@@ -2850,17 +2850,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@testing-library/react@npm:13.4.0":
-  version: 13.4.0
-  resolution: "@testing-library/react@npm:13.4.0"
+"@testing-library/react@npm:12.1.5":
+  version: 12.1.5
+  resolution: "@testing-library/react@npm:12.1.5"
   dependencies:
     "@babel/runtime": ^7.12.5
-    "@testing-library/dom": ^8.5.0
-    "@types/react-dom": ^18.0.0
+    "@testing-library/dom": ^8.0.0
+    "@types/react-dom": <18.0.0
   peerDependencies:
-    react: ^18.0.0
-    react-dom: ^18.0.0
-  checksum: 51ec548c1fdb1271089a5c63e0908f0166f2c7fcd9cacd3108ebbe0ce64cb4351812d885892020dc37608418cfb15698514856502b3cab0e5cc58d6cc1bd4a3e
+    react: <18.0.0
+    react-dom: <18.0.0
+  checksum: 4abd0490405e709a7df584a0db604e508a4612398bb1326e8fa32dd9393b15badc826dcf6d2f7525437886d507871f719f127b9860ed69ddd204d1fa834f576a
   languageName: node
   linkType: hard
 
@@ -13692,7 +13692,7 @@ __metadata:
     "@mui/icons-material": 5.10.3
     "@mui/material": 5.10.0
     "@testing-library/jest-dom": 5.16.5
-    "@testing-library/react": 13.4.0
+    "@testing-library/react": 12.1.5
     "@testing-library/user-event": 14.4.2
     "@types/history": 4.7.3
     "@types/jest": 29.0.0


### PR DESCRIPTION
## Description
Following [the addition of @testing-library/react v13.x to SciGateway](https://github.com/ral-facilities/scigateway/pull/1171), a mismatch occurred due to v13+ [dropping support for React 17](https://github.com/testing-library/react-testing-library/pull/1031), the current version of SciGateway. As React 18 is not on the horizon yet for SciGateway, we need to ensure support for RTL in SciGateway.

## Testing instructions
Check tests pass and RTL <13.x is used

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] {more steps here}

## Agile board tracking
Hotfix