### PR TITLE
Bump node version in CI from v14 to v16

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '14.x'
+          node-version: '16.x'
           cache: 'yarn'
       - name: Install dependencies
         # Ubuntu 16+ does not install libgconf-2-4 by default, so we need to install it ourselves (for Cypress)

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '14.x'
+          node-version: '16.x'
           cache: 'yarn'
 
       - name: Install dependencies


### PR DESCRIPTION
## Description
Hotfix to bump the version of Node used in CI from v14.x to v16.x, in line with https://github.com/ral-facilities/datagateway/pull/1513. 

## Testing instructions
- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
hotfix, connect to nowhere.