### PR TITLE
Add severity selection to admin scheduledMaintenance #1053

### DIFF
--- a/cypress/e2e/login.cy.ts
+++ b/cypress/e2e/login.cy.ts
@@ -1,7 +1,9 @@
 describe('Login', () => {
   beforeEach(() => {
     // intercept these requests so they don't throw exceptions
-    cy.intercept('/scheduled_maintenance', {}).as('scheduled_maintenance');
+    cy.intercept('/scheduled_maintenance', { message: 'test' }).as(
+      'scheduled_maintenance'
+    );
     cy.intercept('/maintenance', {}).as('maintenance');
     // localStorage isn't always cleaned up properly between tests
     // see cypress issues #2573, #781, #5876

--- a/src/adminPage/maintenancePage.component.test.tsx
+++ b/src/adminPage/maintenancePage.component.test.tsx
@@ -71,13 +71,21 @@ describe('maintenance page component', () => {
       })
     );
     await user.click(
+      screen.getByRole('button', { name: 'admin.severity-select-arialabel' })
+    );
+    await user.click(screen.getByRole('option', { name: 'Information' }));
+    await user.click(
       screen.getAllByRole('button', { name: 'admin.save-button' })[0]
     );
 
     await waitFor(() => {
       expect(store.getActions().length).toEqual(1);
       expect(store.getActions()[0]).toEqual(
-        loadScheduledMaintenanceState({ show: true, message: 'test' })
+        loadScheduledMaintenanceState({
+          show: true,
+          message: 'test',
+          severity: 'information',
+        })
       );
     });
   });

--- a/src/adminPage/maintenancePage.component.tsx
+++ b/src/adminPage/maintenancePage.component.tsx
@@ -7,6 +7,8 @@ import {
   Checkbox,
   Button,
   styled,
+  Select,
+  MenuItem,
 } from '@mui/material';
 import {
   MaintenanceState,
@@ -129,6 +131,29 @@ export const MaintenancePage = (
             label={t('admin.display-checkbox') as string}
             labelPlacement="end"
           />
+          <Select
+            sx={{
+              float: 'left',
+              marginLeft: '10px',
+              paddingTop: '5px',
+              minWidth: '120px',
+            }}
+            value={tempScheduledMaintenance.severity ?? ''}
+            onChange={(e) =>
+              setTempScheduledMaintenance({
+                ...tempScheduledMaintenance,
+                severity: e.target.value as
+                  | 'success'
+                  | 'warning'
+                  | 'error'
+                  | 'information',
+              })
+            }
+            variant="standard"
+          >
+            <MenuItem value="warning">Warning</MenuItem>
+            <MenuItem value="information">Information</MenuItem>
+          </Select>
           <Button
             sx={{ float: 'right' }}
             variant="contained"

--- a/src/adminPage/maintenancePage.component.tsx
+++ b/src/adminPage/maintenancePage.component.tsx
@@ -149,6 +149,7 @@ export const MaintenancePage = (
                   | 'information',
               })
             }
+            inputProps={{ 'aria-label': t('admin.severity-select-arialabel') }}
             variant="standard"
           >
             <MenuItem value="warning">Warning</MenuItem>

--- a/src/authentication/testAuthProvider.tsx
+++ b/src/authentication/testAuthProvider.tsx
@@ -51,6 +51,7 @@ export default class TestAuthProvider implements AuthProvider {
     return Promise.resolve({
       show: false,
       message: 'test',
+      severity: 'warning',
     });
   }
 

--- a/src/index.css
+++ b/src/index.css
@@ -18,11 +18,8 @@ code {
   top: 70px !important;
 }
 
-.redux-toastr .toastr.rrt-warning {
-  color: #000000;
-}
-
-.redux-toastr .toastr.rrt-error {
+/* Need to modify to black as the default white isn't good enough contrast */
+.redux-toastr :is(.toastr.rrt-warning, .toastr.rrt-error, .toastr.rrt-info, .toastr.rrt-success) {
   color: #000000;
 }
 

--- a/src/notifications/__snapshots__/scigatewayNotification.component.test.tsx.snap
+++ b/src/notifications/__snapshots__/scigatewayNotification.component.test.tsx.snap
@@ -46,6 +46,52 @@ exports[`Scigateway Notification component Scigateway Notification error message
 </DocumentFragment>
 `;
 
+exports[`Scigateway Notification component Scigateway Notification information message renders correctly 1`] = `
+<DocumentFragment>
+  <div
+    style="display: flex; align-items: center;"
+  >
+    <svg
+      aria-hidden="true"
+      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-kjenk6-MuiSvgIcon-root"
+      data-testid="InfoIcon"
+      focusable="false"
+      viewBox="0 0 24 24"
+    >
+      <path
+        d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"
+      />
+    </svg>
+    <p
+      class="MuiTypography-root MuiTypography-body2 css-rsneeo-MuiTypography-root"
+    >
+      information message
+    </p>
+    <button
+      aria-label="Dismiss notification"
+      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge css-1qpmkg3-MuiButtonBase-root-MuiIconButton-root"
+      tabindex="0"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1nrt62k-MuiSvgIcon-root"
+        data-testid="ClearIcon"
+        focusable="false"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+        />
+      </svg>
+      <span
+        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+      />
+    </button>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`Scigateway Notification component Scigateway Notification success message renders correctly 1`] = `
 <DocumentFragment>
   <div

--- a/src/notifications/scigatewayNotification.component.test.tsx
+++ b/src/notifications/scigatewayNotification.component.test.tsx
@@ -56,6 +56,14 @@ describe('Scigateway Notification component', () => {
     expect(asFragment()).toMatchSnapshot();
   });
 
+  it('Scigateway Notification information message renders correctly', () => {
+    const { asFragment } = render(
+      createScigatewayNotification('information', 'information message'),
+      { wrapper: Wrapper }
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+
   it('an action is fired when Scigateway Notification button is clicked', async () => {
     const mockDismissFn = jest.fn();
     const user = userEvent.setup();

--- a/src/notifications/scigatewayNotification.component.tsx
+++ b/src/notifications/scigatewayNotification.component.tsx
@@ -4,6 +4,7 @@ import DeleteIcon from '@mui/icons-material/Clear';
 import TickIcon from '@mui/icons-material/CheckCircle';
 import WarningIcon from '@mui/icons-material/ErrorOutline';
 import ErrorIcon from '@mui/icons-material/HighlightOff';
+import InfoIcon from '@mui/icons-material/Info';
 import { Action } from 'redux';
 
 const severityIconStyle = {
@@ -40,6 +41,14 @@ const ScigatewayNotification = React.forwardRef(function ScigatewayNotification(
           sx={{
             ...severityIconStyle,
             color: (theme: Theme) => theme.colours.lightOrange,
+          }}
+        />
+      ) : null}
+      {props.severity === 'information' ? (
+        <InfoIcon
+          sx={{
+            ...severityIconStyle,
+            color: (theme: Theme) => theme.colours.lightBlue,
           }}
         />
       ) : null}

--- a/src/state/actions/scigateway.actions.test.tsx
+++ b/src/state/actions/scigateway.actions.test.tsx
@@ -884,7 +884,11 @@ describe('scigateway actions', () => {
     await asyncAction(dispatch, getState);
 
     expect(actions).toContainEqual(
-      loadScheduledMaintenanceState({ show: false, message: 'test' })
+      loadScheduledMaintenanceState({
+        show: false,
+        message: 'test',
+        severity: 'warning',
+      })
     );
   });
 
@@ -939,6 +943,7 @@ describe('scigateway actions', () => {
       Promise.resolve({
         show: true,
         message: 'test',
+        severity: 'warning',
       });
     state.authorisation.provider = testAuthProvider;
 

--- a/src/state/actions/scigateway.actions.tsx
+++ b/src/state/actions/scigateway.actions.tsx
@@ -439,6 +439,9 @@ export const configureSite = (): ThunkResult<Promise<void>> => {
       provider
         .fetchScheduledMaintenanceState()
         .then((scheduledMaintenanceState) => {
+          if (scheduledMaintenanceState['severity'] === undefined) {
+            scheduledMaintenanceState['severity'] = 'warning';
+          }
           dispatch(loadScheduledMaintenanceState(scheduledMaintenanceState));
 
           // Checking the state in the GET response because it does not get

--- a/src/state/actions/scigateway.actions.tsx
+++ b/src/state/actions/scigateway.actions.tsx
@@ -446,7 +446,7 @@ export const configureSite = (): ThunkResult<Promise<void>> => {
           if (scheduledMaintenanceState['show']) {
             displayMaintenanceBanner(
               scheduledMaintenanceState['message'],
-              'warning'
+              scheduledMaintenanceState['severity']
             );
           }
         });
@@ -456,7 +456,7 @@ export const configureSite = (): ThunkResult<Promise<void>> => {
 
 const displayMaintenanceBanner = (
   message: string,
-  severity: 'success' | 'warning' | 'error',
+  severity: 'success' | 'warning' | 'error' | 'information',
   instant = false
 ): void => {
   document.dispatchEvent(

--- a/src/state/middleware/scigateway.middleware.test.tsx
+++ b/src/state/middleware/scigateway.middleware.test.tsx
@@ -668,6 +668,45 @@ describe('scigateway middleware', () => {
       expect(mockToastr.calls[0][0]).toContain('Warning');
       expect(mockToastr.calls[0][1]).toContain('test notification');
     });
+
+    it('should listen for notification events and create toast for information', () => {
+      toastr.info = jest.fn();
+      listenToPlugins(store.dispatch, getState);
+
+      const notificationAction = {
+        type: NotificationType,
+        payload: {
+          message: 'test notification',
+          severity: 'information',
+        },
+      };
+      handler(new CustomEvent('test', { detail: notificationAction }));
+
+      expect(toastr.info).toHaveBeenCalled();
+      const mockToastr = (toastr.info as jest.Mock).mock;
+      expect(mockToastr.calls[0][0]).toContain('Information');
+      expect(mockToastr.calls[0][1]).toContain('test notification');
+    });
+
+    it('should listen for notification events and log error for invalid severity', () => {
+      log.error = jest.fn();
+      listenToPlugins(store.dispatch, getState);
+
+      const notificationAction = {
+        type: NotificationType,
+        payload: {
+          message: 'test notification',
+          severity: 'invalid',
+        },
+      };
+      handler(new CustomEvent('test', { detail: notificationAction }));
+
+      expect(log.error).toHaveBeenCalled();
+      const mockLog = (log.error as jest.Mock).mock;
+      expect(mockLog.calls[0][0]).toContain(
+        'Invalid severity provided: invalid'
+      );
+    });
   });
 
   it('should broadcast requestpluginrerender action but ignore it itself', () => {

--- a/src/state/middleware/scigateway.middleware.tsx
+++ b/src/state/middleware/scigateway.middleware.tsx
@@ -44,7 +44,7 @@ const toastrMessageOptions = {
 
 const toastrMessage = (
   message: string,
-  severity: 'success' | 'warning' | 'error'
+  severity: 'success' | 'warning' | 'error' | 'information'
 ): void => {
   switch (severity) {
     case 'success':
@@ -55,6 +55,9 @@ const toastrMessage = (
       break;
     case 'error':
       toastr.error('Error', message, toastrMessageOptions);
+      break;
+    case 'information':
+      toastr.info('Information', message, toastrMessageOptions);
       break;
     default:
       log.error(`Invalid severity provided: ${severity}`);

--- a/src/state/reducers/scigateway.reducer.test.tsx
+++ b/src/state/reducers/scigateway.reducer.test.tsx
@@ -355,7 +355,11 @@ describe('scigateway reducer', () => {
 
     const updatedState = ScigatewayReducer(
       state,
-      loadScheduledMaintenanceState({ show: true, message: 'test' })
+      loadScheduledMaintenanceState({
+        show: true,
+        message: 'test',
+        severity: 'warning',
+      })
     );
 
     expect(updatedState.scheduledMaintenance.show).toBeTruthy();

--- a/src/state/reducers/scigateway.reducer.tsx
+++ b/src/state/reducers/scigateway.reducer.tsx
@@ -84,6 +84,7 @@ export const initialState: ScigatewayState = {
   scheduledMaintenance: {
     show: false,
     message: '',
+    severity: 'warning',
   },
   maintenance: {
     show: false,

--- a/src/state/scigateway.types.tsx
+++ b/src/state/scigateway.types.tsx
@@ -188,7 +188,7 @@ export interface ScheduledMaintenanceStatePayLoad {
 export interface ScheduledMaintenanceState {
   show: boolean;
   message: string;
-  severity: 'success' | 'warning' | 'error' | 'information';
+  severity?: 'success' | 'warning' | 'error' | 'information';
 }
 
 export interface MaintenanceStatePayLoad {

--- a/src/state/scigateway.types.tsx
+++ b/src/state/scigateway.types.tsx
@@ -188,6 +188,7 @@ export interface ScheduledMaintenanceStatePayLoad {
 export interface ScheduledMaintenanceState {
   show: boolean;
   message: string;
+  severity: 'success' | 'warning' | 'error' | 'information';
 }
 
 export interface MaintenanceStatePayLoad {


### PR DESCRIPTION
## Added severity selection in admin scheduledMaintenance interface
It is now possible to choose a severity for the scheduled maintenance pop-up in the admin interface. 
![image](https://github.com/ral-facilities/scigateway/assets/72079517/33b7ac8b-7343-4de2-824e-aec6648dc30e)

Added a new 'information' severity. 
![image](https://github.com/ral-facilities/scigateway/assets/72079517/5f44ac8b-35df-4785-8bdd-3218d10a7973)

## Testing instructions
Added unit tests to include cases for the 'information' in invalid severity. Updated tests to select severity from the selection list.

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
connect to #1053 