### PR TITLE
Feature/non authentication #1313

### DIFF
--- a/src/adminPage/adminPage.component.test.tsx
+++ b/src/adminPage/adminPage.component.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { createLocation, createMemoryHistory, History } from 'history';
 import { authState, initialState } from '../state/reducers/scigateway.reducer';
 import { StateType } from '../state/state.types';
+import { PluginConfig } from '../state/scigateway.types';
 import configureStore from 'redux-mock-store';
 import AdminPage from './adminPage.component';
 import { Provider } from 'react-redux';
@@ -12,6 +13,7 @@ import { Router } from 'react-router';
 import { StyledEngineProvider, ThemeProvider } from '@mui/material';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { getPluginRoutes } from './adminPage.component';
 
 describe('Admin page component', () => {
   let mockStore;
@@ -127,5 +129,69 @@ describe('Admin page component', () => {
     expect(
       await screen.findByRole('tabpanel', { name: 'Maintenance' })
     ).toBeInTheDocument();
+  });
+
+  it('should return an empty object when given an empty plugins array', () => {
+    const plugins = [];
+    const result = getPluginRoutes(plugins);
+    expect(result).toEqual({});
+  });
+
+  it('should correctly filter and group plugin routes for admin users', () => {
+    const plugins: PluginConfig[] = [
+      {
+        plugin: 'PluginA',
+        admin: true,
+        link: '/admin/pluginA',
+        section: 'A',
+        displayName: 'A',
+        order: 1,
+      },
+      {
+        plugin: 'PluginA',
+        admin: true,
+        link: '/admin/pluginA2',
+        section: 'A',
+        displayName: 'A2',
+        order: 2,
+      },
+      {
+        plugin: 'PluginB',
+        admin: false,
+        link: '/public/pluginB',
+        section: 'B',
+        displayName: 'B',
+        order: 3,
+      },
+    ];
+    const result = getPluginRoutes(plugins, true); // Admin user
+    expect(result).toEqual({
+      PluginA: ['/admin/pluginA', '/admin/pluginA2'],
+    });
+  });
+
+  it('should correctly filter and group plugin routes for non-admin users', () => {
+    const plugins: PluginConfig[] = [
+      {
+        plugin: 'PluginA',
+        admin: true,
+        link: '/admin/pluginA',
+        section: 'A',
+        displayName: 'A',
+        order: 1,
+      },
+      {
+        plugin: 'PluginB',
+        admin: false,
+        link: '/public/pluginB',
+        section: 'B',
+        displayName: 'B',
+        order: 2,
+      },
+    ];
+    const result = getPluginRoutes(plugins, false); // Non-admin user
+    expect(result).toEqual({
+      PluginB: ['/public/pluginB'],
+    });
   });
 });

--- a/src/adminPage/adminPage.component.tsx
+++ b/src/adminPage/adminPage.component.tsx
@@ -18,7 +18,7 @@ export interface AdminPageProps {
   adminPageDefaultTab?: 'maintenance' | 'download';
 }
 
-const getPluginRoutes = (
+export const getPluginRoutes = (
   plugins: PluginConfig[],
   admin?: boolean
 ): {

--- a/src/adminPage/adminPage.component.tsx
+++ b/src/adminPage/adminPage.component.tsx
@@ -9,10 +9,7 @@ import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
 import { Link, Route, Switch, useLocation } from 'react-router-dom';
 import PageNotFound from '../pageNotFound/pageNotFound.component';
-import {
-  getPluginRoutes,
-  PluginPlaceHolder,
-} from '../routing/routing.component';
+import { PluginPlaceHolder } from '../routing/routing.component';
 import MaintenancePage from './maintenancePage.component';
 import { useTranslation } from 'react-i18next';
 
@@ -20,6 +17,30 @@ export interface AdminPageProps {
   plugins: PluginConfig[];
   adminPageDefaultTab?: 'maintenance' | 'download';
 }
+
+const getPluginRoutes = (
+  plugins: PluginConfig[],
+  admin?: boolean
+): {
+  [plugin: string]: string[];
+} => {
+  const pluginRoutes: {
+    [plugin: string]: string[];
+  } = {};
+
+  plugins.forEach((p) => {
+    const isAdmin = admin ? p.admin : !p.admin;
+    const basePluginLink = p.link.split('?')[0];
+    if (isAdmin) {
+      if (pluginRoutes[p.plugin]) {
+        pluginRoutes[p.plugin].push(basePluginLink);
+      } else {
+        pluginRoutes[p.plugin] = [basePluginLink];
+      }
+    }
+  });
+  return pluginRoutes;
+};
 
 const AdminPage = (props: AdminPageProps): ReactElement => {
   const pluginRoutes = getPluginRoutes(props.plugins, true);

--- a/src/authentication/nullAuthProvider.test.tsx
+++ b/src/authentication/nullAuthProvider.test.tsx
@@ -1,0 +1,40 @@
+import mockAxios from 'axios';
+import NullAuthProvider from './nullAuthProvider';
+
+describe('null auth provider', () => {
+  let nullAuthProvider: NullAuthProvider;
+
+  beforeEach(() => {
+    nullAuthProvider = new NullAuthProvider();
+  });
+
+  afterEach(() => {
+    (mockAxios.post as jest.Mock).mockClear();
+  });
+
+  it('should be always logged in, logIn() and logOut() should do nothing', () => {
+    expect(nullAuthProvider.isLoggedIn()).toBeTruthy();
+    nullAuthProvider.logOut();
+    expect(nullAuthProvider.isLoggedIn()).toBeTruthy();
+    nullAuthProvider.logIn();
+    expect(nullAuthProvider.isLoggedIn()).toBeTruthy();
+  });
+
+  it('should always return false for isAdmin', () => {
+    expect(nullAuthProvider.isAdmin()).toBeFalsy();
+  });
+
+  it('should always resolve when verifying login', () => {
+    return nullAuthProvider.verifyLogIn();
+  });
+
+  it('should always resolve when refreshing', () => {
+    return nullAuthProvider.refresh();
+  });
+
+  it('should always return undefined for authUrl, and null for redirectUrl and user ', () => {
+    expect(nullAuthProvider.authUrl).toBeUndefined();
+    expect(nullAuthProvider.redirectUrl).toBeNull();
+    expect(nullAuthProvider.user).toBeNull();
+  });
+});

--- a/src/authentication/nullAuthProvider.tsx
+++ b/src/authentication/nullAuthProvider.tsx
@@ -1,0 +1,37 @@
+import { AuthProvider } from '../state/state.types';
+
+export default class NullAuthProvider implements AuthProvider {
+  private token: string | null;
+  public redirectUrl: string | null;
+  public user = null;
+  public authUrl: string | undefined;
+
+  public constructor() {
+    this.token = null;
+    this.redirectUrl = null;
+  }
+
+  public isLoggedIn(): boolean {
+    return true;
+  }
+
+  public isAdmin(): boolean {
+    return false;
+  }
+
+  public logOut(): void {
+    this.token = null;
+  }
+
+  public logIn(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  public verifyLogIn(): Promise<void> {
+    return this.refresh();
+  }
+
+  public refresh(): Promise<void> {
+    return Promise.resolve();
+  }
+}

--- a/src/authentication/nullAuthProvider.tsx
+++ b/src/authentication/nullAuthProvider.tsx
@@ -1,13 +1,11 @@
 import { AuthProvider } from '../state/state.types';
 
 export default class NullAuthProvider implements AuthProvider {
-  private token: string | null;
   public redirectUrl: string | null;
   public user = null;
   public authUrl: string | undefined;
 
   public constructor() {
-    this.token = null;
     this.redirectUrl = null;
   }
 
@@ -20,7 +18,7 @@ export default class NullAuthProvider implements AuthProvider {
   }
 
   public logOut(): void {
-    this.token = null;
+    // Do nothing
   }
 
   public logIn(): Promise<void> {

--- a/src/mainAppBar/mainAppBar.component.tsx
+++ b/src/mainAppBar/mainAppBar.component.tsx
@@ -31,6 +31,7 @@ import SettingsMenu from './settingsMenu.component';
 import MobileOverflowMenu from './mobileOverflowMenu.component';
 import { appBarIconButtonStyle, appBarMenuItemIconStyle } from './styles';
 import PageLinks from './pageLinks.component';
+import NullAuthProvider from '../authentication/nullAuthProvider';
 
 interface MainAppProps {
   drawerOpen: boolean;
@@ -253,9 +254,9 @@ const mapStateToProps = (state: StateType): MainAppProps => ({
   showAdminPageButton:
     state.scigateway.authorisation.provider.isLoggedIn() &&
     state.scigateway.authorisation.provider.isAdmin(),
-  showUserComponent:
-    state.scigateway.authorisation.provider.constructor.name !==
-    'NullAuthProvider',
+  showUserComponent: !(
+    state.scigateway.authorisation.provider instanceof NullAuthProvider
+  ),
   res: getAppStrings(state, 'main-appbar'),
   darkMode: state.scigateway.darkMode,
   highContrastMode: state.scigateway.highContrastMode,

--- a/src/mainAppBar/mainAppBar.component.tsx
+++ b/src/mainAppBar/mainAppBar.component.tsx
@@ -37,6 +37,7 @@ interface MainAppProps {
   res: AppStrings | undefined;
   showHelpPageButton: boolean;
   showAdminPageButton: boolean;
+  showUserComponent: boolean;
   singlePluginLogo: boolean;
   loggedIn: boolean;
   darkMode: boolean;
@@ -207,7 +208,7 @@ export const MainAppBar = (
           )}
 
           {props.loggedIn && <NotificationBadgeComponent />}
-          <UserProfileComponent />
+          {props.showUserComponent && <UserProfileComponent />}
 
           {!isViewportMdOrLarger && (
             <IconButton
@@ -252,6 +253,9 @@ const mapStateToProps = (state: StateType): MainAppProps => ({
   showAdminPageButton:
     state.scigateway.authorisation.provider.isLoggedIn() &&
     state.scigateway.authorisation.provider.isAdmin(),
+  showUserComponent:
+    state.scigateway.authorisation.provider.constructor.name !==
+    'NullAuthProvider',
   res: getAppStrings(state, 'main-appbar'),
   darkMode: state.scigateway.darkMode,
   highContrastMode: state.scigateway.highContrastMode,

--- a/src/routing/__snapshots__/routing.component.test.tsx.snap
+++ b/src/routing/__snapshots__/routing.component.test.tsx.snap
@@ -297,6 +297,265 @@ exports[`Routing component renders a route for maintenance page when site is und
 </DocumentFragment>
 `;
 
+exports[`Routing component renders an unauthorised route for a plugin 1`] = `
+<DocumentFragment>
+  <div
+    class="css-uuc84g"
+  >
+    <div
+      id="dg-homepage"
+    >
+      <div
+        style="background-image: url(background.jpg); width: 100%; height: 250px;"
+      >
+        <div
+          style="background-repeat: no-repeat; width: 100%; height: 250px;"
+        >
+          <div
+            class="MuiBox-root css-h95k7f"
+          >
+            <h2
+              class="MuiTypography-root MuiTypography-h2 css-1c7qyh0-MuiTypography-root"
+            >
+              <strong>
+                Data discovery
+              </strong>
+               and 
+              <strong>
+                access
+              </strong>
+            </h2>
+            <h2
+              class="MuiTypography-root MuiTypography-h2 css-1c7qyh0-MuiTypography-root"
+            >
+              for 
+              <strong>
+                large-scale
+              </strong>
+              science facilities
+            </h2>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiBox-root css-12vlygr"
+      >
+        <div
+          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 css-12uikys-MuiPaper-root"
+        >
+          <div
+            class="MuiGrid-root MuiGrid-container css-11lq3yg-MuiGrid-root"
+            style="height: 100%;"
+          >
+            <div
+              class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-6 css-1fyyp8j-MuiGrid-root"
+            >
+              <div
+                class="MuiBox-root css-1onku40"
+              >
+                <h3
+                  class="MuiTypography-root MuiTypography-h3 css-vduuh3-MuiTypography-root"
+                >
+                  home-page.browse.title
+                </h3>
+                <p
+                  class="MuiTypography-root MuiTypography-body1 css-4y3rru-MuiTypography-root"
+                >
+                  home-page.browse.description1
+                </p>
+                <p
+                  class="MuiTypography-root MuiTypography-body1 css-4y3rru-MuiTypography-root"
+                >
+                  <strong>
+                    DataGateway
+                  </strong>
+                   focuses on providing data discovery and data access functionality to the data.
+                </p>
+                <div
+                  class="MuiBox-root css-1yuhvjn"
+                >
+                  <a
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium css-2ttl85-MuiButtonBase-root-MuiButton-root"
+                    data-testid="browse-button"
+                    href="/home-page.browse.link"
+                    tabindex="0"
+                  >
+                    home-page.browse.button
+                    <span
+                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                    />
+                  </a>
+                </div>
+              </div>
+            </div>
+            <div
+              class="MuiGrid-root MuiGrid-item MuiGrid-grid-md-6 css-1k7sk4d-MuiGrid-root"
+            >
+              <div
+                style="background-image: url(facility.jpg); background-repeat: no-repeat; background-position: bottom right; background-size: cover; width: 100%; height: 100%; border-radius: 4px;"
+              >
+                <div
+                  class="css-1g012h9"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-mhc70k-MuiGrid-root"
+        >
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4 css-1lj5egr-MuiGrid-root"
+          >
+            <div
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 css-12uikys-MuiPaper-root"
+            >
+              <div
+                class="MuiBox-root css-1onku40"
+              >
+                <div
+                  class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-1ukwqwi-MuiAvatar-root"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-vyilrt-MuiSvgIcon-root"
+                    data-testid="SearchIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                    />
+                  </svg>
+                </div>
+                <h4
+                  class="MuiTypography-root MuiTypography-h4 css-f630zx-MuiTypography-root"
+                >
+                  home-page.search.title
+                </h4>
+                <p
+                  class="MuiTypography-root MuiTypography-body1 css-4y3rru-MuiTypography-root"
+                >
+                  home-page.search.description
+                </p>
+                <div
+                  class="MuiBox-root css-8xl60i"
+                >
+                  <a
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium css-2ttl85-MuiButtonBase-root-MuiButton-root"
+                    data-testid="search-button"
+                    href="/home-page.search.link"
+                    tabindex="0"
+                  >
+                    home-page.search.button
+                    <span
+                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                    />
+                  </a>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4 css-1lj5egr-MuiGrid-root"
+          >
+            <div
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 css-12uikys-MuiPaper-root"
+            >
+              <div
+                class="MuiBox-root css-1onku40"
+              >
+                <div
+                  class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-1ukwqwi-MuiAvatar-root"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-vyilrt-MuiSvgIcon-root"
+                    data-testid="GetAppIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"
+                    />
+                  </svg>
+                </div>
+                <h4
+                  class="MuiTypography-root MuiTypography-h4 css-f630zx-MuiTypography-root"
+                >
+                  home-page.download.title
+                </h4>
+                <p
+                  class="MuiTypography-root MuiTypography-body1 css-4y3rru-MuiTypography-root"
+                >
+                  home-page.download.description
+                </p>
+                <div
+                  class="MuiBox-root css-8xl60i"
+                >
+                  <a
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium css-2ttl85-MuiButtonBase-root-MuiButton-root"
+                    data-testid="download-button"
+                    href="/home-page.download.link"
+                    tabindex="0"
+                  >
+                    home-page.download.button
+                    <span
+                      class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                    />
+                  </a>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4 css-1lj5egr-MuiGrid-root"
+          >
+            <div
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 css-1ju2rzk-MuiPaper-root"
+            >
+              <div
+                style="background-image: url(green-swirl2.png); background-repeat: no-repeat; background-position: top right; background-size: auto 100%; height: 100%;"
+              >
+                <div
+                  class="MuiBox-root css-1onku40"
+                >
+                  <h4
+                    class="MuiTypography-root MuiTypography-h4 css-94tke6-MuiTypography-root"
+                  >
+                    home-page.facility.title
+                  </h4>
+                  <p
+                    class="MuiTypography-root MuiTypography-body1 css-1f5ny8y-MuiTypography-root"
+                  >
+                    home-page.facility.description
+                  </p>
+                  <div
+                    class="MuiBox-root css-8xl60i"
+                  >
+                    <a
+                      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium css-1h8ppsl-MuiButtonBase-root-MuiButton-root"
+                      data-testid="facility-button"
+                      href="home-page.facility.link"
+                      tabindex="0"
+                    >
+                      home-page.facility.button
+                      <span
+                        class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+                      />
+                    </a>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`Routing component renders component with no plugin routes 1`] = `
 <DocumentFragment>
   <div

--- a/src/routing/routing.component.test.tsx
+++ b/src/routing/routing.component.test.tsx
@@ -236,7 +236,7 @@ describe('Routing component', () => {
     expect(asFragment()).toMatchSnapshot();
   });
 
-  it.only('redirects to / if navigating to login or logout page while using nullAuthProvider', () => {
+  it('redirects to / if navigating to login or logout page while using nullAuthProvider', () => {
     state.scigateway.authorisation.provider = new NullAuthProvider();
     render(<Routing />, { wrapper: Wrapper });
     expect(history.location.pathname).toEqual('/');

--- a/src/routing/routing.component.test.tsx
+++ b/src/routing/routing.component.test.tsx
@@ -6,6 +6,7 @@ import * as singleSpa from 'single-spa';
 import { ThemeProvider, useMediaQuery } from '@mui/material';
 import Routing, { PluginPlaceHolder } from './routing.component';
 import TestAuthProvider from '../authentication/testAuthProvider';
+import NullAuthProvider from '../authentication/nullAuthProvider';
 import { StateType } from '../state/state.types';
 import { authState, initialState } from '../state/reducers/scigateway.reducer';
 import { buildTheme } from '../theming';
@@ -235,6 +236,18 @@ describe('Routing component', () => {
     expect(asFragment()).toMatchSnapshot();
   });
 
+  it.only('redirects to / if navigating to login or logout page while using nullAuthProvider', () => {
+    state.scigateway.authorisation.provider = new NullAuthProvider();
+    render(<Routing />, { wrapper: Wrapper });
+    expect(history.location.pathname).toEqual('/');
+
+    history.replace('/login');
+    expect(history.location.pathname).toEqual('/');
+
+    history.replace('/logout');
+    expect(history.location.pathname).toEqual('/');
+  });
+
   it('single-spa remounts a plugin when switching between admin and non-admin plugins via single-spa:before-no-app-change event', () => {
     state.scigateway.authorisation.provider = new TestAuthProvider('logged in');
     state.scigateway.siteLoading = false;
@@ -276,6 +289,56 @@ describe('Routing component', () => {
       new CustomEvent('single-spa:before-no-app-change', {
         detail: {
           oldUrl: 'http://localhost/admin_test_link',
+          newUrl: 'http://localhost/test_link',
+        },
+      })
+    );
+    expect(singleSpa.unloadApplication).toHaveBeenCalledWith(
+      'test_plugin_name'
+    );
+  });
+
+  it('single-spa remounts a plugin when switching between authorised and unauthorised plugins via single-spa:before-no-app-change event', () => {
+    state.scigateway.authorisation.provider = new TestAuthProvider('logged in');
+    state.scigateway.siteLoading = false;
+    state.scigateway.plugins = [
+      {
+        section: 'test section',
+        link: '/test_link',
+        plugin: 'test_plugin_name',
+        displayName: 'Test Plugin',
+        order: 1,
+      },
+      {
+        section: 'test section',
+        link: '/unauthorised_test_link',
+        plugin: 'test_plugin_name',
+        displayName: 'Test Plugin Admin',
+        unauthorised: true,
+        order: 2,
+      },
+    ];
+
+    render(<Routing />, { wrapper: Wrapper });
+
+    window.dispatchEvent(
+      new CustomEvent('single-spa:before-no-app-change', {
+        detail: {
+          oldUrl: 'http://localhost/test_link',
+          newUrl: 'http://localhost/unauthorised_test_link',
+        },
+      })
+    );
+    expect(singleSpa.unloadApplication).toHaveBeenCalledWith(
+      'test_plugin_name'
+    );
+
+    (singleSpa.unloadApplication as jest.Mock).mockClear();
+
+    window.dispatchEvent(
+      new CustomEvent('single-spa:before-no-app-change', {
+        detail: {
+          oldUrl: 'http://localhost/unauthorised_test_link',
           newUrl: 'http://localhost/test_link',
         },
       })

--- a/src/routing/routing.component.test.tsx
+++ b/src/routing/routing.component.test.tsx
@@ -132,7 +132,7 @@ describe('Routing component', () => {
   });
 
   it('renders an unauthorised route for a plugin', () => {
-    state.scigateway.authorisation.provider = new TestAuthProvider('logged in');
+    state.scigateway.authorisation.provider = new TestAuthProvider(null);
     state.scigateway.plugins = [
       {
         section: 'test section',

--- a/src/routing/routing.component.test.tsx
+++ b/src/routing/routing.component.test.tsx
@@ -115,6 +115,32 @@ describe('Routing component', () => {
         admin: true,
         order: 5,
       },
+      {
+        section: 'test section',
+        link: 'test link not authorised',
+        plugin: 'test_plugin_name',
+        displayName: 'Test Plugin Not Authorised',
+        unauthorised: true,
+        order: 6,
+      },
+    ];
+
+    const { asFragment } = render(<Routing />, { wrapper: Wrapper });
+
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders an unauthorised route for a plugin', () => {
+    state.scigateway.authorisation.provider = new TestAuthProvider('logged in');
+    state.scigateway.plugins = [
+      {
+        section: 'test section',
+        link: 'test link',
+        plugin: 'test_plugin_name',
+        displayName: 'Test Plugin',
+        unauthorised: true,
+        order: 1,
+      },
     ];
 
     const { asFragment } = render(<Routing />, { wrapper: Wrapper });

--- a/src/routing/routing.component.tsx
+++ b/src/routing/routing.component.tsx
@@ -22,6 +22,7 @@ import withAuth from './authorisedRoute.component';
 import { Preloader } from '../preloader/preloader.component';
 import * as singleSpa from 'single-spa';
 import { useMediaQuery } from '@mui/material';
+import NullAuthProvider from '../authentication/nullAuthProvider';
 
 interface ContainerDivProps {
   drawerOpen: boolean;
@@ -254,8 +255,7 @@ const mapStateToProps = (state: StateType): RoutingProps => ({
       localStorage.getItem('autoLogin') === 'true'
     ),
   nullAuthProvider:
-    state.scigateway.authorisation.provider.constructor.name ===
-    'NullAuthProvider',
+    state.scigateway.authorisation.provider instanceof NullAuthProvider,
   userIsAdmin: state.scigateway.authorisation.provider.isAdmin(),
   homepageUrl: state.scigateway.homepageUrl,
   loading: state.scigateway.siteLoading,

--- a/src/routing/routing.component.tsx
+++ b/src/routing/routing.component.tsx
@@ -67,6 +67,7 @@ interface RoutingProps {
   maintenance: MaintenanceState;
   userIsloggedIn: boolean;
   userIsAdmin: boolean;
+  nullAuthProvider: boolean;
   homepageUrl?: string;
   loading: boolean;
 }
@@ -229,14 +230,18 @@ const Routing: React.FC<RoutingProps> = (props: RoutingProps) => {
              As the intial state of userIsLoggedIn is false we have to wait
              until the page has fully loaded so it can receive the correct state
              for userIsLoggedIn */}
-          {!props.userIsloggedIn || props.loading ? (
+          {props.nullAuthProvider ? (
+            <Redirect to={scigatewayRoutes.home} />
+          ) : !props.userIsloggedIn || props.loading ? (
             <LoginPage />
           ) : (
             <Redirect to={scigatewayRoutes.logout} />
           )}
         </Route>
         <Route exact path={scigatewayRoutes.logout}>
-          {props.userIsloggedIn || props.loading ? (
+          {props.nullAuthProvider ? (
+            <Redirect to={scigatewayRoutes.home} />
+          ) : props.userIsloggedIn || props.loading ? (
             <LogoutPage />
           ) : (
             <Redirect to={scigatewayRoutes.login} />
@@ -272,6 +277,9 @@ const mapStateToProps = (state: StateType): RoutingProps => ({
       state.scigateway.authorisation.provider.autoLogin &&
       localStorage.getItem('autoLogin') === 'true'
     ),
+  nullAuthProvider:
+    state.scigateway.authorisation.provider.constructor.name ===
+    'NullAuthProvider',
   userIsAdmin: state.scigateway.authorisation.provider.isAdmin(),
   homepageUrl: state.scigateway.homepageUrl,
   loading: state.scigateway.siteLoading,

--- a/src/routing/routing.component.tsx
+++ b/src/routing/routing.component.tsx
@@ -88,6 +88,7 @@ export class PluginPlaceHolder extends React.PureComponent<{
 }
 
 export const AuthorisedPlugin = withAuth(false)(PluginPlaceHolder);
+export const UnauthorisedPlugin = PluginPlaceHolder;
 // Prevents the component from updating when the draw is opened/closed
 export const AuthorisedAdminPage = withAuth(true)(AdminPage);
 
@@ -95,20 +96,27 @@ export const getPluginRoutes = (
   plugins: PluginConfig[],
   admin?: boolean
 ): {
-  [plugin: string]: string[];
+  [plugin: string]: { link: string; unauthorised?: boolean }[];
 } => {
   const pluginRoutes: {
-    [plugin: string]: string[];
+    [plugin: string]: { link: string; unauthorised?: boolean }[];
   } = {};
-
   plugins.forEach((p) => {
     const isAdmin = admin ? p.admin : !p.admin;
     const basePluginLink = p.link.split('?')[0];
     if (isAdmin) {
       if (pluginRoutes[p.plugin]) {
-        pluginRoutes[p.plugin].push(basePluginLink);
+        pluginRoutes[p.plugin].push({
+          link: basePluginLink,
+          unauthorised: p.unauthorised,
+        });
       } else {
-        pluginRoutes[p.plugin] = [basePluginLink];
+        pluginRoutes[p.plugin] = [
+          {
+            link: basePluginLink,
+            unauthorised: p.unauthorised,
+          },
+        ];
       }
     }
   });
@@ -252,10 +260,16 @@ const Routing: React.FC<RoutingProps> = (props: RoutingProps) => {
         {props.maintenance.show && !props.userIsAdmin ? (
           <Route component={MaintenancePage} />
         ) : (
+          //TODO: wrong way of doing unauthorised
+          // I think whole plugin should be authorised or not ?
           Object.entries(pluginRoutes).map(([key, value]) => {
             return (
               <Route key={key} path={value}>
-                <AuthorisedPlugin id={key} />
+                {value ? (
+                  <UnauthorisedPlugin id={key} />
+                ) : (
+                  <AuthorisedPlugin id={key} />
+                )}
               </Route>
             );
           })

--- a/src/state/actions/scigateway.actions.tsx
+++ b/src/state/actions/scigateway.actions.tsx
@@ -151,7 +151,7 @@ export const addHelpTourSteps = (
 });
 
 export const loadAuthProvider = (
-  authProvider: string,
+  authProvider: string | null,
   authUrl?: string,
   autoLogin?: boolean
 ): ActionType<AuthProviderPayload> => ({

--- a/src/state/reducers/scigateway.reducer.test.tsx
+++ b/src/state/reducers/scigateway.reducer.test.tsx
@@ -39,6 +39,7 @@ import TestAuthProvider from '../../authentication/testAuthProvider';
 import JWTAuthProvider from '../../authentication/jwtAuthProvider';
 import GithubAuthProvider from '../../authentication/githubAuthProvider';
 import ICATAuthProvider from '../../authentication/icatAuthProvider';
+import NullAuthProvider from '../../authentication/nullAuthProvider';
 
 describe('scigateway reducer', () => {
   let state: ScigatewayState;
@@ -283,6 +284,12 @@ describe('scigateway reducer', () => {
 
     expect(updatedState.authorisation.provider).toBeInstanceOf(
       ICATAuthProvider
+    );
+
+    updatedState = ScigatewayReducer(state, loadAuthProvider(null));
+
+    expect(updatedState.authorisation.provider).toBeInstanceOf(
+      NullAuthProvider
     );
   });
 

--- a/src/state/reducers/scigateway.reducer.tsx
+++ b/src/state/reducers/scigateway.reducer.tsx
@@ -57,6 +57,7 @@ import log from 'loglevel';
 import JWTAuthProvider from '../../authentication/jwtAuthProvider';
 import LoadingAuthProvider from '../../authentication/loadingAuthProvider';
 import GithubAuthProvider from '../../authentication/githubAuthProvider';
+import NullAuthProvider from '../../authentication/nullAuthProvider';
 import { Step } from 'react-joyride';
 import ICATAuthProvider from '../../authentication/icatAuthProvider';
 
@@ -354,27 +355,32 @@ export function handleAuthProviderUpdate(
   payload: AuthProviderPayload
 ): ScigatewayState {
   let provider = state.authorisation.provider;
-  switch (payload.authProvider.split('.')[0]) {
-    case 'jwt':
-      provider = new JWTAuthProvider(payload.authUrl);
-      break;
 
-    case 'github':
-      provider = new GithubAuthProvider(payload.authUrl);
-      break;
+  if (payload.authProvider === null) {
+    provider = new NullAuthProvider();
+  } else {
+    switch (payload.authProvider.split('.')[0]) {
+      case 'jwt':
+        provider = new JWTAuthProvider(payload.authUrl);
+        break;
 
-    case 'icat':
-      provider = new ICATAuthProvider(
-        payload.authProvider.split('.')[1],
-        payload.authUrl,
-        payload.autoLogin
-      );
-      break;
+      case 'github':
+        provider = new GithubAuthProvider(payload.authUrl);
+        break;
 
-    default:
-      throw Error(
-        `Unrecognised auth provider: ${payload.authProvider}, this is a development issue as there is no implementation registered for this provider.`
-      );
+      case 'icat':
+        provider = new ICATAuthProvider(
+          payload.authProvider.split('.')[1],
+          payload.authUrl,
+          payload.autoLogin
+        );
+        break;
+
+      default:
+        throw Error(
+          `Unrecognised auth provider: ${payload.authProvider}, this is a development issue as there is no implementation registered for this provider.`
+        );
+    }
   }
 
   return {

--- a/src/state/scigateway.types.tsx
+++ b/src/state/scigateway.types.tsx
@@ -176,7 +176,7 @@ export interface DismissNotificationPayload {
 }
 
 export interface AuthProviderPayload {
-  authProvider: string;
+  authProvider: string | null;
   authUrl?: string;
   autoLogin?: boolean;
 }

--- a/src/state/scigateway.types.tsx
+++ b/src/state/scigateway.types.tsx
@@ -114,6 +114,7 @@ export interface RegisterRoutePayload {
   link: string;
   plugin: string;
   displayName: string;
+  unauthorised?: boolean;
   hideFromMenu?: boolean;
   admin?: boolean;
   order: number;
@@ -129,6 +130,7 @@ export interface PluginConfig {
   link: string;
   plugin: string;
   displayName: string;
+  unauthorised?: boolean;
   hideFromMenu?: boolean;
   admin?: boolean;
   order: number;

--- a/src/state/state.types.tsx
+++ b/src/state/state.types.tsx
@@ -14,6 +14,7 @@ export interface Plugin {
   name: string;
   src: string;
   enable: boolean;
+  unauthorised?: boolean;
   location: 'main' | 'left' | 'right';
 }
 


### PR DESCRIPTION
## Description
Created nullAuthProvider which allows to disable authentication related functionality when `"auth-provider": null` is specified in SG settings. 
Also, plugin routes can now be unauthenticated by specifying the optional `unauthorised: true` argument in plugin route settings. Plugin routes are authenticated by default.

## Testing instructions
Updated unit tests to check for redirections and remounting. Added a new test suite for nullAuthProvider.

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
connect to #1313 