### PR TITLE
Pin docker base images to SHA

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Login to Harbor
         uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0
         with:
-          registry: harbor.stfc.ac.uk/datagateway
+          registry: ${{ secrets.HARBOR_URL }}
           username: ${{ secrets.HARBOR_USERNAME }}
           password: ${{ secrets.HARBOR_TOKEN }}
 
@@ -58,7 +58,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@818d4b7b91585d195f67373fd9cb0332e31a7175 # v4.6.0
         with:
-          images: harbor.stfc.ac.uk/datagateway/scigateway
+          images: ${{ secrets.HARBOR_URL }}/scigateway
 
       - name: Build and push Docker image to Harbor
         uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4.2.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Dockerfile to build and serve scigateway
 
 # Build stage
-FROM node:20.11-alpine3.18 as builder
+FROM node:20.11.1-alpine3.18@sha256:a02826c7340c37a29179152723190bcc3044f933c925f3c2d78abb20f794de3f as builder
 
 WORKDIR /scigateway-build
 
@@ -24,7 +24,7 @@ COPY docker/settings.json public/settings.json
 RUN yarn build
 
 # Run stage
-FROM httpd:2.4-alpine3.15
+FROM httpd:2.4.53-alpine3.15@sha256:4eb4177b9245c686696dd8120c79cd64b7632b27d890db4cad3b0e844ed737af
 
 WORKDIR /usr/local/apache2/htdocs
 


### PR DESCRIPTION
## Description
This PR pins the base docker images in the Dockerfiles to commit SHAs so that Renovate (or Dependabot if Renovate doesn't work) can create PRs each time there is a change in the upstream base images that the base images are set to use as new SHAs are generated on every upstream change. Not sure if Renovate will also update the OS versions but if it doesn't then we will have to do the Alpine version updates manually for now.

Please note that I have pinned it to an older SHA to verify that Renovate (or Dependabot if Renovate doesn't work) will create a PR.

## Testing instructions
- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage