### PR TITLE
Bump Docker base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Dockerfile to build and serve scigateway
 
 # Build stage
-FROM node:20.11.1-alpine3.19@sha256:bf77dc26e48ea95fca9d1aceb5acfa69d2e546b765ec2abfb502975f1a2d4def as builder
+FROM node:20.14.0-alpine3.20@sha256:928b24aaadbd47c1a7722c563b471195ce54788bf8230ce807e1dd500aec0549 as builder
 
 WORKDIR /scigateway-build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ COPY docker/settings.json public/settings.json
 RUN yarn build
 
 # Run stage
-FROM httpd:2.4.58-alpine3.19@sha256:92535cf7f151901ba91b04186292c3bd5bf82aa6ffa6eb7bc405fefbffedd480
+FROM httpd:2.4.59-alpine3.20@sha256:554f25b8496f360a58febaaa5df9effb8e037cc1b70b27d40b7353a85e8edbf0
 
 WORKDIR /usr/local/apache2/htdocs
 

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "@testing-library/react": "12.1.5",
     "@testing-library/user-event": "14.5.2",
     "@types/jsonwebtoken": "9.0.1",
-    "@types/node": "20.11.5",
+    "@types/node": "20.14.0",
     "@types/react": "17.0.38",
     "@types/react-redux": "7.1.20",
     "@types/react-router": "5.1.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3322,12 +3322,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:*, @types/node@npm:20.11.5":
+"@types/node@npm:*":
   version: 20.11.5
   resolution: "@types/node@npm:20.11.5"
   dependencies:
     undici-types: "npm:~5.26.4"
   checksum: 10/9f31c471047d7b3e240ce7b77ff29b0d15e83be7e3feafb3d0b0d0931122b438b1eefa302a5a2e1e9849914ff3fd76aafbd8ccb372efb1331ba048da63bce6f8
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:20.14.0":
+  version: 20.14.0
+  resolution: "@types/node@npm:20.14.0"
+  dependencies:
+    undici-types: "npm:~5.26.4"
+  checksum: 10/49b332fbf8aee4dc4f61cc1f1f6e130632510f795dd7b274e55894516feaf4bec8a3d13ea764e2443e340a64ce9bbeb006d14513bf6ccdd4f21161eccc7f311e
   languageName: node
   linkType: hard
 
@@ -13884,7 +13893,7 @@ __metadata:
     "@types/jest": "npm:29.5.2"
     "@types/js-cookie": "npm:3.0.1"
     "@types/jsonwebtoken": "npm:9.0.1"
-    "@types/node": "npm:20.11.5"
+    "@types/node": "npm:20.14.0"
     "@types/react": "npm:17.0.38"
     "@types/react-dom": "npm:17.0.11"
     "@types/react-redux": "npm:7.1.20"


### PR DESCRIPTION
## Description
Bumps the `node` Docker image from `20.11.1-alpine3.19` to `20.14.0-alpine3.20` and the `httpd` Docker image from `2.4.58-alpine3.19` to `2.4.59-alpine3.20`. It also bumps the project `@types/node` dependency from `20.11.5` to `20.14.0`.

## Testing instructions
- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage