### PR TITLE
Add docker image push when tags pushed #1390

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -38,32 +38,32 @@ jobs:
         run: yarn e2e
 
   docker:
-    # This job triggers only if all the other jobs succeed. It builds the Docker image and if successful,
-    # it pushes it to Harbor.
+    # This job triggers only if all the other jobs succeed. It builds the Docker image to ensure it builds correctly.
     needs: [test]
     name: Docker
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout repo
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Login to Harbor
-        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
           registry: ${{ secrets.HARBOR_URL }}
           username: ${{ secrets.HARBOR_USERNAME }}
           password: ${{ secrets.HARBOR_TOKEN }}
 
-      - name: Extract metadata (tags, labels) for Docker
+      - name: Extract metadata (tags, labels, annotations) for Docker
         id: meta
-        uses: docker/metadata-action@818d4b7b91585d195f67373fd9cb0332e31a7175 # v4.6.0
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
         with:
           images: ${{ secrets.HARBOR_URL }}/scigateway
 
-      - name: Build and push Docker image to Harbor
-        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4.2.1
+      - name: Build Docker image
+        uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6.9.0
         with:
           context: .
-          push: true
+          push: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}

--- a/.github/workflows/docker-release-build.yml
+++ b/.github/workflows/docker-release-build.yml
@@ -1,0 +1,40 @@
+name: Docker Release Build
+on:
+  push:
+    tags: '*'
+
+jobs:
+  docker:
+    # This job builds the Docker image and if successful, it pushes it to Harbor.
+    name: Docker
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Login to Harbor
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ${{ secrets.HARBOR_URL }}
+          username: ${{ secrets.HARBOR_USERNAME }}
+          password: ${{ secrets.HARBOR_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
+        with:
+          images: ${{ secrets.HARBOR_URL }}/scigateway
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=ref,event=tag,pattern={{ref}}
+
+      - name: Build and push Docker image to Harbor
+        uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6.9.0
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}


### PR DESCRIPTION
## Description
Adds a docker release action that builds and pushes the docker image when a tag is pushed. 

### Notes
- I tested the `docker/metadata-action` part of this new action on my own repo and found the following behaviour:

| GitHub Tag | Docker Image Tags |
| ------------- | ------------- |
| v1.0.1  | 1.0, 1.0.1, v1.0.1 |
| v1.0.1-dev | 1.0.1-dev, v1.0.1-dev |
| 1.0.1 | 1.0, 1.0.1 |
| 1.0.1-dev | 1.0.1-dev |
| docker-test | docker-test |

- We use the additional `type=semver,pattern={{major}}.{{minor}}` tag on IMS so our docker compose doesn't need to be updated for a patch update and can instead just point to `1.0` so I have done the same here

- `latest` is disabled here as it would otherwise always be added with tags that do not follow the semver format and we don't use it at the moment anyway. If it is needed in the future will likely need a separate workflow to filter the tag as regex.

- Disables docker builds from being pushed in PRs and branches instead only doing the build to ensure it can perform the docker build successfully prior to a release.

- https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file?learn=dependency_version_updates&learnProduct=code-security#docker Suggests the tag must be the same for both the repo and docker image to function. As a result I think we may have to remove the `v` when doing releases though I am not 100% sure. It also reduces the duplication as in the table above.

- We still publish images under the datagateway project. This should probably be changed at some point in the future.

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Check labels and annotations make sense in the CI (see the `Extract metadata (tags, labels, annotations) for Docker` step)

## Agile board tracking
Closes #1390