### PR TITLE
feat: Add OGJWTAuthProvider to handle admin users

### DIFF
--- a/src/authentication/OGJWTAuthProvider.test.tsx
+++ b/src/authentication/OGJWTAuthProvider.test.tsx
@@ -1,0 +1,42 @@
+import OGJWTAuthProvider from './OGJWTAuthProvider';
+
+describe('OG-JWT Auth provider', () => {
+  const createOGJWTAuthProvider = (token?: string): OGJWTAuthProvider => {
+    jest.spyOn(window.localStorage.__proto__, 'getItem');
+    window.localStorage.__proto__.getItem = jest
+      .fn()
+      .mockImplementation((name) =>
+        name === 'scigateway:token' ? token : null
+      );
+    window.localStorage.__proto__.removeItem = jest.fn();
+    window.localStorage.__proto__.setItem = jest.fn();
+    return new OGJWTAuthProvider('http://localhost:8000');
+  };
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('isAdmin is false when token is not in local storage', () => {
+    const ogJWTAuthProvider = createOGJWTAuthProvider();
+    expect(ogJWTAuthProvider.isAdmin()).toBeFalsy();
+  });
+
+  it('isAdmin is true when "/users POST" is in the authorised routes', () => {
+    const tokenWithAuthorisedRoutes =
+      'eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJ1c2VybmFtZSI6ImJhY2tlbmQiLCJhdXRob3Jpc2VkX3JvdXRlcyI6WyIvc3VibWl0L2hkZiBQT1NUIiwiL3N1Ym1pdC9tYW5pZmVzdCBQT1NUIiwiL3JlY29yZHMve2lkX30gREVMRVRFIiwiL2V4cGVyaW1lbnRzIFBPU1QiLCIvdXNlcnMgUE9TVCIsIi91c2VycyBQQVRDSCIsIi91c2Vycy97aWRffSBERUxFVEUiXSwiZXhwIjoxNzMzMTM3NDk5fQ.jRJZr38lUeqKL1D5M6TdYIS8DEEWcZUgFfvNYcqZIqraKi9Ck2VNv3uf5XjOsD-phjjNltMmh77MxbVyUvE7ZCtCgN4vJyjA3NiF-YPiDK8miRIo9DPVEi1NBBvlMoZm_vyLcOTW0ClX4XLXuOi_1qJkMZkw0P_VtARstNnXuaiRwXiHe80IObm6GNTxFmOx5db4xTMtvYVtUOY26O68cJ4fDuOZ-xq4pvWV-oH-IigM-e-LC70eS4dGxRyx5TFHUQtwWfAvsSrrhwLf8iMXuem0oFs7qSKd0Tpc3mymVq0ZnHZQg7ctYY57lMZo57QxtCqxqDd_4A25jucf5LrchQ';
+    const ogJWTAuthProvider = createOGJWTAuthProvider(
+      tokenWithAuthorisedRoutes
+    );
+    expect(ogJWTAuthProvider.isAdmin()).toBeTruthy();
+  });
+  // TODO change '/users POST' to '/users GET' once that route is created
+  it('isAdmin is false when "/users POST" is not in the authorised routes', () => {
+    const tokenWithAuthorisedRoutes =
+      'eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJ1c2VybmFtZSI6ImZyb250ZW5kIiwiYXV0aG9yaXNlZF9yb3V0ZXMiOm51bGwsImV4cCI6MTczMzE0MDM2Nn0.PdzhtTPhu7skG-DJCeOMLHCruxvwoCEbgsINzHncpsVv0JkBmG0-272evQPQJVYzSwMUdjW8EpQu20RVDiQ9-cR0Ae_RYfKOiMv2_R8bLkSfyMIr9C3NOi6FONJlO79u1he15fYT85OAxH9IaOZLfSsVxW2eJBehKphOZdX2VSQqmAbe8f35chU-a7cQNGRkxmPcHsT_M563W53T-s7EnarXt5VIo0ybXL02jjhERHUgydGiWTa6sIN-u571FDyU7Br7VxvQmQ7tTADWTC0IxSLdoWX1XPt_ef0sxKRrnqByKdPI1q-5WQI0Jme0SYVS3DwesfMyyhrtkfjrm3MjBg';
+    const ogJWTAuthProvider = createOGJWTAuthProvider(
+      tokenWithAuthorisedRoutes
+    );
+    expect(ogJWTAuthProvider.isAdmin()).toBeFalsy();
+  });
+});

--- a/src/authentication/OGJWTAuthProvider.tsx
+++ b/src/authentication/OGJWTAuthProvider.tsx
@@ -1,0 +1,17 @@
+import JWTAuthProvider from './jwtAuthProvider';
+import parseJwt from './parseJwt';
+
+export default class OGJWTAuthProvider extends JWTAuthProvider {
+  public isAdmin(): boolean {
+    if (!this.token) return false;
+    const tokenString = parseJwt(this.token);
+    const tokenObject = JSON.parse(tokenString);
+    if (
+      !tokenObject.authorised_routes ||
+      tokenObject.authorised_routes.length === 0
+    )
+      return false;
+    // TODO change '/users POST' to '/users GET' once that route is created
+    return tokenObject.authorised_routes.includes('/users POST');
+  }
+}

--- a/src/state/reducers/scigateway.reducer.test.tsx
+++ b/src/state/reducers/scigateway.reducer.test.tsx
@@ -1,46 +1,47 @@
 import log from 'loglevel';
-import {
-  toggleDrawer,
-  authorised,
-  unauthorised,
-  loadingAuthentication,
-  dismissMenuItem,
-  configureAnalytics,
-  initialiseAnalytics,
-  siteLoadingUpdate,
-  loadAuthProvider,
-  configureStrings,
-  loadFeatureSwitches,
-  toggleHelp,
-  addHelpTourSteps,
-  invalidToken,
-  loadedAuthentication,
-  loadDarkModePreference,
-  registerHomepageUrl,
-  loadScheduledMaintenanceState,
-  loadMaintenanceState,
-  loadHighContrastModePreference,
-  customLogo,
-  customNavigationDrawerLogo,
-  customAdminPageDefaultTab,
-  autoLoginAuthorised,
-  resetAuthState,
-  registerContactUsAccessibilityFormUrl,
-  customPrimaryColour,
-} from '../actions/scigateway.actions';
-import ScigatewayReducer, {
-  initialState,
-  handleAuthProviderUpdate,
-  authState,
-} from './scigateway.reducer';
-import { SignOutType } from '../scigateway.types';
-import { ScigatewayState } from '../state.types';
-import TestAuthProvider from '../../authentication/testAuthProvider';
-import JWTAuthProvider from '../../authentication/jwtAuthProvider';
 import GithubAuthProvider from '../../authentication/githubAuthProvider';
 import ICATAuthProvider from '../../authentication/icatAuthProvider';
-import NullAuthProvider from '../../authentication/nullAuthProvider';
+import JWTAuthProvider from '../../authentication/jwtAuthProvider';
 import LDAPJWTAuthProvider from '../../authentication/ldapJWTAuthProvider';
+import NullAuthProvider from '../../authentication/nullAuthProvider';
+import OGJWTAuthProvider from '../../authentication/OGJWTAuthProvider';
+import TestAuthProvider from '../../authentication/testAuthProvider';
+import {
+  addHelpTourSteps,
+  authorised,
+  autoLoginAuthorised,
+  configureAnalytics,
+  configureStrings,
+  customAdminPageDefaultTab,
+  customLogo,
+  customNavigationDrawerLogo,
+  customPrimaryColour,
+  dismissMenuItem,
+  initialiseAnalytics,
+  invalidToken,
+  loadAuthProvider,
+  loadDarkModePreference,
+  loadedAuthentication,
+  loadFeatureSwitches,
+  loadHighContrastModePreference,
+  loadingAuthentication,
+  loadMaintenanceState,
+  loadScheduledMaintenanceState,
+  registerContactUsAccessibilityFormUrl,
+  registerHomepageUrl,
+  resetAuthState,
+  siteLoadingUpdate,
+  toggleDrawer,
+  toggleHelp,
+  unauthorised,
+} from '../actions/scigateway.actions';
+import { SignOutType } from '../scigateway.types';
+import { ScigatewayState } from '../state.types';
+import ScigatewayReducer, {
+  authState,
+  handleAuthProviderUpdate,
+  initialState,
+} from './scigateway.reducer';
 
 describe('scigateway reducer', () => {
   let state: ScigatewayState;
@@ -291,6 +292,12 @@ describe('scigateway reducer', () => {
 
     expect(updatedState.authorisation.provider).toBeInstanceOf(
       LDAPJWTAuthProvider
+    );
+
+    updatedState = ScigatewayReducer(state, loadAuthProvider('og-jwt'));
+
+    expect(updatedState.authorisation.provider).toBeInstanceOf(
+      OGJWTAuthProvider
     );
 
     updatedState = ScigatewayReducer(state, loadAuthProvider(null));

--- a/src/state/reducers/scigateway.reducer.tsx
+++ b/src/state/reducers/scigateway.reducer.tsx
@@ -1,66 +1,67 @@
-import createReducer from './createReducer';
+import log from 'loglevel';
+import { Step } from 'react-joyride';
+import GithubAuthProvider from '../../authentication/githubAuthProvider';
+import ICATAuthProvider from '../../authentication/icatAuthProvider';
+import JWTAuthProvider from '../../authentication/jwtAuthProvider';
+import LDAPJWTAuthProvider from '../../authentication/ldapJWTAuthProvider';
+import LoadingAuthProvider from '../../authentication/loadingAuthProvider';
+import NullAuthProvider from '../../authentication/nullAuthProvider';
+import OGJWTAuthProvider from '../../authentication/OGJWTAuthProvider';
 import { singleSpaPluginRoutes } from '../actions/loadMicroFrontends';
+import { buildPluginConfig } from '../pluginhelper';
 import {
-  NotificationType,
-  NotificationPayload,
-  RegisterRouteType,
-  RegisterRoutePayload,
-  ToggleDrawerType,
-  AuthSuccessType,
-  AutoLoginSuccessType,
-  AuthFailureType,
-  ConfigureStringsType,
-  ConfigureStringsPayload,
-  SignOutType,
-  FeatureSwitchesPayload,
-  ConfigureFeatureSwitchesType,
-  LoadingAuthType,
-  InvalidateTokenType,
-  AuthProviderPayload,
-  LoadAuthProviderType,
-  SiteLoadingPayload,
-  SiteLoadingType,
-  DismissNotificationType,
-  PluginConfig,
-  ConfigureAnalyticsType,
-  ConfigureAnalyticsPayload,
-  InitialiseAnalyticsType,
-  ToggleHelpType,
   AddHelpTourStepsPayload,
   AddHelpTourStepsType,
-  LoadedAuthType,
-  LoadDarkModePreferenceType,
-  LoadDarkModePreferencePayload,
-  HomepageUrlPayload,
-  CustomLogoPayload,
-  RegisterHomepageUrlType,
-  LoadScheduledMaintenanceStateType,
-  ScheduledMaintenanceStatePayLoad,
-  MaintenanceStatePayLoad,
-  LoadMaintenanceStateType,
-  CustomLogoType,
-  LoadHighContrastModePreferencePayload,
-  LoadHighContrastModePreferenceType,
-  ResetAuthStateType,
-  CustomNavigationDrawerLogoPayload,
-  CustomNavigationDrawerLogoType,
+  AuthFailureType,
+  AuthProviderPayload,
+  AuthSuccessType,
+  AutoLoginSuccessType,
+  ConfigureAnalyticsPayload,
+  ConfigureAnalyticsType,
+  ConfigureFeatureSwitchesType,
+  ConfigureStringsPayload,
+  ConfigureStringsType,
+  ContactUsAccessibilityFormUrlPayload,
   CustomAdminPageDefaultTabPayload,
   CustomAdminPageDefaultTabType,
-  RegisterContactUsAccessibilityFormUrlType,
-  ContactUsAccessibilityFormUrlPayload,
-  CustomPrimaryColourType,
+  CustomLogoPayload,
+  CustomLogoType,
+  CustomNavigationDrawerLogoPayload,
+  CustomNavigationDrawerLogoType,
   CustomPrimaryColourPayload,
+  CustomPrimaryColourType,
+  DismissNotificationType,
+  FeatureSwitchesPayload,
+  HomepageUrlPayload,
+  InitialiseAnalyticsType,
+  InvalidateTokenType,
+  LoadAuthProviderType,
+  LoadDarkModePreferencePayload,
+  LoadDarkModePreferenceType,
+  LoadedAuthType,
+  LoadHighContrastModePreferencePayload,
+  LoadHighContrastModePreferenceType,
+  LoadingAuthType,
+  LoadMaintenanceStateType,
+  LoadScheduledMaintenanceStateType,
+  MaintenanceStatePayLoad,
+  NotificationPayload,
+  NotificationType,
+  PluginConfig,
+  RegisterContactUsAccessibilityFormUrlType,
+  RegisterHomepageUrlType,
+  RegisterRoutePayload,
+  RegisterRouteType,
+  ResetAuthStateType,
+  ScheduledMaintenanceStatePayLoad,
+  SignOutType,
+  SiteLoadingPayload,
+  SiteLoadingType,
+  ToggleDrawerType,
+  ToggleHelpType,
 } from '../scigateway.types';
-import { ScigatewayState, AuthState } from '../state.types';
-import { buildPluginConfig } from '../pluginhelper';
-import log from 'loglevel';
-import JWTAuthProvider from '../../authentication/jwtAuthProvider';
-import LoadingAuthProvider from '../../authentication/loadingAuthProvider';
-import GithubAuthProvider from '../../authentication/githubAuthProvider';
-import NullAuthProvider from '../../authentication/nullAuthProvider';
-import { Step } from 'react-joyride';
-import ICATAuthProvider from '../../authentication/icatAuthProvider';
-import LDAPJWTAuthProvider from '../../authentication/ldapJWTAuthProvider';
+import { AuthState, ScigatewayState } from '../state.types';
+import createReducer from './createReducer';
 
 export const authState: AuthState = {
   failedToLogin: false,
@@ -370,6 +371,9 @@ export function handleAuthProviderUpdate(
         provider = new LDAPJWTAuthProvider(payload.authUrl);
         break;
 
+      case 'og-jwt':
+        provider = new OGJWTAuthProvider(payload.authUrl);
+        break;
       case 'github':
         provider = new GithubAuthProvider(payload.authUrl);
         break;


### PR DESCRIPTION


## Description
- Implement OGJWTAuthProvider class with isAdmin method to check for admin privileges based on JWT's authorised_routes.
- Add unit tests for isAdmin method covering scenarios with no token, empty authorised_routes, and token containing '/users GET' route.

## Testing instructions

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage


## Agile board tracking
closes #1423 