### PR TITLE
Remove libgconf install step on CI jobs

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -20,10 +20,7 @@ jobs:
           node-version: 20
           cache: 'yarn'
       - name: Install dependencies
-        # Ubuntu 16+ does not install libgconf-2-4 by default, so we need to install it ourselves (for Cypress)
-        run: |
-          sudo apt-get install libgconf-2-4
-          yarn --immutable
+        run: yarn --immutable
       - name: Run linting
         run: yarn lint:js
       - name: Run unit tests

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -23,10 +23,7 @@ jobs:
           cache: 'yarn'
 
       - name: Install dependencies
-        # Ubuntu 16+ does not install libgconf-2-4 by default, so we need to install it ourselves (for Cypress)
-        run: |
-          sudo apt-get install libgconf-2-4
-          yarn --immutable
+        run: yarn --immutable
 
       - name: Build
         run: yarn build


### PR DESCRIPTION
## Description
Github changed the default machine from Ubuntu 22 to Ubuntu 24, which doesn't have libgconf-2-4. Equally, Cypress no longer needs this dependency so it can just be removed

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
