### PR TITLE
Fix loading bug using more general solution

### DIFF
--- a/src/routing/routing.component.test.tsx
+++ b/src/routing/routing.component.test.tsx
@@ -371,106 +371,6 @@ describe('Routing component', () => {
     expect(history.location.pathname).toEqual('/logout');
   });
 
-  it('single-spa remounts a plugin when switching between admin and non-admin plugins via single-spa:before-no-app-change event', () => {
-    state.scigateway.authorisation.provider = new TestAuthProvider('logged in');
-    state.scigateway.siteLoading = false;
-    state.scigateway.plugins = [
-      {
-        section: 'test section',
-        link: '/test_link',
-        plugin: 'test_plugin_name',
-        displayName: 'Test Plugin',
-        order: 1,
-      },
-      {
-        section: 'test section',
-        link: '/admin_test_link',
-        plugin: 'test_plugin_name',
-        displayName: 'Test Plugin Admin',
-        admin: true,
-        order: 2,
-      },
-    ];
-
-    render(<Routing />, { wrapper: Wrapper });
-
-    window.dispatchEvent(
-      new CustomEvent('single-spa:before-no-app-change', {
-        detail: {
-          oldUrl: 'http://localhost/test_link',
-          newUrl: 'http://localhost/admin_test_link',
-        },
-      })
-    );
-    expect(singleSpa.unloadApplication).toHaveBeenCalledWith(
-      'test_plugin_name'
-    );
-
-    vi.mocked(singleSpa.unloadApplication).mockClear();
-
-    window.dispatchEvent(
-      new CustomEvent('single-spa:before-no-app-change', {
-        detail: {
-          oldUrl: 'http://localhost/admin_test_link',
-          newUrl: 'http://localhost/test_link',
-        },
-      })
-    );
-    expect(singleSpa.unloadApplication).toHaveBeenCalledWith(
-      'test_plugin_name'
-    );
-  });
-
-  it('single-spa remounts a plugin when switching between authorised and unauthorised plugins via single-spa:before-no-app-change event', () => {
-    state.scigateway.authorisation.provider = new TestAuthProvider('logged in');
-    state.scigateway.siteLoading = false;
-    state.scigateway.plugins = [
-      {
-        section: 'test section',
-        link: '/test_link',
-        plugin: 'test_plugin_name',
-        displayName: 'Test Plugin',
-        order: 1,
-      },
-      {
-        section: 'test section',
-        link: '/unauthorised_test_link',
-        plugin: 'test_plugin_name',
-        displayName: 'Test Plugin Admin',
-        unauthorised: true,
-        order: 2,
-      },
-    ];
-
-    render(<Routing />, { wrapper: Wrapper });
-
-    window.dispatchEvent(
-      new CustomEvent('single-spa:before-no-app-change', {
-        detail: {
-          oldUrl: 'http://localhost/test_link',
-          newUrl: 'http://localhost/unauthorised_test_link',
-        },
-      })
-    );
-    expect(singleSpa.unloadApplication).toHaveBeenCalledWith(
-      'test_plugin_name'
-    );
-
-    vi.mocked(singleSpa.unloadApplication).mockClear();
-
-    window.dispatchEvent(
-      new CustomEvent('single-spa:before-no-app-change', {
-        detail: {
-          oldUrl: 'http://localhost/unauthorised_test_link',
-          newUrl: 'http://localhost/test_link',
-        },
-      })
-    );
-    expect(singleSpa.unloadApplication).toHaveBeenCalledWith(
-      'test_plugin_name'
-    );
-  });
-
   it("single-spa reloads a plugin when it hasn't loaded for some reason", () => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
     state.scigateway.authorisation.provider = new TestAuthProvider('logged in');
@@ -485,6 +385,7 @@ describe('Routing component', () => {
       },
     ];
     state.router.location = createLocation('/test_link');
+    const unloadApplicationSpy = vi.spyOn(singleSpa, 'unloadApplication');
 
     vi.spyOn(document, 'getElementById').mockImplementation(() => {
       return document.createElement('div');
@@ -496,9 +397,44 @@ describe('Routing component', () => {
 
     vi.runAllTimers();
 
-    expect(singleSpa.unloadApplication).toHaveBeenCalledWith(
-      'test_plugin_name'
-    );
+    expect(unloadApplicationSpy).toHaveBeenCalledWith('test_plugin_name');
+
+    // Could not use toHaveBeenCalledWith(expect.any(Number)) as it is a mocked object in this test
+    expect(clearIntervalSpy).toHaveBeenCalled();
+
+    // restore clearInterval to avoid errors with it not being a function on unmount
+    clearIntervalSpy.mockRestore();
+    vi.useRealTimers();
+  });
+
+  it("single-spa doesn't reload a plugin when it has been loaded", () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    state.scigateway.authorisation.provider = new TestAuthProvider('logged in');
+    state.scigateway.siteLoading = false;
+    state.scigateway.plugins = [
+      {
+        section: 'test section',
+        link: '/test_link',
+        plugin: 'test_plugin_name',
+        displayName: 'Test Plugin',
+        order: 1,
+      },
+    ];
+    state.router.location = createLocation('/test_link');
+    const unloadApplicationSpy = vi.spyOn(singleSpa, 'unloadApplication');
+
+    vi.spyOn(document, 'getElementById').mockImplementation((element) => {
+      if (element === 'plugin-preloader') return null; // simulate loaded plugin
+      return document.createElement('div');
+    });
+
+    const clearIntervalSpy = vi.spyOn(window, 'clearInterval');
+
+    render(<Routing />, { wrapper: Wrapper });
+
+    vi.runAllTimers();
+
+    expect(unloadApplicationSpy).not.toHaveBeenCalled();
 
     // Could not use toHaveBeenCalledWith(expect.any(Number)) as it is a mocked object in this test
     expect(clearIntervalSpy).toHaveBeenCalled();

--- a/src/routing/routing.component.tsx
+++ b/src/routing/routing.component.tsx
@@ -133,81 +133,36 @@ const popSessionStorageItem = (
 };
 
 const Routing: React.FC<RoutingProps> = (props: RoutingProps) => {
-  const adminRoutes = getAdminRoutes({ plugins: props.plugins });
-  // only set to false if we're on a plugin route i.e. not a scigateway route
-  const manuallyLoadedPluginRef = React.useRef(
-    Object.values(scigatewayRoutes).includes(props.location.pathname) ||
-      props.location.pathname === adminRoutes.maintenance
-  );
-
   const theme = useTheme();
   const isMobileViewport = useMediaQuery(theme.breakpoints.down('md'));
 
+  // this useEffect should catch any instances of single-spa "thinking" a plugin is loaded
+  // when it actually isn't, and calls unloadApplication to force single-spa to reload
   React.useEffect(() => {
-    let intervalId: number | undefined;
-    // only try and manually load the first plugin on initial page load after site loaded using setInterval
-    if (!props.loading && !manuallyLoadedPluginRef.current) {
-      intervalId = window.setInterval(() => {
-        const pluginConf = props.plugins.find((p) =>
-          props.location.pathname.startsWith(p.link.split('?')[0])
-        );
+    const pluginConf = props.plugins.find((p) =>
+      props.location.pathname.startsWith(p.link.split('?')[0])
+    );
 
-        // finding pluginConf after loading implies that the route has loaded
-        // & that the site has loaded, so the plugin should have been loaded already
-        // and if it hasn't we need to manually load it
-        if (pluginConf && document.getElementById(pluginConf.plugin)) {
+    let intervalId: number | undefined;
+
+    // if we find pluginConf, we're on a plugin route
+    if (pluginConf) {
+      // set interval to give plugin divs a chance to load
+      intervalId = window.setInterval(() => {
+        // if we find the plugin div, it's loaded so can stop the interval
+        if (document.getElementById(pluginConf.plugin)) {
+          // if plugin div has loaded but still has loading spinner, tell single-spa to reload
           if (document.getElementById('plugin-preloader')) {
             singleSpa.unloadApplication(pluginConf.plugin);
           }
-          manuallyLoadedPluginRef.current = true;
           window.clearInterval(intervalId);
         }
       }, 500);
     }
-
     return () => {
-      // you can call clearInterval with an undefined ID fine
       window.clearInterval(intervalId);
     };
-  }, [props.loading, props.plugins, props.location]);
-  React.useEffect(() => {
-    // switching between an admin & non-admin route of the same app causes problems
-    // as the Route and thus the plugin div changes but single-spa doesn't remount
-    // so we need to explicitly tell single-spa to remount that specific plugin
-    const handler = (
-      event: CustomEvent<{
-        oldUrl: string;
-        newUrl: string;
-      }>
-    ): void => {
-      const oldPlugin = props.plugins.find((p) =>
-        new URL(event.detail.oldUrl).pathname.startsWith(p.link.split('?')[0])
-      );
-      const newPlugin = props.plugins.find((p) =>
-        new URL(event.detail.newUrl).pathname.startsWith(p.link.split('?')[0])
-      );
-
-      if (
-        oldPlugin &&
-        newPlugin &&
-        oldPlugin.plugin === newPlugin.plugin &&
-        ((oldPlugin.admin && !newPlugin.admin) ||
-          (newPlugin.admin && !oldPlugin.admin) ||
-          oldPlugin.unauthorised !== newPlugin.unauthorised)
-      ) {
-        singleSpa.unloadApplication(oldPlugin.plugin);
-      }
-    };
-    window.addEventListener(
-      'single-spa:before-no-app-change',
-      handler as EventListener
-    );
-    return () =>
-      window.removeEventListener(
-        'single-spa:before-no-app-change',
-        handler as EventListener
-      );
-  }, [props.plugins]);
+  }, [props.location.pathname, props.plugins]);
 
   const prevUserIsLoggedIn = usePrevious(props.userIsLoggedIn);
 


### PR DESCRIPTION
## Description
I found another instance of the "loading bug" aka where single-spa thinks a plugin is mounted but the loading spinner is there. If you go to datagateway-dseg, go to one of the browse pages, and click either the search button or the cart button in the top left. This should 100% trigger the bug - I believe this is due to the navigation being in the plugin itself, so SG reacts slow enough to it that single-spa "mounts" the new plugin before the new plugin div is loaded.

This PR fixes the above bug, and I simplified the code to try and cover most use cases of the bug (aka rather than detecting specific circumstances, just look every time the route changes if we're on a plugin route, wait for the div to load and when it loads, if the preloader spinner is there retrigger single-spa loading)

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [x] Check Actions build
- [x] Review changes to test coverage
- [x] Test it fixes the new instance of the loading bug - i.e. test that clicking the search or cart buttons in dataview doesn't trigger the bug
- [x] Test that switching from an admin route to a non-admin route doesn't trigger the bug (so go to the download admin page and then click on download in the sidebar) - I removed the specific fix for this but this new fix still covers this case