### PR TITLE
Improve post-login redirects

### DIFF
--- a/cypress/e2e/login.cy.ts
+++ b/cypress/e2e/login.cy.ts
@@ -442,7 +442,10 @@ describe('Login', () => {
     });
 
     it('should be able to login via SSO after auto login and be displayed as logged in', () => {
-      cy.visit('/login');
+      // test it redirects us to plugin after login
+      cy.visit('/plugin1');
+      cy.get('#demo_plugin').should('exist');
+      cy.contains('Sign in').click();
 
       cy.get('#select-mnemonic').click();
       cy.contains('Keycloak').click();
@@ -467,8 +470,8 @@ describe('Login', () => {
 
       cy.contains('Sign in').should('not.exist');
       cy.get('[aria-label="Open user menu"]').should('be.visible');
-      // check we redirect back to homepage
-      cy.url().should('eq', 'http://localhost:3000/');
+      // check we redirect back to referrer
+      cy.url().should('eq', 'http://localhost:3000/plugin1');
     });
 
     it('should autoLogin after logout', () => {

--- a/cypress/e2e/login.cy.ts
+++ b/cypress/e2e/login.cy.ts
@@ -437,6 +437,8 @@ describe('Login', () => {
 
       cy.contains('Sign in').should('not.exist');
       cy.get('[aria-label="Open user menu"]').should('be.visible');
+      // check we redirect back to homepage
+      cy.url().should('eq', 'http://localhost:3000/');
     });
 
     it('should be able to login via SSO after auto login and be displayed as logged in', () => {
@@ -463,8 +465,10 @@ describe('Login', () => {
         cy.url().should('include', url);
       });
 
-      cy.contains('Sign out').should('exist');
+      cy.contains('Sign in').should('not.exist');
       cy.get('[aria-label="Open user menu"]').should('be.visible');
+      // check we redirect back to homepage
+      cy.url().should('eq', 'http://localhost:3000/');
     });
 
     it('should autoLogin after logout', () => {
@@ -560,6 +564,8 @@ describe('Login', () => {
 
       cy.contains('Sign in').should('not.exist');
       cy.get('[aria-label="Open user menu"]').should('be.visible');
+      // check we redirect back to homepage
+      cy.url().should('eq', 'http://localhost:3000/');
     });
 
     it('should be able to login via SSO non-PKCE and be displayed as logged in', () => {

--- a/src/mainAppBar/userProfile.component.test.tsx
+++ b/src/mainAppBar/userProfile.component.test.tsx
@@ -1,21 +1,24 @@
-import React from 'react';
-import UserProfileComponent from './userProfile.component';
-import { StateType } from '../state/state.types';
-import configureStore, { type MockStore } from 'redux-mock-store';
-import { authState, initialState } from '../state/reducers/scigateway.reducer';
-import { Provider } from 'react-redux';
-import { push } from 'connected-react-router';
 import { StyledEngineProvider, ThemeProvider } from '@mui/material';
-import { thunk } from 'redux-thunk';
-import TestAuthProvider from '../authentication/testAuthProvider';
-import { buildTheme } from '../theming';
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { push } from 'connected-react-router';
+import { createMemoryHistory } from 'history';
+import React from 'react';
+import { Provider } from 'react-redux';
+import { Router } from 'react-router-dom';
+import configureStore, { type MockStore } from 'redux-mock-store';
+import { thunk } from 'redux-thunk';
+import TestAuthProvider from '../authentication/testAuthProvider';
+import { authState, initialState } from '../state/reducers/scigateway.reducer';
+import { StateType } from '../state/state.types';
+import { buildTheme } from '../theming';
+import UserProfileComponent from './userProfile.component';
 
 describe('User profile component', () => {
   let testStore: MockStore;
   let state: StateType;
   const theme = buildTheme(false);
+  let history: MemoryHistory;
 
   function Wrapper({
     children,
@@ -24,9 +27,11 @@ describe('User profile component', () => {
   }): JSX.Element {
     return (
       <Provider store={testStore}>
-        <StyledEngineProvider injectFirst>
-          <ThemeProvider theme={theme}>{children}</ThemeProvider>
-        </StyledEngineProvider>
+        <Router history={history}>
+          <StyledEngineProvider injectFirst>
+            <ThemeProvider theme={theme}>{children}</ThemeProvider>
+          </StyledEngineProvider>
+        </Router>
       </Provider>
     );
   }
@@ -39,6 +44,7 @@ describe('User profile component', () => {
       'test-token'
     );
     testStore = configureStore([thunk])(state);
+    history = createMemoryHistory();
   });
 
   it('renders sign in button if not signed in', () => {
@@ -54,13 +60,17 @@ describe('User profile component', () => {
   it('redirects to login when sign in is pressed', async () => {
     const user = userEvent.setup();
     state.scigateway.authorisation.provider = new TestAuthProvider(null);
+    history.replace('/test');
 
     render(<UserProfileComponent />, { wrapper: Wrapper });
 
     await user.click(screen.getByRole('button', { name: 'login-button' }));
 
-    expect(testStore.getActions().length).toEqual(1);
-    expect(testStore.getActions()[0]).toEqual(push('/login'));
+    expect(history.location.pathname).toBe('/login');
+    expect(history.location.state).toEqual({
+      referrer: '/test',
+      referredFrom: 'clickingSignIn',
+    });
   });
 
   it('renders sign in button if user signed in via autoLogin', () => {

--- a/src/mainAppBar/userProfile.component.tsx
+++ b/src/mainAppBar/userProfile.component.tsx
@@ -1,29 +1,29 @@
-import React, { useState } from 'react';
-import { Dispatch, Action, AnyAction } from 'redux';
 import AccountCircleIcon from '@mui/icons-material/AccountCircle';
 import LogoutIcon from '@mui/icons-material/ExitToApp';
 import {
-  IconButton,
-  Theme,
-  Menu,
-  MenuItem,
+  Avatar,
   Button,
-  Typography,
   Divider,
+  IconButton,
   ListItemIcon,
   ListItemText,
-  Avatar,
+  Menu,
+  MenuItem,
+  Theme,
+  Typography,
 } from '@mui/material';
 import { alpha } from '@mui/material/styles';
+import log from 'loglevel';
+import React, { useState } from 'react';
+import { connect } from 'react-redux';
+import { useHistory, useLocation } from 'react-router-dom';
+import { AnyAction, Dispatch } from 'redux';
+import { ThunkDispatch } from 'redux-thunk';
+import UserInfo from '../authentication/user';
+import { signOut } from '../state/actions/scigateway.actions';
+import { AppStrings } from '../state/scigateway.types';
 import { StateType, User } from '../state/state.types';
 import { getAppStrings, getString } from '../state/strings';
-import { signOut } from '../state/actions/scigateway.actions';
-import { connect } from 'react-redux';
-import { AppStrings } from '../state/scigateway.types';
-import { ThunkDispatch } from 'redux-thunk';
-import { push } from 'connected-react-router';
-import log from 'loglevel';
-import UserInfo from '../authentication/user';
 
 interface UserProfileProps {
   loggedIn: boolean;
@@ -32,7 +32,6 @@ interface UserProfileProps {
 }
 
 interface UserProfileDispatchProps {
-  signIn: () => Action;
   signOut: () => void;
 }
 
@@ -43,6 +42,8 @@ export const UserProfileComponent = (
 ): React.ReactElement => {
   const [menuAnchor, setMenuAnchor] = useState<HTMLButtonElement | null>(null);
   const closeMenu = (): void => setMenuAnchor(null);
+  const location = useLocation();
+  const { push } = useHistory();
   const logout = (): void => {
     closeMenu();
     props.signOut();
@@ -112,7 +113,10 @@ export const UserProfileComponent = (
             },
           })}
           onClick={() => {
-            props.signIn();
+            push('/login', {
+              referrer: location.pathname,
+              referredFrom: 'clickingSignIn',
+            });
             log.debug('signing in');
           }}
         >
@@ -142,7 +146,6 @@ const mapStateToProps = (state: StateType): UserProfileProps => ({
 });
 
 const mapDispatchToProps = (dispatch: Dispatch): UserProfileDispatchProps => ({
-  signIn: () => dispatch(push('/login')),
   signOut: () => {
     const thunkDispatch = dispatch as ThunkDispatch<StateType, null, AnyAction>;
     thunkDispatch(signOut());

--- a/src/routing/authorisedRoute.component.test.tsx
+++ b/src/routing/authorisedRoute.component.test.tsx
@@ -10,7 +10,7 @@ import { connectRouter } from 'connected-react-router';
 import { MemoryHistory, createLocation, createMemoryHistory } from 'history';
 import React from 'react';
 import { Provider } from 'react-redux';
-import { Router } from 'react-router-dom';
+import { Route, Router, Switch } from 'react-router-dom';
 import {
   AnyAction,
   applyMiddleware,
@@ -75,7 +75,12 @@ describe('AuthorisedRoute component', () => {
         <ThemeProvider theme={theme}>
           <Router history={history}>
             <Provider store={testStore}>
-              <AuthorisedComponent />
+              {/* Add a router and switch to unmount when we redirect */}
+              <Switch>
+                <Route exact path="/">
+                  <AuthorisedComponent />
+                </Route>
+              </Switch>
             </Provider>
           </Router>
         </ThemeProvider>
@@ -212,8 +217,11 @@ describe('AuthorisedRoute component', () => {
       componentToProtect: ComponentToProtect,
     });
 
-    expect(history.location.pathname === '/login');
-    expect(history.location.state.referrer === '/');
+    expect(history.location.pathname).toBe('/login');
+    expect(history.location.state).toEqual({
+      referrer: '/',
+      referredFrom: 'authorisedRoute',
+    });
     expect(screen.queryByText('protected component')).not.toBeInTheDocument();
   });
 

--- a/src/routing/authorisedRoute.component.tsx
+++ b/src/routing/authorisedRoute.component.tsx
@@ -79,7 +79,10 @@ const withAuth =
               <Redirect
                 to={{
                   pathname: '/login',
-                  state: { referrer: location },
+                  state: {
+                    referrer: location,
+                    referredFrom: 'authorisedRoute',
+                  },
                 }}
               />
             ) : /* If using a plugin as the start page, redirect here so the plugin renders with the redirected url */

--- a/src/routing/routing.component.test.tsx
+++ b/src/routing/routing.component.test.tsx
@@ -259,6 +259,33 @@ describe('Routing component', () => {
     expect(history.location.pathname).toEqual('/test');
   });
 
+  it('redirects to / on /login route when logged in after auto-logged in (no referrer)', () => {
+    state.scigateway.siteLoading = false;
+    state.scigateway.authorisation.provider = new TestAuthProvider('logged in');
+    state.scigateway.authorisation.provider.autoLogin = vi
+      .fn()
+      .mockImplementation(() => Promise.resolve());
+    let isAutoLoggedIn = 'true';
+    storageGetItemSpy.mockImplementation((name) =>
+      name === 'autoLogin' ? isAutoLoggedIn : null
+    );
+
+    history.replace('/login');
+
+    const { rerender } = render(<Routing />, { wrapper: Wrapper });
+
+    expect(history.location.pathname).toEqual('/login');
+
+    // simulate logging in - probably not needed for this unit test but it changes the token etc.
+    state.scigateway.authorisation.provider.logIn('username', 'password');
+    // no longer auto-logged in so change what localStorage returns
+    isAutoLoggedIn = 'false';
+
+    rerender(<Routing />);
+
+    expect(history.location.pathname).toEqual('/');
+  });
+
   it('renders /login page when navigating to login page when auto-logged in', () => {
     state.scigateway.authorisation.provider = new TestAuthProvider('logged in');
     state.scigateway.siteLoading = false;

--- a/src/routing/routing.component.test.tsx
+++ b/src/routing/routing.component.test.tsx
@@ -236,12 +236,15 @@ describe('Routing component', () => {
     expect(asFragment()).toMatchSnapshot();
   });
 
-  it('redirects to referrer on /login route when auto-logged in', () => {
+  it('redirects to referrer on /login route when auto-logged when referred by authorisedRoute', () => {
     state.scigateway.authorisation.provider = new TestAuthProvider(null);
     state.scigateway.siteLoading = false;
 
     history.replace('/login');
-    state.router.location.state = { referrer: '/test' };
+    state.router.location.state = {
+      referrer: '/test',
+      referredFrom: 'authorisedRoute',
+    };
 
     const { rerender } = render(<Routing />, { wrapper: Wrapper });
 

--- a/src/routing/routing.component.tsx
+++ b/src/routing/routing.component.tsx
@@ -203,8 +203,10 @@ const Routing: React.FC<RoutingProps> = (props: RoutingProps) => {
           {props.nullAuthProvider ? (
             <Redirect to={scigatewayRoutes.home} />
           ) : !props.userIsLoggedIn ||
+            // if authorisedRoute redirected here but we're now autoLoggedIn, don't show login page & instead redirect - otherwise we want to show it
             (props.userIsAutoLoggedIn &&
-              !(props.location.state as { referrer?: string })?.referrer) ||
+              (props.location.state as { referredFrom?: string })
+                ?.referredFrom !== 'authorisedRoute') ||
             props.loading ? (
             <LoginPage />
           ) : (
@@ -219,7 +221,10 @@ const Routing: React.FC<RoutingProps> = (props: RoutingProps) => {
                         popSessionStorageItem('referrer')) ??
                       scigatewayRoutes.home)
                     : scigatewayRoutes.logout,
-                state: { referrer: props.location.pathname },
+                state: {
+                  referrer: props.location.pathname,
+                  referredFrom: 'postLoginRedirect',
+                },
               }}
             />
           )}

--- a/src/routing/routing.component.tsx
+++ b/src/routing/routing.component.tsx
@@ -165,6 +165,7 @@ const Routing: React.FC<RoutingProps> = (props: RoutingProps) => {
   }, [props.location.pathname, props.plugins]);
 
   const prevUserIsLoggedIn = usePrevious(props.userIsLoggedIn);
+  const prevUserIsAutoLoggedIn = usePrevious(props.userIsAutoLoggedIn);
 
   return (
     // If a user is authorised, redirect to the URL they attempted to navigate to e.g. "/plugin"
@@ -210,7 +211,9 @@ const Routing: React.FC<RoutingProps> = (props: RoutingProps) => {
             <Redirect
               to={{
                 pathname:
-                  prevUserIsLoggedIn === false && props.userIsLoggedIn
+                  (prevUserIsLoggedIn === false ||
+                    (prevUserIsAutoLoggedIn && !props.userIsAutoLoggedIn)) &&
+                  props.userIsLoggedIn
                     ? (((props.location.state as { referrer?: string })
                         ?.referrer ||
                         popSessionStorageItem('referrer')) ??


### PR DESCRIPTION
## Description
There was an issue with the post-login redirects not working with `autoLogin` set to true so I fixed that here. However, that will only ever take you to the homepage as the `authorisedRoute` component will never redirect you to the login page with a `referrer` when auto-logged-in.

So I added a referrer when clicking the sign in button itself, which means we always attempt to put the user back on the page they were on before the sign in. I had to add some extra state `referredFrom` to not interfere with some of the `authorisedRoute` redirect logic.

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [x] Review code
- [x] Check Actions build
- [x] Review changes to test coverage
- [x] Check that when `autoLogin` is true (so you need to point to an ICAT with an anon authenticator, dgw-dseg will do) you can login on a random page and after login you'll be redirected to the page you were on
- [x] Can also optionally test this behaviour with autologin off - e.g. go to the SG help page, sign in, it should take you back to the help page