### PR TITLE
Use MUI Link for "contact support" to work

### DIFF
--- a/src/pageNotFound/__snapshots__/pageNotFound.component.test.tsx.snap
+++ b/src/pageNotFound/__snapshots__/pageNotFound.component.test.tsx.snap
@@ -42,7 +42,7 @@ exports[`Page Not found component > renders pageNotFound page correctly 1`] = `
         >
           homepage
         </a>
-         or
+        or
         <a
           class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-1sg0g1v-MuiTypography-root-MuiLink-root"
           data-test-id="page-not-found-contact-support-link"

--- a/src/pageNotFound/__snapshots__/pageNotFound.component.test.tsx.snap
+++ b/src/pageNotFound/__snapshots__/pageNotFound.component.test.tsx.snap
@@ -34,7 +34,7 @@ exports[`Page Not found component > renders pageNotFound page correctly 1`] = `
       <p
         class="MuiTypography-root MuiTypography-body1 css-n19zd7-MuiTypography-root"
       >
-        We're sorry, the page you requested was not found on the server. If you entered the URL manually please check your spelling and try again. Otherwise, return to the
+        We're sorry, the page you requested was not found on the server. If you entered the URL manually please check your spelling and try again. Otherwise, return to the 
         <a
           class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-1sg0g1v-MuiTypography-root-MuiLink-root"
           data-test-id="page-not-found-homepage-link"
@@ -42,7 +42,7 @@ exports[`Page Not found component > renders pageNotFound page correctly 1`] = `
         >
           homepage
         </a>
-        or
+         or 
         <a
           class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-1sg0g1v-MuiTypography-root-MuiLink-root"
           data-test-id="page-not-found-contact-support-link"

--- a/src/pageNotFound/__snapshots__/pageNotFound.component.test.tsx.snap
+++ b/src/pageNotFound/__snapshots__/pageNotFound.component.test.tsx.snap
@@ -34,19 +34,19 @@ exports[`Page Not found component > renders pageNotFound page correctly 1`] = `
       <p
         class="MuiTypography-root MuiTypography-body1 css-n19zd7-MuiTypography-root"
       >
-        We're sorry, the page you requested was not found on the server. If you entered the URL manually please check your spelling and try again. Otherwise, return to the 
+        We're sorry, the page you requested was not found on the server. If you entered the URL manually please check your spelling and try again. Otherwise, return to the
         <a
-          class="css-1jolfkj"
+          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-1sg0g1v-MuiTypography-root-MuiLink-root"
           data-test-id="page-not-found-homepage-link"
           href="/"
         >
           homepage
         </a>
-         or 
+         or
         <a
-          class="css-1jolfkj"
+          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineHover css-1sg0g1v-MuiTypography-root-MuiLink-root"
           data-test-id="page-not-found-contact-support-link"
-          href="/footer.links.contact"
+          href="footer.links.contact"
         >
           contact support
         </a>

--- a/src/pageNotFound/pageNotFound.component.test.tsx
+++ b/src/pageNotFound/pageNotFound.component.test.tsx
@@ -53,6 +53,6 @@ describe('Page Not found component', () => {
     );
     expect(
       screen.getByRole('link', { name: 'contact support' })
-    ).toHaveAttribute('href', '/footer.links.contact');
+    ).toHaveAttribute('href', 'footer.links.contact');
   });
 });

--- a/src/pageNotFound/pageNotFound.component.tsx
+++ b/src/pageNotFound/pageNotFound.component.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
+import BugReportIcon from '@mui/icons-material/BugReport';
+import { Box, styled, Theme } from '@mui/material';
 import Link from '@mui/material/Link';
 import Typography from '@mui/material/Typography';
-import { Box, styled, Theme } from '@mui/material';
-import BugReportIcon from '@mui/icons-material/BugReport';
-import { useTranslation, Trans } from 'react-i18next';
+import React from 'react';
+import { Trans, useTranslation } from 'react-i18next';
 import { Link as RouterLink } from 'react-router-dom';
 
 const StyledLink = styled(Link)<{ component?: React.ElementType; to?: string }>(
@@ -65,15 +65,15 @@ export const PageNotFoundComponent = (): React.ReactElement => {
           <Trans t={t} i18nKey="page-not-found.message">
             We&#39;re sorry, the page you requested was not found on the server.
             If you entered the URL manually please check your spelling and try
-            again. Otherwise, return to the
+            again. Otherwise, return to the{' '}
             <StyledLink
               component={RouterLink}
               data-test-id="page-not-found-homepage-link"
               to="/"
             >
               homepage
-            </StyledLink>
-            or
+            </StyledLink>{' '}
+            or{' '}
             <StyledLink
               data-test-id="page-not-found-contact-support-link"
               href={t('footer.links.contact') as string}

--- a/src/pageNotFound/pageNotFound.component.tsx
+++ b/src/pageNotFound/pageNotFound.component.tsx
@@ -1,13 +1,16 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import Link from '@mui/material/Link';
 import Typography from '@mui/material/Typography';
 import { Box, styled, Theme } from '@mui/material';
 import BugReportIcon from '@mui/icons-material/BugReport';
 import { useTranslation, Trans } from 'react-i18next';
+import { Link as RouterLink } from 'react-router-dom';
 
-const StyledLink = styled(Link)(({ theme }) => ({
-  color: theme.palette.text.primary,
-}));
+const StyledLink = styled(Link)<{ component?: React.ElementType; to?: string }>(
+  ({ theme }) => ({
+    color: theme.palette.text.primary,
+  })
+);
 
 export const PageNotFoundComponent = (): React.ReactElement => {
   const [t] = useTranslation();
@@ -63,13 +66,17 @@ export const PageNotFoundComponent = (): React.ReactElement => {
             We&#39;re sorry, the page you requested was not found on the server.
             If you entered the URL manually please check your spelling and try
             again. Otherwise, return to the{' '}
-            <StyledLink data-test-id="page-not-found-homepage-link" to="/">
+            <StyledLink
+              component={RouterLink}
+              data-test-id="page-not-found-homepage-link"
+              to="/"
+            >
               homepage
             </StyledLink>{' '}
             or{' '}
             <StyledLink
               data-test-id="page-not-found-contact-support-link"
-              to={t('footer.links.contact') as string}
+              href={t('footer.links.contact') as string}
             >
               contact support
             </StyledLink>

--- a/src/pageNotFound/pageNotFound.component.tsx
+++ b/src/pageNotFound/pageNotFound.component.tsx
@@ -65,15 +65,15 @@ export const PageNotFoundComponent = (): React.ReactElement => {
           <Trans t={t} i18nKey="page-not-found.message">
             We&#39;re sorry, the page you requested was not found on the server.
             If you entered the URL manually please check your spelling and try
-            again. Otherwise, return to the{' '}
+            again. Otherwise, return to the
             <StyledLink
               component={RouterLink}
               data-test-id="page-not-found-homepage-link"
               to="/"
             >
               homepage
-            </StyledLink>{' '}
-            or{' '}
+            </StyledLink>
+            or
             <StyledLink
               data-test-id="page-not-found-contact-support-link"
               href={t('footer.links.contact') as string}


### PR DESCRIPTION
## Description
Updates the `pageNotFound` component to use MUI's `Link` so the `mailto` works for contacting support.

## Testing instructions
Navigate to a URL which redirects to the `/404` page. Click the "contact support" text and it should open a new email.

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
https://github.com/fiaisis/frontend/issues/642