### PR TITLE
Ensure failing to fetch OIDC config details doesn't block logging in with other authenticators

### DIFF
--- a/src/authentication/baseAPIAuthProvider.test.tsx
+++ b/src/authentication/baseAPIAuthProvider.test.tsx
@@ -409,7 +409,9 @@ describe('Base API auth provider', () => {
           })
         );
 
-        await testBaseAPIAuthProvider.initialiseOIDCProviders();
+        const resultOIDCProviders =
+          await testBaseAPIAuthProvider.initialiseOIDCProviders();
+        expect(resultOIDCProviders).toEqual([]);
         expect(log.error).toHaveBeenCalledWith(
           'Unable to fetch OIDC providers'
         );
@@ -420,17 +422,24 @@ describe('Base API auth provider', () => {
           type: NotificationType,
           payload: {
             message:
-              'It is not possible to authenticate you at the moment. Please, try again later.',
+              'Failed to fetch OIDC providers. If you need to login with single sign-on - please, try again later.',
             severity: 'error',
           },
         });
       });
 
-      it('should error on invalid configuration_url endpoint call', async () => {
+      it('should error on invalid configuration_url endpoint call & return any providers that did not error', async () => {
         vi.mocked(mockAxios.get)
           .mockImplementationOnce(() =>
             Promise.resolve({
               data: {
+                [`${oidcProvider.provider_id}fail`]: {
+                  client_id: `${oidcProvider.client_id}fail`,
+                  display_name: `${oidcProvider.display_name}fail`,
+                  configuration_url: `${oidcProvider.configuration_url}fail`,
+                  pkce: oidcProvider.pkce,
+                  scope: oidcProvider.scope,
+                },
                 [oidcProvider.provider_id]: {
                   client_id: oidcProvider.client_id,
                   display_name: oidcProvider.display_name,
@@ -441,7 +450,7 @@ describe('Base API auth provider', () => {
               },
             })
           )
-          .mockImplementation(() =>
+          .mockImplementationOnce(() =>
             Promise.reject({
               response: {
                 status: 500,
@@ -449,11 +458,11 @@ describe('Base API auth provider', () => {
             })
           );
 
-        await expect(
-          testBaseAPIAuthProvider.initialiseOIDCProviders()
-        ).rejects.toThrowError();
+        const resultOIDCProviders =
+          await testBaseAPIAuthProvider.initialiseOIDCProviders();
+        expect(resultOIDCProviders).toEqual([]);
         expect(log.error).toHaveBeenCalledWith(
-          'Unable to fetch OIDC config from OIDC configuration URL'
+          `Unable to fetch OIDC config from OIDC configuration URL for provider ${oidcProvider.display_name}fail`
         );
         expect(document.dispatchEvent).toHaveBeenCalled();
         expect(
@@ -461,8 +470,7 @@ describe('Base API auth provider', () => {
         ).toEqual({
           type: NotificationType,
           payload: {
-            message:
-              'It is not possible to authenticate you at the moment. Please, try again later.',
+            message: `It is not possible to load the ${oidcProvider.display_name}fail authenticator at the moment. Please, try again later.`,
             severity: 'error',
           },
         });

--- a/src/authentication/baseAPIAuthProvider.tsx
+++ b/src/authentication/baseAPIAuthProvider.tsx
@@ -9,7 +9,10 @@ import { OIDCProvider } from '../state/state.types';
 import BaseAuthProvider from './baseAuthProvider';
 import parseJwt from './parseJwt';
 
-export function fetchOIDCConfig(oidcConfigurationUrl?: string): Promise<{
+export function fetchOIDCConfig(
+  oidcConfigurationUrl: string,
+  oidcProviderName: string
+): Promise<{
   authorization_endpoint: string;
   token_endpoint: string;
 }> {
@@ -26,14 +29,15 @@ export function fetchOIDCConfig(oidcConfigurationUrl?: string): Promise<{
       };
     })
     .catch((e) => {
-      log.error('Unable to fetch OIDC config from OIDC configuration URL');
+      log.error(
+        `Unable to fetch OIDC config from OIDC configuration URL for provider ${oidcProviderName}`
+      );
       document.dispatchEvent(
         new CustomEvent('scigateway', {
           detail: {
             type: NotificationType,
             payload: {
-              message:
-                'It is not possible to authenticate you at the moment. Please, try again later.',
+              message: `It is not possible to load the ${oidcProviderName} authenticator at the moment. Please, try again later.`,
               severity: 'error',
             },
           },
@@ -62,7 +66,7 @@ export function fetchOIDCProviders(authUrl?: string): Promise<OIDCProvider[]> {
             type: NotificationType,
             payload: {
               message:
-                'It is not possible to authenticate you at the moment. Please, try again later.',
+                'Failed to fetch OIDC providers. If you need to login with single sign-on - please, try again later.',
               severity: 'error',
             },
           },
@@ -305,11 +309,28 @@ export default abstract class BaseAPIAuthProvider extends BaseAuthProvider {
 
   public async initialiseOIDCProviders(): Promise<InitialisedOIDCProvider[]> {
     const oidcProviders = await fetchOIDCProviders(this.authUrl);
-    return await Promise.all(
-      oidcProviders.map(async (oidcProvider) => {
-        const config = await fetchOIDCConfig(oidcProvider.configuration_url);
-        return { ...config, ...oidcProvider };
-      })
+
+    return (
+      (
+        await Promise.all(
+          oidcProviders.map(async (oidcProvider) => {
+            // try-catch to ensure single OIDC provider failing doesn't block initialising other providers
+            try {
+              const config = await fetchOIDCConfig(
+                oidcProvider.configuration_url,
+                oidcProvider.display_name
+              );
+              return { ...config, ...oidcProvider };
+            } catch {
+              return 'error';
+            }
+          })
+        )
+      )
+        // filter out any OIDC providers that errored
+        .filter((result): result is InitialisedOIDCProvider => {
+          return typeof result === 'object';
+        })
     );
   }
 


### PR DESCRIPTION
## Description
Change `initialiseOIDCProviders` to catch any errors `fetchOIDCConfig` throws and filter them out from the resulting array. This means a) we no longer block login if no OIDC authenticators work and b) if one OIDC provider fails then the others still work. Also improve the error messages to be more specific re: fetching OIDC config

This was noticed by Sabah yesterday as ORCiD had some maintenance yesterday that caused this issue

## Testing instructions
Add a set up instructions describing how the reviewer should test the code

- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage
- [ ] On datagateway-dseg I have 2 OIDC providers set up - I can configure one of them to always error to help test this change - let me know