### PR TITLE
Use plugin blue text logo in dark high-contrast mode

### DIFF
--- a/src/mainAppBar/mainAppBar.component.test.tsx
+++ b/src/mainAppBar/mainAppBar.component.test.tsx
@@ -122,10 +122,12 @@ describe('Main app bar component', () => {
     expect(screen.queryByRole('button', { name: 'help-page' })).toBeNull();
   });
 
-  it('uses single plugin logo when feature is true', async () => {
+  it('uses the dark single plugin logo when dark and high contrast modes are enabled', async () => {
     state.scigateway.logo = undefined;
     state.scigateway.siteLoading = false;
     state.scigateway.features.singlePluginLogo = true;
+    state.scigateway.darkMode = true;
+    state.scigateway.highContrastMode = true;
     state.scigateway.plugins = [
       {
         order: 0,
@@ -133,6 +135,7 @@ describe('Main app bar component', () => {
         plugin: 'plugin',
         link: '/plugin',
         displayName: 'Plugin',
+        logoLightMode: 'plugin_logo_light',
         logoDarkMode: 'plugin_logo_dark',
       },
     ];
@@ -407,7 +410,8 @@ describe('Main app bar component', () => {
       plugin: 'plugin',
       displayName: 'pluginName',
       order: 1,
-      logoDarkMode: 'pluginLogo',
+      logoLightMode: 'pluginLogoLight',
+      logoDarkMode: 'pluginLogoDark',
     };
     delete state.scigateway.logo;
     state.scigateway.plugins = [plugin];
@@ -420,7 +424,39 @@ describe('Main app bar component', () => {
       { wrapper: Wrapper }
     );
 
-    expect(await screen.findByRole('img')).toHaveAttribute('src', 'pluginLogo');
+    expect(await screen.findByRole('img')).toHaveAttribute(
+      'src',
+      'pluginLogoLight'
+    );
+  });
+
+  it('sets the dark plugin logo only when dark and high contrast modes are enabled', async () => {
+    const plugin: PluginConfig = {
+      section: 'section',
+      link: '/link',
+      plugin: 'plugin',
+      displayName: 'pluginName',
+      order: 1,
+      logoLightMode: 'pluginLogoLight',
+      logoDarkMode: 'pluginLogoDark',
+    };
+    delete state.scigateway.logo;
+    state.scigateway.plugins = [plugin];
+    state.scigateway.siteLoading = false;
+    state.scigateway.darkMode = true;
+    state.scigateway.highContrastMode = true;
+
+    render(
+      <div id="plugin">
+        <MainAppBarComponent />
+      </div>,
+      { wrapper: Wrapper }
+    );
+
+    expect(await screen.findByRole('img')).toHaveAttribute(
+      'src',
+      'pluginLogoDark'
+    );
   });
 
   it('sets scigateway logo if no plugin is matched', () => {

--- a/src/mainAppBar/mainAppBar.component.test.tsx
+++ b/src/mainAppBar/mainAppBar.component.test.tsx
@@ -122,7 +122,7 @@ describe('Main app bar component', () => {
     expect(screen.queryByRole('button', { name: 'help-page' })).toBeNull();
   });
 
-  it('uses the dark single plugin logo when dark and high contrast modes are enabled', async () => {
+  it('uses the light single plugin logo when dark and high contrast modes are enabled', async () => {
     state.scigateway.logo = undefined;
     state.scigateway.siteLoading = false;
     state.scigateway.features.singlePluginLogo = true;
@@ -147,7 +147,7 @@ describe('Main app bar component', () => {
         within(screen.getByRole('button', { name: 'home-page' })).getByRole(
           'img'
         )
-      ).toHaveAttribute('src', 'plugin_logo_dark');
+      ).toHaveAttribute('src', 'plugin_logo_light');
     });
   });
 
@@ -426,11 +426,11 @@ describe('Main app bar component', () => {
 
     expect(await screen.findByRole('img')).toHaveAttribute(
       'src',
-      'pluginLogoLight'
+      'pluginLogoDark'
     );
   });
 
-  it('sets the dark plugin logo only when dark and high contrast modes are enabled', async () => {
+  it('sets the light plugin logo when dark and high contrast modes are enabled', async () => {
     const plugin: PluginConfig = {
       section: 'section',
       link: '/link',
@@ -455,7 +455,7 @@ describe('Main app bar component', () => {
 
     expect(await screen.findByRole('img')).toHaveAttribute(
       'src',
-      'pluginLogoDark'
+      'pluginLogoLight'
     );
   });
 

--- a/src/mainAppBar/mainAppBar.component.tsx
+++ b/src/mainAppBar/mainAppBar.component.tsx
@@ -77,11 +77,11 @@ type CombinedMainAppBarProps = MainAppProps & MainAppDispatchProps;
 
 const getPluginLogo = (
   plugin: PluginConfig,
-  useDarkModeLogo: boolean
+  useLightBackgroundLogo: boolean
 ): string | undefined =>
-  useDarkModeLogo
-    ? (plugin.logoDarkMode ?? plugin.logoLightMode)
-    : (plugin.logoLightMode ?? plugin.logoDarkMode);
+  useLightBackgroundLogo
+    ? (plugin.logoLightMode ?? plugin.logoDarkMode)
+    : (plugin.logoDarkMode ?? plugin.logoLightMode);
 
 export const MainAppBar = (
   props: CombinedMainAppBarProps
@@ -93,7 +93,8 @@ export const MainAppBar = (
   const location = useLocation();
   const theme = useTheme();
   const isViewportMdOrLarger = useMediaQuery(theme.breakpoints.up('md'));
-  const useDarkModeLogo = props.darkMode && props.highContrastMode;
+  // Dark high-contrast mode uses a light app bar background.
+  const useLightBackgroundLogo = props.darkMode && props.highContrastMode;
 
   React.useEffect(() => {
     if (!props.loading) {
@@ -102,13 +103,16 @@ export const MainAppBar = (
         //Use the first plugin's logo for everything if 'singlePluginLogo' is true, otherwise choose depending on current plugin visible
         if (props.singlePluginLogo) {
           setLogo(
-            getPluginLogo(props.plugins[0], useDarkModeLogo) ?? ScigatewayLogo
+            getPluginLogo(props.plugins[0], useLightBackgroundLogo) ??
+              ScigatewayLogo
           );
           set = true;
         } else {
           for (const p of props.plugins) {
             if (document.getElementById(p.plugin) !== null) {
-              setLogo(getPluginLogo(p, useDarkModeLogo) ?? ScigatewayLogo);
+              setLogo(
+                getPluginLogo(p, useLightBackgroundLogo) ?? ScigatewayLogo
+              );
               set = true;
               break;
             }
@@ -125,7 +129,7 @@ export const MainAppBar = (
     location,
     props.loading,
     props.singlePluginLogo,
-    useDarkModeLogo,
+    useLightBackgroundLogo,
   ]);
 
   const { toggleDrawer } = props;

--- a/src/mainAppBar/mainAppBar.component.tsx
+++ b/src/mainAppBar/mainAppBar.component.tsx
@@ -75,6 +75,14 @@ const TitleButton = styled(Button)(({ theme }) => ({
 
 type CombinedMainAppBarProps = MainAppProps & MainAppDispatchProps;
 
+const getPluginLogo = (
+  plugin: PluginConfig,
+  useDarkModeLogo: boolean
+): string | undefined =>
+  useDarkModeLogo
+    ? (plugin.logoDarkMode ?? plugin.logoLightMode)
+    : (plugin.logoLightMode ?? plugin.logoDarkMode);
+
 export const MainAppBar = (
   props: CombinedMainAppBarProps
 ): React.ReactElement => {
@@ -85,6 +93,7 @@ export const MainAppBar = (
   const location = useLocation();
   const theme = useTheme();
   const isViewportMdOrLarger = useMediaQuery(theme.breakpoints.up('md'));
+  const useDarkModeLogo = props.darkMode && props.highContrastMode;
 
   React.useEffect(() => {
     if (!props.loading) {
@@ -92,12 +101,14 @@ export const MainAppBar = (
       if (props.plugins.length >= 1) {
         //Use the first plugin's logo for everything if 'singlePluginLogo' is true, otherwise choose depending on current plugin visible
         if (props.singlePluginLogo) {
-          setLogo(props.plugins[0].logoDarkMode ?? ScigatewayLogo);
+          setLogo(
+            getPluginLogo(props.plugins[0], useDarkModeLogo) ?? ScigatewayLogo
+          );
           set = true;
         } else {
           for (const p of props.plugins) {
             if (document.getElementById(p.plugin) !== null) {
-              setLogo(p.logoDarkMode ?? ScigatewayLogo);
+              setLogo(getPluginLogo(p, useDarkModeLogo) ?? ScigatewayLogo);
               set = true;
               break;
             }
@@ -109,7 +120,13 @@ export const MainAppBar = (
         setLogo(ScigatewayLogo);
       }
     }
-  }, [props.plugins, location, props.loading, props.singlePluginLogo]);
+  }, [
+    props.plugins,
+    location,
+    props.loading,
+    props.singlePluginLogo,
+    useDarkModeLogo,
+  ]);
 
   const { toggleDrawer } = props;
 

--- a/src/state/scigateway.types.tsx
+++ b/src/state/scigateway.types.tsx
@@ -115,8 +115,8 @@ export interface RegisterRoutePayload {
   admin?: boolean;
   order: number;
   helpText?: string;
-  logoLightMode?: string;
-  logoDarkMode?: string;
+  logoLightMode?: string; /** Logo variant intended for light app bar backgrounds. */
+  logoDarkMode?: string; /** Logo variant intended for dark app bar backgrounds. */
   logoAltText?: string;
   helpSteps?: { target: string; content: string }[];
 }
@@ -131,8 +131,8 @@ export interface PluginConfig {
   admin?: boolean;
   order: number;
   helpText?: string;
-  logoLightMode?: string;
-  logoDarkMode?: string;
+  logoLightMode?: string; /** Logo variant intended for light app bar backgrounds. */
+  logoDarkMode?: string; /** Logo variant intended for dark app bar backgrounds. */
   logoAltText?: string;
   helpSteps?: { target: string; content: string }[];
 }


### PR DESCRIPTION
## Description
Update the main app bar plugin logo selection so `logoLightMode` is used when dark mode and high contrast mode are both enabled. This change makes the app bar use the light logo by default and switch to the dark logo only for dark high-contrast mode. 

The existing `logoLightMode` and `logoDarkMode` fields have been documented as light-background and dark-background logo variants.

NOTE: may require further changes for individual plugins which use SciGateway.

## Testing instructions
1. Start SciGateway with a plugin that provides both `logoLightMode` and `logoDarkMode`.
2. Open the plugin and confirm the dark-background logo is shown in light mode.
3. Enable dark mode only and confirm the dark-background logo is still shown.
4. Enable high contrast mode while dark mode is still on and confirm the light-background logo is shown.
5. Disable high contrast mode again and confirm the logo switches back to the dark-background logo.
6. Run `yarn.cmd vitest run src/mainAppBar/mainAppBar.component.test.tsx` and confirm the test file passes.

- [x] Review code
- [x] Check Actions build
- [x] Review changes to test coverage
- [ ] {more steps here}

## Agile board tracking
FIA issue: https://github.com/fiaisis/frontend/issues/160
FIA PR fix: https://github.com/fiaisis/frontend/pull/689